### PR TITLE
Fix AI commentary (model, error handling, crash prevention)

### DIFF
--- a/server/ai.js
+++ b/server/ai.js
@@ -16,7 +16,7 @@ function getClient() {
   return _client;
 }
 
-// Streams a fun 1-2 sentence sports-announcer quip after a team sells at auction.
+// Generates a fun 1-2 sentence sports-announcer quip after a team sells at auction.
 // Emits: auction:commentary:chunk { token }, auction:commentary:done { text }
 async function generateAuctionCommentary({
   teamName, seed, region, price,
@@ -39,21 +39,21 @@ ${spendNote}
 
 Respond with only the commentary text. No quotes, no prefix.`;
 
-  const stream = client.messages.stream({
-    model: 'claude-haiku-4-5-20251001',
-    max_tokens: 120,
-    messages: [{ role: 'user', content: prompt }],
-  });
-
-  let fullText = '';
-  for await (const text of stream.textStream) {
-    fullText += text;
+  try {
+    const message = await client.messages.create({
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 120,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const text = message.content[0]?.text || '';
     io.emit('auction:commentary:chunk', { token: text });
+    io.emit('auction:commentary:done', { text });
+  } catch (e) {
+    console.error('[AI auction]', e.message);
   }
-  io.emit('auction:commentary:done', { text: fullText });
 }
 
-// Streams a 2-3 sentence Calcutta-focused recap after a bracket game result.
+// Generates a 2-3 sentence Calcutta-focused recap after a bracket game result.
 // Emits: bracket:recap:chunk { token }, bracket:recap:done { text }
 async function streamGameRecap({
   roundNumber,
@@ -95,18 +95,18 @@ ${standingsSummary}
 
 Respond with only the commentary. No quotes, no prefix.`;
 
-  const stream = client.messages.stream({
-    model: 'claude-haiku-4-5-20251001',
-    max_tokens: 180,
-    messages: [{ role: 'user', content: prompt }],
-  });
-
-  let fullText = '';
-  for await (const text of stream.textStream) {
-    fullText += text;
+  try {
+    const message = await client.messages.create({
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 180,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const text = message.content[0]?.text || '';
     io.emit('bracket:recap:chunk', { token: text });
+    io.emit('bracket:recap:done', { text });
+  } catch (e) {
+    console.error('[AI recap]', e.message);
   }
-  io.emit('bracket:recap:done', { text: fullText });
 }
 
 module.exports = { generateAuctionCommentary, streamGameRecap };

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,7 @@
 require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
+
+process.on('uncaughtException', (err) => console.error('[uncaughtException]', err));
+process.on('unhandledRejection', (reason) => console.error('[unhandledRejection]', reason));
 const express = require('express');
 const { createServer } = require('http');
 const { Server } = require('socket.io');

--- a/server/socket.js
+++ b/server/socket.js
@@ -16,7 +16,11 @@ function startTimer(itemId, endTime) {
   if (delay <= 0) return;
   activeTimer = setTimeout(() => {
     const io = global._io;
-    if (io) closeAuction(itemId, io);
+    try {
+      if (io) closeAuction(itemId, io);
+    } catch (e) {
+      console.error('[closeAuction timer]', e);
+    }
   }, delay);
 }
 


### PR DESCRIPTION
## Summary
- **Model**: Switched to `claude-sonnet-4-5-20250929` — the only available model on this API key that responds successfully (haiku-4-5 returns 529 overloaded, all claude-3 models return 404)
- **Error handling**: Replaced `messages.stream()` with `messages.create()` to eliminate unhandled rejections from the Anthropic SDK's internal async stream setup — errors now caught reliably in try/catch
- **Crash prevention**: Added `process.on('uncaughtException'/'unhandledRejection')` handlers so server errors are logged instead of silently killing the process
- **Socket safety**: Wrapped `closeAuction` timer callback in try/catch

## Test plan
- [ ] Sell a team at auction — AI commentary toast should appear
- [ ] Record a bracket game result — game recap commentary should appear
- [ ] Server should not crash if API call fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)