### PR TITLE
Fix AI commentary model ID

### DIFF
--- a/server/ai.js
+++ b/server/ai.js
@@ -40,7 +40,7 @@ ${spendNote}
 Respond with only the commentary text. No quotes, no prefix.`;
 
   const stream = client.messages.stream({
-    model: 'claude-haiku-4-5',
+    model: 'claude-haiku-4-5-20251001',
     max_tokens: 120,
     messages: [{ role: 'user', content: prompt }],
   });
@@ -96,7 +96,7 @@ ${standingsSummary}
 Respond with only the commentary. No quotes, no prefix.`;
 
   const stream = client.messages.stream({
-    model: 'claude-haiku-4-5',
+    model: 'claude-haiku-4-5-20251001',
     max_tokens: 180,
     messages: [{ role: 'user', content: prompt }],
   });


### PR DESCRIPTION
## Summary
- Model ID `claude-haiku-4-5` is not a valid API identifier, causing silent errors that prevented AI commentary from appearing after auction sales and game results
- Updated both calls in `server/ai.js` to use the correct versioned ID: `claude-haiku-4-5-20251001`

## Test plan
- [ ] Complete an auction sale — AI commentary toast should appear and stream in
- [ ] Record a bracket game result — game recap commentary should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)