### PR TITLE
Fix dotenv path so ANTHROPIC_API_KEY loads in all environments

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
 const express = require('express');
 const { createServer } = require('http');
 const { Server } = require('socket.io');


### PR DESCRIPTION
Use an explicit path relative to __dirname so the root .env is found whether the server is started from the project root (production) or from the server/ directory (dev mode).