### PR TITLE
Add shareable email invite links

### DIFF
--- a/client/src/pages/Join.jsx
+++ b/client/src/pages/Join.jsx
@@ -1,14 +1,24 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 export default function Join() {
   const { join, adminLogin } = useAuth();
+  const [searchParams] = useSearchParams();
   const [name, setName] = useState('');
   const [inviteCode, setInviteCode] = useState('');
   const [adminPassword, setAdminPassword] = useState('');
   const [mode, setMode] = useState('join'); // 'join' | 'admin'
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const inviteFromUrl = (searchParams.get('invite') || '').trim().toUpperCase().slice(0, 8);
+
+  useEffect(() => {
+    if (!inviteFromUrl) return;
+    setInviteCode(inviteFromUrl);
+    setMode('join');
+    setError('');
+  }, [inviteFromUrl]);
 
   const handleJoin = async (e) => {
     e.preventDefault();
@@ -103,12 +113,17 @@ export default function Join() {
                 id="join-code"
                 type="text"
                 value={inviteCode}
-                onChange={(e) => setInviteCode(e.target.value.toUpperCase())}
+                onChange={(e) => setInviteCode(e.target.value.toUpperCase().slice(0, 8))}
                 placeholder="XXXXXX"
                 maxLength={8}
                 className="input font-mono tracking-widest"
                 required
               />
+              {inviteFromUrl && (
+                <p className="text-xs text-text-secondary mt-1">
+                  Invite code loaded from your link.
+                </p>
+              )}
             </div>
             {error && (
               <div role="alert" className="badge badge-error w-full justify-start px-3 py-2 rounded-xl text-sm">
@@ -149,7 +164,7 @@ export default function Join() {
         )}
 
         <p className="text-center text-text-secondary text-sm mt-6">
-          Ask your group admin for the invite code
+          Ask your group admin for an invite code or invite link
         </p>
       </div>
     </div>

--- a/client/src/pages/admin/SettingsTab.jsx
+++ b/client/src/pages/admin/SettingsTab.jsx
@@ -15,6 +15,7 @@ export default function SettingsTab() {
   const [settings, setSettings] = useState(null);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState('');
+  const [inviteMsg, setInviteMsg] = useState('');
 
   useEffect(() => {
     api('/admin/settings').then((r) => r.json()).then(setSettings);
@@ -43,6 +44,34 @@ export default function SettingsTab() {
     const r = await api('/admin/invite-code/regenerate', { method: 'POST' });
     const data = await r.json();
     setSettings((s) => ({ ...s, invite_code: data.invite_code }));
+  };
+
+  const getInviteLink = () => {
+    if (!settings?.invite_code) return '';
+    return `${window.location.origin}/join?invite=${encodeURIComponent(settings.invite_code)}`;
+  };
+
+  const copyInviteLink = async () => {
+    const link = getInviteLink();
+    if (!link) return;
+
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(link);
+      } else {
+        const input = document.createElement('input');
+        input.value = link;
+        document.body.appendChild(input);
+        input.select();
+        document.execCommand('copy');
+        document.body.removeChild(input);
+      }
+      setInviteMsg('Invite link copied!');
+      setTimeout(() => setInviteMsg(''), 2000);
+    } catch {
+      setInviteMsg('Could not copy link');
+      setTimeout(() => setInviteMsg(''), 2000);
+    }
   };
 
   const downloadCsv = async () => {
@@ -212,6 +241,25 @@ export default function SettingsTab() {
             >
               Regenerate
             </button>
+          </div>
+          <div className="mt-3">
+            <label className="block text-xs font-medium text-slate-400 mb-1">Share Link</label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                readOnly
+                value={getInviteLink()}
+                className="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-slate-200 text-xs"
+              />
+              <button
+                type="button"
+                onClick={copyInviteLink}
+                className="bg-slate-600 hover:bg-slate-500 text-white px-3 py-2 rounded-lg text-xs whitespace-nowrap"
+              >
+                Copy Link
+              </button>
+            </div>
+            {inviteMsg && <div className="text-status-success text-xs mt-1">{inviteMsg}</div>}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Summary:
- support join URLs with ?invite=CODE by prefilling invite code on the join page
- add a shareable invite link field in admin settings
- add a Copy Link action for quick sharing by email/text

Validation:
- vite HMR loaded Join and SettingsTab updates without runtime errors
- npm run build --prefix client completed successfully