### PR TITLE
Update recap prompt instructions for per-person briefs

### DIFF
--- a/client/src/pages/Auction.jsx
+++ b/client/src/pages/Auction.jsx
@@ -182,6 +182,8 @@ export default function Auction() {
   const [loading, setLoading] = useState(true);
   const [scheduledStart, setScheduledStart] = useState(null);
   const [countdown, setCountdown] = useState('');
+  const [completionSummary, setCompletionSummary] = useState('');
+  const [completionSummaryLoading, setCompletionSummaryLoading] = useState(false);
 
   const refreshItems = useCallback(() => {
     api(`/auction/items${apiTParam || ''}`)
@@ -197,6 +199,8 @@ export default function Auction() {
         setActive(data.active);
         setRecentBids(data.recentBids || []);
         setItems(data.items || []);
+        setCompletionSummary(data.completionSummary || '');
+        if (data.completionSummary) setCompletionSummaryLoading(false);
       });
   }, [apiTParam]);
 
@@ -225,11 +229,15 @@ export default function Auction() {
     return () => clearInterval(id);
   }, [scheduledStart]);
 
-  useSocketEvent('auction:state', useCallback(({ active, recentBids, auctionStatus, scheduledStart: ss }) => {
+  useSocketEvent('auction:state', useCallback(({ active, recentBids, auctionStatus, scheduledStart: ss, completionSummary }) => {
     if (isViewingHistory) return;
     if (active !== undefined) setActive(active);
     if (recentBids) setRecentBids(recentBids);
     if (auctionStatus) setAuctionStatus(auctionStatus);
+    if (completionSummary !== undefined) {
+      setCompletionSummary(completionSummary || '');
+      if (completionSummary) setCompletionSummaryLoading(false);
+    }
     setScheduledStart(ss || null);
   }, [isViewingHistory]));
 
@@ -247,6 +255,7 @@ export default function Auction() {
     setBidInput('');
     setBidError('');
     setSoldMessage(null);
+    setCompletionSummaryLoading(false);
   }, [refreshAll, isViewingHistory]));
 
   useSocketEvent('auction:update', useCallback(({ currentPrice, leaderId, leaderName, leaderColor, endTime, recentBids }) => {
@@ -307,6 +316,16 @@ export default function Auction() {
     if (!isViewingHistory) { setAuctionStatus('complete'); setActive(null); }
   }, [isViewingHistory]));
 
+  useSocketEvent('auction:summary:started', useCallback(() => {
+    if (!isViewingHistory) setCompletionSummaryLoading(true);
+  }, [isViewingHistory]));
+
+  useSocketEvent('auction:summary:done', useCallback(({ text }) => {
+    if (isViewingHistory) return;
+    setCompletionSummary(text || '');
+    setCompletionSummaryLoading(false);
+  }, [isViewingHistory]));
+
   useSocketEvent('auction:error', useCallback(({ message }) => {
     if (!isViewingHistory) setBidError(message);
   }, [isViewingHistory]));
@@ -332,6 +351,14 @@ export default function Auction() {
   const soldCount = items.filter((i) => i.status === 'sold').length;
   const pendingCount = items.filter((i) => i.status === 'pending').length;
   const isLeader = active?.current_leader_id === participant?.id;
+  const recapLines = (completionSummary || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const recapBullets = recapLines.filter((line) => line.startsWith('- '));
+  const recapIntro = recapLines
+    .filter((line) => !line.startsWith('- '))
+    .join(' ');
 
   if (loading) {
     return (
@@ -488,7 +515,44 @@ export default function Auction() {
             <span aria-hidden="true" className="text-3xl leading-none">🏆</span>
           </div>
           <h2 className="text-2xl font-bold text-text-primary mb-2">Auction Complete!</h2>
-          <p className="text-text-secondary">All teams have been sold. Check Standings and My Teams.</p>
+          <p className="text-text-secondary">
+            All teams have been sold. Check Standings{participant?.isAdmin ? '.' : ' and My Teams.'}
+          </p>
+          {(completionSummaryLoading || completionSummary) && (
+            <div className="mt-6 text-left max-w-3xl mx-auto bg-surface-base/50 border border-surface-border rounded-xl p-4">
+              <div className="section-label mb-2">AI Auction Recap</div>
+              {completionSummaryLoading && !completionSummary && (
+                <div className="inline-flex items-center gap-2 text-xs text-text-secondary">
+                  <span className="w-3.5 h-3.5 rounded-full border-2 border-text-muted border-t-brand animate-spin" aria-hidden="true" />
+                  <span>Generating final recap…</span>
+                </div>
+              )}
+              {completionSummary && (
+                <div className="space-y-3">
+                  {recapIntro && (
+                    <p className="text-sm text-text-secondary leading-relaxed">{recapIntro}</p>
+                  )}
+                  {recapBullets.length > 0 ? (
+                    <div className="space-y-2">
+                      {recapBullets.map((line, idx) => (
+                        <div
+                          key={`${line}-${idx}`}
+                          className="text-sm text-text-primary bg-surface-raised/60 border border-surface-border rounded-lg px-3 py-2"
+                          style={{ borderLeftWidth: '3px', borderLeftColor: 'rgba(249, 115, 22, 0.65)' }}
+                        >
+                          {line.slice(2)}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-sm text-text-primary leading-relaxed whitespace-pre-wrap">
+                      {completionSummary}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
       ) : auctionStatus === 'waiting' ? (

--- a/server/ai.js
+++ b/server/ai.js
@@ -107,4 +107,47 @@ Respond with only the 2-3 sentence intro text. No quotes, no prefix.`;
   }
 }
 
-module.exports = { generateAuctionCommentary, streamRoundRecap };
+async function generateAuctionCompletionSummary({
+  participantSummaries, // [{ participantName, teamsOwned, totalSpent, avgSpend }]
+  totalPot,
+}) {
+  const client = getClient();
+  if (!client) return '';
+  if (!Array.isArray(participantSummaries) || participantSummaries.length === 0) return '';
+
+  const lines = participantSummaries.map((p) => (
+    `${p.participantName}: spent $${p.totalSpent} on ${p.teamsOwned} team${p.teamsOwned === 1 ? '' : 's'} (avg $${p.avgSpend})`
+  )).join('\n');
+
+  const prompt = `You are recapping a March Madness Calcutta auction for a friend group.
+Write a full-auction recap that is edgy, funny, and accurate. Keep it sharp, not corny and not overly punny.
+
+Rules:
+- Write exactly 1 short intro sentence.
+- Then output exactly one bullet per participant using this format:
+  - NAME — spent $X on Y teams: one concise, spicy but factual line
+- Do not invent data.
+- Keep each bullet to one sentence.
+- No markdown headers.
+- Keep the whole response brief.
+
+Auction total pot: $${totalPot}
+Participant results:
+${lines}
+
+Return only the recap text.`;
+
+  try {
+    const message = await client.messages.create({
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 700,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    return (message.content[0]?.text || '').trim();
+  } catch (e) {
+    console.error('[AI auction completion]', e.message);
+    return '';
+  }
+}
+
+module.exports = { generateAuctionCommentary, streamRoundRecap, generateAuctionCompletionSummary };

--- a/server/db.js
+++ b/server/db.js
@@ -125,6 +125,7 @@ function init() {
       auction_auto_advance  INTEGER NOT NULL DEFAULT 0,
       ai_commentary_enabled   INTEGER NOT NULL DEFAULT 1,
       auction_scheduled_start INTEGER DEFAULT NULL,
+      auction_completion_summary TEXT,
       created_at              INTEGER DEFAULT (unixepoch()),
       archived_at             INTEGER
     );
@@ -136,6 +137,9 @@ function init() {
   }
   if (!columnExists('tournaments', 'auction_scheduled_start')) {
     db.exec('ALTER TABLE tournaments ADD COLUMN auction_scheduled_start INTEGER DEFAULT NULL');
+  }
+  if (!columnExists('tournaments', 'auction_completion_summary')) {
+    db.exec('ALTER TABLE tournaments ADD COLUMN auction_completion_summary TEXT');
   }
 
   // M2: Seed tournament id=1 from existing settings (if tournaments table is empty)
@@ -407,7 +411,13 @@ function seedTeamsForTournament(tid, teams) {
       insertAuction.run(result.lastInsertRowid, i, tid);
     });
 
-    db.prepare("UPDATE tournaments SET auction_status = 'waiting', tournament_started = 0 WHERE id = ?").run(tid);
+    db.prepare(`
+      UPDATE tournaments
+      SET auction_status = 'waiting',
+          tournament_started = 0,
+          auction_completion_summary = NULL
+      WHERE id = ?
+    `).run(tid);
   })();
 
   const order = getTournamentSetting(tid, 'auction_order') || 'random';
@@ -454,6 +464,51 @@ function getAuctionItems(tid) {
     WHERE ai.tournament_id = ?
     ORDER BY ai.queue_order
   `).all(_tid);
+}
+
+function getAuctionCounts(tid) {
+  const _tid = tid ?? getActiveTournamentId();
+  const counts = db.prepare(`
+    SELECT
+      COUNT(*) as total_count,
+      SUM(CASE WHEN status = 'sold' THEN 1 ELSE 0 END) as sold_count,
+      SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) as active_count,
+      SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) as pending_count
+    FROM auction_items
+    WHERE tournament_id = ?
+  `).get(_tid);
+
+  return {
+    total_count: counts?.total_count || 0,
+    sold_count: counts?.sold_count || 0,
+    active_count: counts?.active_count || 0,
+    pending_count: counts?.pending_count || 0,
+  };
+}
+
+function getResolvedAuctionStatus(tid) {
+  const _tid = tid ?? getActiveTournamentId();
+  const configured = getTournamentSetting(_tid, 'auction_status') || 'waiting';
+  const counts = getAuctionCounts(_tid);
+  if (
+    counts.total_count > 0 &&
+    counts.sold_count === counts.total_count &&
+    counts.pending_count === 0 &&
+    counts.active_count === 0
+  ) {
+    return 'complete';
+  }
+  return configured;
+}
+
+function getAuctionCompletionSummary(tid) {
+  const _tid = tid ?? getActiveTournamentId();
+  return db.prepare('SELECT auction_completion_summary FROM tournaments WHERE id = ?').get(_tid)?.auction_completion_summary || '';
+}
+
+function setAuctionCompletionSummary(tid, summary) {
+  const _tid = tid ?? getActiveTournamentId();
+  db.prepare('UPDATE tournaments SET auction_completion_summary = ? WHERE id = ?').run(summary || null, _tid);
 }
 
 function getActiveAuctionItem(tid) {
@@ -665,7 +720,11 @@ module.exports = {
   getAllParticipants,
   getTeams,
   getAuctionItems,
+  getAuctionCounts,
   getActiveAuctionItem,
+  getResolvedAuctionStatus,
+  getAuctionCompletionSummary,
+  setAuctionCompletionSummary,
   getRecentBids,
   getOwnership,
   getFullStandings,

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -69,6 +69,7 @@ function clearTournamentState(tid, { removeNonAdminParticipants = false } = {}) 
     setTournamentSetting(tid, 'auction_status', 'waiting');
     setTournamentSetting(tid, 'tournament_started', '0');
     setTournamentSetting(tid, 'auction_scheduled_start', '');
+    db.prepare('UPDATE tournaments SET auction_completion_summary = NULL WHERE id = ?').run(tid);
   })();
 
   applyAuctionOrder(tid, getTournamentSetting(tid, 'auction_order') || 'random');

--- a/server/routes/auction.js
+++ b/server/routes/auction.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const {
   getActiveTournamentId,
-  getAuctionItems, getActiveAuctionItem, getRecentBids, getTournamentSetting,
+  getAuctionItems, getActiveAuctionItem, getRecentBids, getResolvedAuctionStatus, getAuctionCompletionSummary,
 } = require('../db');
 const { requireAuth } = require('./middleware');
 
@@ -19,7 +19,8 @@ router.get('/', requireAuth, (req, res) => {
   const active = getActiveAuctionItem(tid);
   const recentBids = active ? getRecentBids(active.team_id) : [];
   res.json({
-    auctionStatus: getTournamentSetting(tid, 'auction_status'),
+    auctionStatus: getResolvedAuctionStatus(tid),
+    completionSummary: getAuctionCompletionSummary(tid),
     items,
     active,
     recentBids,

--- a/server/services/auctionService.js
+++ b/server/services/auctionService.js
@@ -2,11 +2,16 @@ const {
   db,
   getActiveTournamentId,
   getTournamentSetting,
+  setTournamentSetting,
   getActiveAuctionItem,
+  getResolvedAuctionStatus,
+  getAuctionCompletionSummary,
+  setAuctionCompletionSummary,
   getRecentBids,
   getTotalPot,
+  getAuctionCounts,
 } = require('../db');
-const { generateAuctionCommentary } = require('../ai');
+const { generateAuctionCommentary, generateAuctionCompletionSummary } = require('../ai');
 
 function createAuctionService(io, options = {}) {
   const autoAdvanceDelayMs = options.autoAdvanceDelayMs ?? 3000;
@@ -14,6 +19,7 @@ function createAuctionService(io, options = {}) {
   const clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
   let activeTimer = null;
   let activeItemId = null;
+  let completionSummaryInFlightByTid = new Set();
 
   function clearActiveTimer() {
     if (activeTimer) {
@@ -61,11 +67,76 @@ function createAuctionService(io, options = {}) {
     }, io).catch((e) => console.error('[AI auction]', e.message));
   }
 
+  async function maybeGenerateCompletionSummary(tid) {
+    if (completionSummaryInFlightByTid.has(tid)) return;
+    if (getTournamentSetting(tid, 'ai_commentary_enabled') === '0') return;
+    if (!process.env.ANTHROPIC_API_KEY) return;
+    if (getAuctionCompletionSummary(tid)) return;
+
+    completionSummaryInFlightByTid.add(tid);
+    let emittedStarted = false;
+    try {
+      const participantSummaries = db.prepare(`
+        SELECT
+          p.name as participantName,
+          COALESCE(COUNT(o.team_id), 0) as teamsOwned,
+          COALESCE(SUM(o.purchase_price), 0) as totalSpent
+        FROM tournament_participants tp
+        JOIN participants p ON p.id = tp.participant_id
+        LEFT JOIN ownership o
+          ON o.participant_id = p.id
+         AND o.tournament_id = tp.tournament_id
+        WHERE tp.tournament_id = ?
+          AND p.is_admin = 0
+        GROUP BY p.id, p.name
+        ORDER BY totalSpent DESC, teamsOwned DESC, p.name ASC
+      `).all(tid);
+      if (!participantSummaries.length) return;
+
+      const normalizedParticipants = participantSummaries.map((p) => ({
+        participantName: p.participantName,
+        teamsOwned: p.teamsOwned || 0,
+        totalSpent: Math.round((p.totalSpent || 0) * 100) / 100,
+        avgSpend: p.teamsOwned > 0
+          ? Math.round(((p.totalSpent || 0) / p.teamsOwned) * 100) / 100
+          : 0,
+      }));
+
+      io.emit('auction:summary:started');
+      emittedStarted = true;
+      const text = await generateAuctionCompletionSummary({
+        participantSummaries: normalizedParticipants,
+        totalPot: getTotalPot(tid),
+      });
+      if (!text) {
+        io.emit('auction:summary:done', { text: '' });
+        return;
+      }
+
+      setAuctionCompletionSummary(tid, text);
+      io.emit('auction:summary:done', { text });
+    } catch (e) {
+      console.error('[AI auction completion]', e.message);
+      if (emittedStarted) io.emit('auction:summary:done', { text: '' });
+    } finally {
+      completionSummaryInFlightByTid.delete(tid);
+    }
+  }
+
   function checkAuctionCompletion(tid) {
-    const pending = db.prepare(
-      "SELECT COUNT(*) as c FROM auction_items WHERE status IN ('pending', 'active') AND tournament_id = ?"
-    ).get(tid).c;
-    if (pending === 0) io.emit('auction:complete');
+    const counts = getAuctionCounts(tid);
+    const isComplete = (
+      counts.total_count > 0 &&
+      counts.sold_count === counts.total_count &&
+      counts.pending_count === 0 &&
+      counts.active_count === 0
+    );
+    if (!isComplete) return;
+
+    setTournamentSetting(tid, 'auction_status', 'complete');
+    io.emit('auction:status', { status: 'complete' });
+    io.emit('auction:complete');
+    maybeGenerateCompletionSummary(tid).catch((e) => console.error('[AI auction completion]', e.message));
   }
 
   function startAuction({ tid, teamId } = {}) {
@@ -168,9 +239,10 @@ function createAuctionService(io, options = {}) {
   function emitAuctionState(socket, tid) {
     const tournamentId = tid ?? getActiveTournamentId();
     const active = getActiveAuctionItem(tournamentId);
-    const auctionStatus = getTournamentSetting(tournamentId, 'auction_status');
+    const auctionStatus = getResolvedAuctionStatus(tournamentId);
     const rawScheduled = getTournamentSetting(tournamentId, 'auction_scheduled_start');
     const scheduledStart = rawScheduled ? parseInt(rawScheduled, 10) : null;
+    const completionSummary = getAuctionCompletionSummary(tournamentId);
 
     if (active) {
       const recentBids = getRecentBids(active.team_id);
@@ -179,6 +251,7 @@ function createAuctionService(io, options = {}) {
         recentBids,
         auctionStatus,
         scheduledStart,
+        completionSummary,
       });
       return;
     }
@@ -188,6 +261,7 @@ function createAuctionService(io, options = {}) {
       recentBids: [],
       auctionStatus,
       scheduledStart,
+      completionSummary,
     });
   }
 


### PR DESCRIPTION
## Summary
- Adjust the Auction Recap prompt to ask for a brief, nicely styled summary per participant instead of a team-level summary
- Ensure the prompt now highlights the updated expectations for the recap responses
## Testing
- Not run (not requested)