### PR TITLE
Keep sold card visible and embed AI commentary

### DIFF
--- a/client/src/components/AiCommentary.jsx
+++ b/client/src/components/AiCommentary.jsx
@@ -5,29 +5,16 @@ import { useSocketEvent } from '../context/SocketContext';
 const AUTO_DISMISS_MS = 10000;
 
 const CONFIG = {
-  auction: { icon: '🎙️', label: 'Auction Commentary' },
-  recap:   { icon: '📊', label: 'Game Recap' },
+  recap: { icon: '📊', label: 'Game Recap' },
 };
 
 export default function AiCommentary() {
-  // note: { type: 'auction'|'recap', text: string, done: boolean } | null
+  // note: { type: 'recap', text: string, done: boolean } | null
   const [note, setNote] = useState(null);
   // Progress bar width (0→100) for the auto-dismiss timer
   const [progress, setProgress] = useState(100);
 
   // --- socket handlers ---
-  const onAuctionChunk = useCallback(({ token }) => {
-    setNote((prev) =>
-      !prev || prev.done
-        ? { type: 'auction', text: token, done: false }
-        : { ...prev, text: prev.text + token }
-    );
-  }, []);
-
-  const onAuctionDone = useCallback(() => {
-    setNote((prev) => (prev ? { ...prev, done: true } : null));
-  }, []);
-
   const onRecapChunk = useCallback(({ token }) => {
     setNote((prev) =>
       !prev || prev.done
@@ -40,10 +27,8 @@ export default function AiCommentary() {
     setNote((prev) => (prev ? { ...prev, done: true } : null));
   }, []);
 
-  useSocketEvent('auction:commentary:chunk', onAuctionChunk);
-  useSocketEvent('auction:commentary:done',  onAuctionDone);
-  useSocketEvent('bracket:recap:chunk',      onRecapChunk);
-  useSocketEvent('bracket:recap:done',       onRecapDone);
+  useSocketEvent('bracket:recap:chunk', onRecapChunk);
+  useSocketEvent('bracket:recap:done', onRecapDone);
 
   // --- auto-dismiss with animated countdown bar ---
   useEffect(() => {

--- a/client/src/pages/Auction.jsx
+++ b/client/src/pages/Auction.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { useSocket, useSocketEvent } from '../context/SocketContext';
 import { useTournament } from '../context/TournamentContext';
@@ -264,14 +264,37 @@ export default function Auction() {
     setBidError('');
   }, [isViewingHistory]));
 
-  useSocketEvent('auction:sold', useCallback(({ teamName, winnerName, winnerColor, finalPrice }) => {
+  useSocketEvent('auction:sold', useCallback(({ teamName, winnerName, winnerColor, finalPrice, aiCommentaryEnabled }) => {
     if (isViewingHistory) return;
-    setSoldMessage({ teamName, winnerName, winnerColor, finalPrice });
+    setSoldMessage({
+      teamName,
+      winnerName,
+      winnerColor,
+      finalPrice,
+      commentary: '',
+      commentaryLoading: !!aiCommentaryEnabled,
+    });
     setActive(null);
     setRecentBids([]);
     refreshItems();
-    setTimeout(() => setSoldMessage(null), 6000);
   }, [refreshItems, isViewingHistory]));
+
+  useSocketEvent('auction:commentary:chunk', useCallback(({ token }) => {
+    if (isViewingHistory) return;
+    setSoldMessage((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        commentary: `${prev.commentary || ''}${token || ''}`,
+        commentaryLoading: true,
+      };
+    });
+  }, [isViewingHistory]));
+
+  useSocketEvent('auction:commentary:done', useCallback(() => {
+    if (isViewingHistory) return;
+    setSoldMessage((prev) => (prev ? { ...prev, commentaryLoading: false } : prev));
+  }, [isViewingHistory]));
 
   useSocketEvent('auction:nobids', useCallback(() => {
     if (isViewingHistory) return;
@@ -350,6 +373,17 @@ export default function Auction() {
             <span className="font-semibold" style={{ color: soldMessage.winnerColor }}>{soldMessage.winnerName}</span>
             {' '}for <span className="font-bold text-text-primary tabular-nums">{fmt(soldMessage.finalPrice)}</span>
           </div>
+          {soldMessage.commentary && (
+            <div className="mt-3 max-w-2xl mx-auto text-sm text-text-primary leading-relaxed">
+              {soldMessage.commentary}
+            </div>
+          )}
+          {soldMessage.commentaryLoading && (
+            <div className="mt-3 inline-flex items-center gap-2 text-xs text-text-secondary">
+              <span className="w-3.5 h-3.5 rounded-full border-2 border-text-muted border-t-brand animate-spin" aria-hidden="true" />
+              <span>Generating AI commentary…</span>
+            </div>
+          )}
         </div>
       )}
 

--- a/server/socket.js
+++ b/server/socket.js
@@ -100,6 +100,8 @@ function closeAuction(itemId, io) {
 
     const winner = db.prepare('SELECT name, color FROM participants WHERE id = ?').get(item.current_leader_id);
     const team = db.prepare('SELECT name, seed, region FROM teams WHERE id = ?').get(item.team_id);
+    const aiCommentaryEnabled = getTournamentSetting(tid, 'ai_commentary_enabled') !== '0'
+      && !!process.env.ANTHROPIC_API_KEY;
 
     io.emit('auction:sold', {
       itemId,
@@ -109,9 +111,12 @@ function closeAuction(itemId, io) {
       winnerName: winner?.name,
       winnerColor: winner?.color,
       finalPrice: item.current_price,
+      aiCommentaryEnabled,
     });
 
-    generateSaleCommentary(item, winner, team, tid, io);
+    if (aiCommentaryEnabled) {
+      generateSaleCommentary(item, winner, team, tid, io);
+    }
     autoAdvanceToNextItem(tid, io);
   } else {
     // No bids — mark as skipped/pending again for re-queue


### PR DESCRIPTION
Summary:
- move auction AI commentary display into the sold-team card in Auction
- show an inline loading indicator while AI commentary is generating
- keep the sold card visible until the next team starts
- include aiCommentaryEnabled on auction:sold payload so loader only appears when commentary is expected
- keep AiCommentary toast focused on bracket recap events only

Validation:
- node --check server/socket.js
- npm run build --prefix client