### PR TITLE
Update AI commentary summaries to use new trigger points

### DIFF
--- a/client/src/components/AiCommentary.jsx
+++ b/client/src/components/AiCommentary.jsx
@@ -5,7 +5,7 @@ import { useSocketEvent } from '../context/SocketContext';
 const AUTO_DISMISS_MS = 10000;
 
 const CONFIG = {
-  recap: { icon: '📊', label: 'Game Recap' },
+  recap: { icon: '📊', label: 'Round Recap' },
 };
 
 export default function AiCommentary() {

--- a/server/ai.js
+++ b/server/ai.js
@@ -53,16 +53,12 @@ Respond with only the commentary text. No quotes, no prefix.`;
   }
 }
 
-// Generates a 2-3 sentence Calcutta-focused recap after a bracket game result.
+// Generates an end-of-round recap with a per-team summary block.
 // Emits: bracket:recap:chunk { token }, bracket:recap:done { text }
-async function streamGameRecap({
+async function streamRoundRecap({
   roundNumber,
-  winnerTeam,  // { name, seed, region }
-  loserTeam,   // { name, seed, region }
-  winnerOwner, // { name, purchase_price } | null
-  loserOwner,  // { name, purchase_price } | null
-  earnings,    // dollars earned for this win (0 if no payout configured)
-  standings,   // top-5 array [{ name, total_earned, total_spent }]
+  teamSummaries, // [{ seed, teamName, ownerName, purchasePrice, outcome, roundEarnings }]
+  standings,     // top array [{ name, total_earned, total_spent }]
   totalPot,
 }, io) {
   const client = getClient();
@@ -70,38 +66,40 @@ async function streamGameRecap({
 
   const roundName = ROUND_NAMES[roundNumber] || `Round ${roundNumber}`;
 
-  const ownershipLines = [
-    winnerOwner
-      ? `${winnerTeam.name} is owned by ${winnerOwner.name} (paid $${winnerOwner.purchase_price} at auction)${earnings > 0 ? ` — earns $${earnings} for this win` : ''}.`
-      : `${winnerTeam.name} is unowned — no one profits from this win.`,
-    loserOwner
-      ? `${loserTeam.name} was owned by ${loserOwner.name} (paid $${loserOwner.purchase_price}) — they're out.`
-      : `${loserTeam.name} was unowned.`,
-  ].join('\n');
-
   const standingsSummary = standings
-    .slice(0, 5)
+    .slice(0, 8)
     .map((p, i) => `${i + 1}. ${p.name}: $${p.total_earned} earned, $${p.total_spent} spent`)
     .join('\n');
 
-  const prompt = `You are a commentator for a small March Madness Calcutta pool among friends. Write 2-3 conversational sentences about this result from a Calcutta money perspective — who profits, who's hurting, any standings drama. Be specific with names and dollar amounts. Keep it tight.
+  const teamInput = (teamSummaries || []).map((t) => (
+    `#${t.seed} ${t.teamName} | ${t.ownerName ? `${t.ownerName} (paid $${t.purchasePrice})` : 'Unowned'} | ${t.outcome}${t.roundEarnings > 0 ? ` | +$${t.roundEarnings}` : ''}`
+  )).join('\n');
 
-${roundName}: #${winnerTeam.seed} ${winnerTeam.name} defeats #${loserTeam.seed} ${loserTeam.name}
-
-${ownershipLines}
+  const prompt = `You are a commentator for a small March Madness Calcutta pool among friends.
+Write 2-3 conversational sentences about the completed ${roundName} from a money/standings perspective.
+Be specific with names and dollar amounts.
 
 Current standings (total pot $${totalPot}):
 ${standingsSummary}
 
-Respond with only the commentary. No quotes, no prefix.`;
+Round team outcomes:
+${teamInput}
+
+Respond with only the 2-3 sentence intro text. No quotes, no prefix.`;
 
   try {
     const message = await client.messages.create({
       model: 'claude-sonnet-4-5-20250929',
-      max_tokens: 180,
+      max_tokens: 220,
       messages: [{ role: 'user', content: prompt }],
     });
-    const text = message.content[0]?.text || '';
+
+    const intro = (message.content[0]?.text || '').trim();
+    const perTeamSummary = (teamSummaries || []).map((t) => (
+      `- #${t.seed} ${t.teamName} (${t.ownerName ? `${t.ownerName}, paid $${t.purchasePrice}` : 'Unowned'}) — ${t.outcome}${t.roundEarnings > 0 ? `, earned $${t.roundEarnings}` : ''}`
+    )).join('\n');
+
+    const text = `${intro}\n\n${roundName} Team Summary:\n${perTeamSummary}`.trim();
     io.emit('bracket:recap:chunk', { token: text });
     io.emit('bracket:recap:done', { text });
   } catch (e) {
@@ -109,4 +107,4 @@ Respond with only the commentary. No quotes, no prefix.`;
   }
 }
 
-module.exports = { generateAuctionCommentary, streamGameRecap };
+module.exports = { generateAuctionCommentary, streamRoundRecap };

--- a/server/routes/bracket.js
+++ b/server/routes/bracket.js
@@ -6,12 +6,92 @@ const {
   getTotalPot, getGameById, getGameByPosition, calculatePayoutAmount,
 } = require('../db');
 const { requireAuth, requireAdmin } = require('./middleware');
-const { streamGameRecap } = require('../ai');
+const { streamRoundRecap } = require('../ai');
 
 const router = express.Router();
 
 function resolveTid(req) {
   return req.query.t ? parseInt(req.query.t) : getActiveTournamentId();
+}
+
+function isRoundComplete(roundNumber, tid) {
+  const row = db.prepare(`
+    SELECT
+      COUNT(*) as total_games,
+      SUM(CASE WHEN winner_id IS NOT NULL THEN 1 ELSE 0 END) as completed_games
+    FROM games
+    WHERE tournament_id = ?
+      AND round = ?
+      AND team1_id IS NOT NULL
+      AND team2_id IS NOT NULL
+  `).get(tid, roundNumber);
+
+  const totalGames = row?.total_games || 0;
+  const completedGames = row?.completed_games || 0;
+  return totalGames > 0 && completedGames === totalGames;
+}
+
+function getRoundTeamSummaries(roundNumber, tid) {
+  const roundGames = db.prepare(`
+    SELECT
+      g.id as game_id,
+      g.position,
+      g.winner_id,
+      t1.id as team1_id, t1.name as team1_name, t1.seed as team1_seed,
+      t2.id as team2_id, t2.name as team2_name, t2.seed as team2_seed,
+      p1.name as team1_owner_name, o1.purchase_price as team1_purchase_price,
+      p2.name as team2_owner_name, o2.purchase_price as team2_purchase_price
+    FROM games g
+    LEFT JOIN teams t1 ON t1.id = g.team1_id
+    LEFT JOIN teams t2 ON t2.id = g.team2_id
+    LEFT JOIN ownership o1 ON o1.team_id = g.team1_id AND o1.tournament_id = g.tournament_id
+    LEFT JOIN participants p1 ON p1.id = o1.participant_id
+    LEFT JOIN ownership o2 ON o2.team_id = g.team2_id AND o2.tournament_id = g.tournament_id
+    LEFT JOIN participants p2 ON p2.id = o2.participant_id
+    WHERE g.tournament_id = ?
+      AND g.round = ?
+      AND g.team1_id IS NOT NULL
+      AND g.team2_id IS NOT NULL
+    ORDER BY g.position
+  `).all(tid, roundNumber);
+
+  const earningsRows = db.prepare(`
+    SELECT game_id, amount
+    FROM earnings
+    WHERE tournament_id = ? AND round_number = ?
+  `).all(tid, roundNumber);
+  const earningsByGame = new Map(earningsRows.map((r) => [r.game_id, r.amount || 0]));
+
+  const summaries = [];
+  for (const game of roundGames) {
+    const gameEarnings = earningsByGame.get(game.game_id) || 0;
+
+    if (game.team1_id) {
+      const advanced = game.winner_id === game.team1_id;
+      summaries.push({
+        seed: game.team1_seed,
+        teamName: game.team1_name,
+        ownerName: game.team1_owner_name || null,
+        purchasePrice: game.team1_purchase_price != null ? game.team1_purchase_price : null,
+        outcome: advanced ? 'advanced' : 'eliminated',
+        roundEarnings: advanced ? gameEarnings : 0,
+      });
+    }
+
+    if (game.team2_id) {
+      const advanced = game.winner_id === game.team2_id;
+      summaries.push({
+        seed: game.team2_seed,
+        teamName: game.team2_name,
+        ownerName: game.team2_owner_name || null,
+        purchasePrice: game.team2_purchase_price != null ? game.team2_purchase_price : null,
+        outcome: advanced ? 'advanced' : 'eliminated',
+        roundEarnings: advanced ? gameEarnings : 0,
+      });
+    }
+  }
+
+  return summaries;
 }
 
 // GET /api/bracket
@@ -69,27 +149,17 @@ router.post('/result', requireAdmin, (req, res) => {
   if (io) {
     io.emit('bracket:update', { gameId, winnerId, loserId });
 
-    if (getTournamentSetting(tid, 'ai_commentary_end_of_round') !== '0') {
-      // Fire-and-forget AI recap
-      const winnerTeam = db.prepare('SELECT name, seed, region FROM teams WHERE id = ?').get(winnerId);
-      const loserTeam  = db.prepare('SELECT name, seed, region FROM teams WHERE id = ?').get(loserId);
-      const winnerOwner = db.prepare(
-        'SELECT p.name, o.purchase_price FROM ownership o JOIN participants p ON p.id = o.participant_id WHERE o.team_id = ? AND o.tournament_id = ?'
-      ).get(winnerId, tid);
-      const loserOwner = db.prepare(
-        'SELECT p.name, o.purchase_price FROM ownership o JOIN participants p ON p.id = o.participant_id WHERE o.team_id = ? AND o.tournament_id = ?'
-      ).get(loserId, tid);
-      const earnings = db.prepare('SELECT amount FROM earnings WHERE game_id = ?').get(gameId)?.amount || 0;
+    if (
+      getTournamentSetting(tid, 'ai_commentary_end_of_round') !== '0'
+      && isRoundComplete(game.round, tid)
+    ) {
       const totalPot = getTotalPot(tid);
-      const standings = getFullStandings(tid).slice(0, 5);
+      const standings = getFullStandings(tid).slice(0, 8);
+      const teamSummaries = getRoundTeamSummaries(game.round, tid);
 
-      streamGameRecap({
+      streamRoundRecap({
         roundNumber: game.round,
-        winnerTeam,
-        loserTeam,
-        winnerOwner,
-        loserOwner,
-        earnings,
+        teamSummaries,
         standings,
         totalPot,
       }, io).catch((e) => console.error('[AI recap]', e.message));


### PR DESCRIPTION
Summary
- ensure "AI commentary end of round" logic summarizes per team after each NCAA tournament round (Round of 64, 32, Sweet 16, Elite 8, etc.) instead of after every game
- resolve fixture size setting so the UI-controlled value is respected by the Load Test Fixture button
- refresh branch state based on latest main and prepare new dev branch for continuing work

Testing
- Not run (not requested)