### PR TITLE
Update admin login flow and bracket rounds

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -37,12 +37,19 @@ function AppRoutes() {
       {participant && <Nav />}
       <main className="min-h-screen">
         <Routes>
-          <Route path="/join" element={participant ? <Navigate to="/" replace /> : <Join />} />
+          <Route path="/join" element={participant ? <Navigate to={participant.isAdmin ? '/admin' : '/'} replace /> : <Join />} />
           <Route path="/" element={<ProtectedRoute><Auction /></ProtectedRoute>} />
           <Route path="/auction" element={<ProtectedRoute><Auction /></ProtectedRoute>} />
           <Route path="/bracket" element={<ProtectedRoute><Bracket /></ProtectedRoute>} />
           <Route path="/standings" element={<ProtectedRoute><Standings /></ProtectedRoute>} />
-          <Route path="/my-teams" element={<ProtectedRoute><MyTeams /></ProtectedRoute>} />
+          <Route
+            path="/my-teams"
+            element={
+              <ProtectedRoute>
+                {participant?.isAdmin ? <Navigate to="/admin" replace /> : <MyTeams />}
+              </ProtectedRoute>
+            }
+          />
           <Route path="/admin" element={<ProtectedRoute adminOnly><Admin /></ProtectedRoute>} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/client/src/components/Nav.jsx
+++ b/client/src/components/Nav.jsx
@@ -14,7 +14,7 @@ export default function Nav() {
   const links = [
     { to: '/standings', label: 'Standings' },
     { to: '/bracket', label: 'Bracket' },
-    { to: '/my-teams', label: 'My Teams' },
+    ...(participant?.isAdmin ? [] : [{ to: '/my-teams', label: 'My Teams' }]),
     { to: '/auction', label: 'Auction' },
     ...(participant?.isAdmin ? [{ to: '/admin', label: 'Admin' }] : []),
   ];

--- a/client/src/pages/admin/BracketAdminTab.jsx
+++ b/client/src/pages/admin/BracketAdminTab.jsx
@@ -60,14 +60,38 @@ export default function BracketAdminTab() {
   const [tournamentStarted, setTournamentStarted] = useState(false);
   const [loading, setLoading] = useState(true);
   const [msg, setMsg] = useState('');
+  const [expandedRounds, setExpandedRounds] = useState({});
+
+  const buildGamesByRound = (allGames) => {
+    const byRound = {};
+    for (const g of allGames) {
+      if (!byRound[g.round]) byRound[g.round] = [];
+      byRound[g.round].push(g);
+    }
+    return byRound;
+  };
+
+  const roundHasUndecidedGames = (roundGames) =>
+    roundGames.some((g) => g.team1_id && g.team2_id && !g.winner_id);
 
   const load = () => {
     Promise.all([
       api('/bracket').then((r) => r.json()),
       api('/admin/settings').then((r) => r.json()),
     ]).then(([bracketData, settings]) => {
-      setGames(bracketData.games || []);
+      const nextGames = bracketData.games || [];
+      const grouped = buildGamesByRound(nextGames);
+
+      setGames(nextGames);
       setTournamentStarted(settings.tournament_started === '1');
+      setExpandedRounds((prev) => {
+        const next = {};
+        for (const [round, roundGames] of Object.entries(grouped)) {
+          const defaultExpanded = roundHasUndecidedGames(roundGames);
+          next[round] = prev[round] ?? defaultExpanded;
+        }
+        return next;
+      });
       setLoading(false);
     });
   };
@@ -105,11 +129,17 @@ export default function BracketAdminTab() {
 
   if (loading) return <div className="text-slate-400 py-8 text-center">Loading...</div>;
 
-  const gamesByRound = {};
-  for (const g of games) {
-    if (!gamesByRound[g.round]) gamesByRound[g.round] = [];
-    gamesByRound[g.round].push(g);
-  }
+  const gamesByRound = buildGamesByRound(games);
+  const roundEntries = Object.entries(gamesByRound).sort((a, b) => Number(a[0]) - Number(b[0]));
+  const allExpanded = roundEntries.length > 0 && roundEntries.every(([round]) => !!expandedRounds[round]);
+  const toggleAllRounds = () => {
+    const nextExpanded = !allExpanded;
+    setExpandedRounds((prev) => {
+      const next = { ...prev };
+      for (const [round] of roundEntries) next[round] = nextExpanded;
+      return next;
+    });
+  };
 
   return (
     <div className="space-y-6">
@@ -119,9 +149,17 @@ export default function BracketAdminTab() {
             Initialize Bracket
           </button>
         ) : (
-          <button onClick={resetBracket} className="bg-red-700 hover:bg-red-800 text-white font-bold px-5 py-2 rounded-lg">
-            Reset All Results
-          </button>
+          <>
+            <button
+              onClick={toggleAllRounds}
+              className="bg-slate-700 hover:bg-slate-600 text-white font-semibold px-4 py-2 rounded-lg"
+            >
+              {allExpanded ? 'Collapse All Rounds' : 'Expand All Rounds'}
+            </button>
+            <button onClick={resetBracket} className="bg-red-700 hover:bg-red-800 text-white font-bold px-5 py-2 rounded-lg">
+              Reset All Results
+            </button>
+          </>
         )}
         {msg && <span className="text-green-400 text-sm">{msg}</span>}
       </div>
@@ -130,18 +168,41 @@ export default function BracketAdminTab() {
         <p className="text-slate-400">Initialize the bracket to start entering results.</p>
       ) : (
         <div className="space-y-8">
-          {Object.entries(gamesByRound).map(([round, roundGames]) => (
-            <div key={round}>
-              <h3 className="text-sm font-semibold uppercase tracking-wider text-orange-400 mb-3">
-                {ROUND_NAMES[parseInt(round)]}
-              </h3>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                {roundGames.map((game) => (
-                  <GameRow key={game.id} game={game} onSetWinner={setWinner} onUnset={unsetWinner} />
-                ))}
+          {roundEntries.map(([round, roundGames]) => {
+            const unresolvedCount = roundGames.filter((g) => g.team1_id && g.team2_id && !g.winner_id).length;
+            const isExpanded = !!expandedRounds[round];
+            return (
+              <div key={round} className="border border-slate-700 rounded-xl overflow-hidden">
+                <button
+                  onClick={() => setExpandedRounds((prev) => ({ ...prev, [round]: !prev[round] }))}
+                  className="w-full flex items-center justify-between px-4 py-3 bg-slate-900/70 hover:bg-slate-800/70 transition-colors text-left"
+                  aria-expanded={isExpanded}
+                >
+                  <div className="flex items-center gap-3">
+                    <h3 className="text-sm font-semibold uppercase tracking-wider text-orange-400">
+                      {ROUND_NAMES[parseInt(round, 10)]}
+                    </h3>
+                    {unresolvedCount > 0 && (
+                      <span className="text-xs font-medium px-2 py-0.5 rounded bg-amber-400/15 text-amber-300 border border-amber-500/30">
+                        {unresolvedCount} undecided
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-slate-300 text-xs">{isExpanded ? 'Hide' : 'Show'}</span>
+                </button>
+
+                {isExpanded && (
+                  <div className="p-3">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                      {roundGames.map((game) => (
+                        <GameRow key={game.id} game={game} onSetWinner={setWinner} onUnset={unsetWinner} />
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
Summary
- route admin logins straight to the admin dashboard and hide the “My Teams” navigation when the user is an admin
- make each round on the admin bracket results page collapsible, add expand/collapse-all controls, and keep rounds collapsed unless undecided games exist

Testing
- Not run (not requested)