### PR TITLE
Split monorepo into NCAA + F1 apps and wire Railway deployment

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,175 @@
+# Calcutta Monorepo - Developer Handoff
+
+This is the top-level handoff for the repository. It explains the split architecture and where to make changes.
+
+## Repository split
+
+The repo now contains two independent web apps:
+
+- `apps/ncaa`: March Madness Calcutta app (legacy app, existing UI styling preserved)
+- `apps/f1`: Formula 1 season Calcutta app (new product, separate domain model/UI)
+
+Shared code exists in:
+
+- `packages/core`: generic helper functions used by repo tooling and local development
+
+Important: `apps/f1/server` is intentionally self-contained for Railway subdirectory deploys. Do not add runtime imports from outside `apps/f1` unless the deploy strategy changes.
+
+## Monorepo layout
+
+- `apps/ncaa/server`: NCAA API, socket events, SQLite domain logic
+- `apps/ncaa/client`: NCAA React frontend (Tailwind)
+- `apps/f1/server`: F1 API, socket events, scoring engine, provider adapter
+- `apps/f1/client`: F1 React frontend (custom telemetry-dark CSS)
+- `packages/core`: shared money/auth/auction helpers
+- `.github/workflows/ci.yml`: split CI jobs (`ncaa`, `f1`, style-freeze check)
+- `scripts/check-ncaa-style-freeze.sh`: guard against accidental NCAA style changes
+
+## Running locally
+
+From repo root:
+
+- NCAA only: `npm run dev:ncaa`
+- F1 only: `npm run dev:f1`
+- Both: `npm run dev`
+
+Default local ports:
+
+- NCAA server/client: `3001` / `5173`
+- F1 server/client: `3002` / `5174`
+
+Env overrides supported:
+
+- NCAA: `NCAA_PORT`, `NCAA_CLIENT_ORIGIN`
+- F1: `F1_PORT`, `F1_CLIENT_ORIGIN`, `F1_RESULTS_PROVIDER`
+
+## Testing/building
+
+From repo root:
+
+- All tests: `npm run test`
+- NCAA tests only: `npm run test:ncaa`
+- F1 tests only: `npm run test:f1`
+- All builds: `npm run build`
+- NCAA style freeze check: `npm run check:ncaa-style-freeze`
+
+## Deployment (Railway)
+
+### NCAA service
+
+- Use root `railway.toml` or `apps/ncaa/railway.toml`
+- Healthcheck: `/api/health`
+- DB path should be on volume, e.g. `DB_PATH=/data/calcutta.db`
+
+### F1 service
+
+- Service root: `apps/f1`
+- Config file: `apps/f1/railway.toml`
+- Healthcheck: `/api/health`
+- DB path should be on volume, e.g. `DB_PATH=/data/f1-calcutta.db`
+- Build must install both server and client deps (already configured in `apps/f1/railway.toml`)
+
+Railway port guidance:
+
+- In production, prefer Railway-provided `PORT`
+- Do not force a fixed local dev port in Railway env unless necessary
+
+## Change targeting rules
+
+When requesting updates, always scope explicitly:
+
+- NCAA only: modify `apps/ncaa/**` only
+- F1 only: modify `apps/f1/**` only
+- Shared only when required: `packages/core/**`
+
+Suggested request format:
+
+- `[NCAA] ... Only touch apps/ncaa/**.`
+- `[F1] ... Only touch apps/f1/**.`
+
+## Current product status
+
+### NCAA
+
+- Existing March Madness behavior retained
+- Existing visual system intentionally preserved
+- CI guard prevents unintended NCAA styling edits
+
+### F1
+
+- Auction + ownership + standings implemented
+- Event results sync implemented via provider adapter (`mock` provider default)
+- Deterministic scoring engine implemented:
+  - GP payouts total `300 bps` (3%)
+  - Sprint payouts total `100 bps` (1%)
+  - Ties split evenly in cents
+  - Random finish bonus position drawn once per event and persisted
+  - Season bonus allocations from remainder based on configured bps
+
+## App-specific docs
+
+- NCAA deep-dive: `apps/ncaa/HANDOFF.md`
+- F1 deep-dive: `apps/f1/HANDOFF.md`
+
+## Operator Runbook
+
+### Daily operations
+
+1. Check both service health endpoints:
+   - NCAA: `https://<ncaa-domain>/api/health`
+   - F1: `https://<f1-domain>/api/health`
+2. Verify both services show healthy in Railway deployments.
+3. Confirm volume mounts remain attached at `/data`.
+
+### Deploy checklist (after merge)
+
+1. Ensure NCAA service points to root config (`/railway.toml`) or `apps/ncaa/railway.toml`.
+2. Ensure F1 service root is `apps/f1` and config path is `apps/f1/railway.toml`.
+3. Redeploy NCAA service, then F1 service.
+4. Validate app UI and health endpoints after each deploy.
+
+### Required env vars by service
+
+- NCAA:
+  - `ADMIN_PASSWORD`
+  - `NODE_ENV=production`
+  - `DB_PATH=/data/calcutta.db`
+  - optional `ANTHROPIC_API_KEY`
+
+- F1:
+  - `ADMIN_PASSWORD`
+  - `NODE_ENV=production`
+  - `DB_PATH=/data/f1-calcutta.db`
+  - optional `F1_RESULTS_PROVIDER=mock`
+  - avoid setting `F1_PORT` in Railway unless needed
+
+### Railway networking/domain guidance
+
+1. Generate domain per service in the service's **Networking** tab.
+2. Use target port `8080` (or Railway-provided `PORT` value shown in service variables).
+3. Keep health check path `/api/health`.
+
+### Common failure modes and fixes
+
+- `MODULE_NOT_FOUND` for files outside app root (F1):
+  - Cause: subdirectory deploy cannot resolve imports outside `apps/f1`.
+  - Fix: keep runtime imports self-contained within `apps/f1`.
+
+- Healthcheck failed immediately after deploy:
+  - Check deploy logs for startup exception.
+  - Ensure service listens on Railway `PORT` (not hardcoded local port).
+  - Verify health path is `/api/health`.
+
+- SQLite reset/lost data:
+  - Confirm volume is attached to correct service.
+  - Confirm `DB_PATH` points to `/data/...`.
+
+- NCAA loads but F1 fails (or vice versa):
+  - Verify service root/config path and build command for the failing service.
+
+### Rollback procedure
+
+1. In Railway, open failing service -> Deployments.
+2. Select last known healthy deployment and rollback.
+3. Re-verify `/api/health` and basic login flow.
+4. Open a follow-up fix PR before attempting forward deploy again.

--- a/apps/f1/HANDOFF.md
+++ b/apps/f1/HANDOFF.md
@@ -1,28 +1,48 @@
-# F1 Calcutta App Handoff
+# F1 App - Developer Handoff
 
-## Stack
+This document is specific to the F1 app under `apps/f1`.
+
+## Scope
+
+- Product: Formula 1 season Calcutta
+- Paths: `apps/f1/server`, `apps/f1/client`
+- Deployment target: F1 Railway service
+
+## Tech stack
 
 - Server: Node.js, Express, Socket.io, better-sqlite3
-- Client: React + Vite
-- Shared: `packages/core` utilities for money/auth/auction math
+- Client: React (Vite), custom CSS theme (telemetry-dark)
+- DB: SQLite (`DB_PATH`), default `apps/f1/server/f1-calcutta.db`
+
+## Important architecture note
+
+`apps/f1/server` is self-contained for Railway subdirectory deploys.
+Do not introduce runtime imports from outside `apps/f1` unless deploy strategy changes.
+
+Local shared helpers are in:
+
+- `apps/f1/server/lib/core.js`
 
 ## Key backend modules
 
-- `server/db.js` - schema + query helpers
-- `server/services/auctionService.js` - auction lifecycle
-- `server/services/scoringService.js` - event scoring, tie splitting, random bonus draw, season bonuses
-- `server/providers/index.js` - results provider adapter
-- `server/routes/admin.js` - auction controls, results sync, rule updates
+- `server/index.js`: app bootstrap + routes + socket wiring
+- `server/db.js`: schema + seed + query helpers
+- `server/services/auctionService.js`: auction lifecycle
+- `server/services/scoringService.js`: event scoring, ties, random bonus, season bonuses
+- `server/providers/index.js`: results provider adapter factory
+- `server/providers/mockResultsProvider.js`: deterministic mock provider
+- `server/routes/admin.js`: settings, auction control, sync, manual override, rules
+- `server/routes/events.js`: events listing and payout details
 
 ## F1 scoring model
 
-- GP categories total: `3.00%` of pool (`300 bps`)
-- Sprint categories total: `1.00%` of pool (`100 bps`)
-- Ties split category payout evenly in cents
-- Random bonus position is persisted per event and never redrawn
-- Season bonus rules allocate percentages of the remaining pool
+- Grand Prix categories total `300 bps` (3%) of pot
+- Sprint categories total `100 bps` (1%) of pot
+- Ties split payout evenly in integer cents
+- Random finishing-position bonus is drawn once and persisted per event
+- Season bonus payouts allocate remaining pool by configured bonus-rule bps
 
-## Important tables
+## Primary tables
 
 - `seasons`, `participants`, `season_participants`
 - `drivers`, `auction_items`, `bids`, `ownership`
@@ -30,11 +50,41 @@
 - `event_payout_rules`, `event_payouts`
 - `season_bonus_rules`, `season_bonus_payouts`
 
-## Sync flow
+## Results sync flow
 
-1. Admin calls `/api/admin/results/sync-next` or `/sync-event/:id`
+1. Admin calls `/api/admin/results/sync-next` or `/api/admin/results/sync-event/:id`
 2. Provider returns event results
-3. Results upsert into `event_results`
+3. Results are upserted into `event_results`
 4. Event payouts recalculated
 5. Season bonus payouts recalculated
 6. Socket events emitted: `results:sync:*`, `event:scored`, `standings:update`
+
+## Development commands
+
+From repo root:
+
+- `npm run dev:f1`
+- `npm run test:f1`
+- `npm run build:f1`
+
+From app root (`apps/f1`):
+
+- `npm run dev`
+- `npm run build`
+
+## Deployment notes (Railway)
+
+- Service root: `apps/f1`
+- Config file: `apps/f1/railway.toml`
+- Health endpoint: `/api/health`
+- Preferred DB env: `DB_PATH=/data/f1-calcutta.db`
+- Prefer Railway `PORT` in production (avoid forcing local dev port env)
+
+## Monorepo boundary
+
+Do not import runtime F1 code from `apps/ncaa`.
+
+If a change is F1-only, avoid edits to:
+
+- `apps/ncaa/**`
+- `packages/core/**` unless explicitly needed for tooling/shared behavior

--- a/apps/ncaa/HANDOFF.md
+++ b/apps/ncaa/HANDOFF.md
@@ -1,443 +1,66 @@
-# Calcutta App — Developer Handoff
-
-This document is the primary context reference for working on this codebase. Read it before making any changes.
-
----
-
-## What This App Does
-
-A real-time March Madness Calcutta auction web app. Players join with an invite code, then bid on NCAA tournament teams in a live ascending auction. Whoever owns a team earns money when that team wins bracket games. The admin controls the auction, enters bracket results, and configures payouts.
-
----
-
-## Tech Stack
-
-| Layer | Technology |
-|---|---|
-| Server | Node.js + Express, `better-sqlite3` (SQLite), Socket.io |
-| Client | React (Vite), Tailwind CSS, Socket.io client |
-| AI | Anthropic Claude API (`@anthropic-ai/sdk`) |
-| Deploy | Railway (single process serves API + static build) |
-| DB | SQLite file at `server/calcutta.db` (persisted via Railway volume) |
-
-**Node version:** 18+. There is no TypeScript — everything is plain JS/JSX.
-
----
-
-## Repository Layout
-
-```
-/
-├── server/
-│   ├── index.js          # Express + Socket.io entrypoint
-│   ├── db.js             # ALL database logic, migrations, query helpers
-│   ├── socket.js         # Socket.io auth + event wiring (uses auction service)
-│   ├── ai.js             # Anthropic API calls (auction commentary, round recap)
-│   ├── scheduler.js      # Scheduled auction auto-start timer
-│   ├── services/
-│   │   └── auctionService.js # Shared auction domain logic (start/close/bid/timers)
-│   ├── routes/
-│   │   ├── auth.js       # /api/auth — join, admin login, logout, /me
-│   │   ├── admin.js      # /api/admin — settings, auction control, bracket, teams
-│   │   ├── auction.js    # /api/auction — queue and item reads
-│   │   ├── bracket.js    # /api/bracket — read games, set/unset results
-│   │   ├── standings.js  # /api/standings — leaderboard
-│   │   ├── tournaments.js# /api/tournaments — multi-tournament management
-│   │   ├── export.js     # /api/admin/export/csv
-│   │   └── middleware.js # requireAuth, requireAdmin
-│   └── data/
-│       ├── teams2025.js         # Hard-coded 64-team bracket teams
-│       └── gameSchedule2025.js  # Historical 2025 date/time/network by bracket slot
-│   └── tests/
-│       └── auctionService.test.js # Focused integration tests for auction service
-│
-├── client/src/
-│   ├── App.jsx           # Router, context providers, ProtectedRoute
-│   ├── utils.js          # fmt(), api(), REGION_COLORS, ROUND_NAMES constants
-│   ├── main.jsx          # React entry point
-│   ├── index.css         # Tailwind base + custom component classes
-│   ├── context/
-│   │   ├── AuthContext.jsx       # useAuth() — participant state, join/login/logout
-│   │   ├── SocketContext.jsx     # useSocket() — socket.io connection
-│   │   └── TournamentContext.jsx # useTournament() — tournament metadata
-│   ├── components/
-│   │   ├── Nav.jsx
-│   │   ├── AiCommentary.jsx  # Round recap toast (auction sale commentary is in Auction sold card)
-│   │   ├── CountdownTimer.jsx
-│   │   ├── ParticipantAvatar.jsx
-│   │   └── TeamLogo.jsx
-│   └── pages/
-│       ├── Join.jsx        # /join — participant join + admin login
-│       ├── Auction.jsx     # / and /auction — live bidding UI
-│       ├── Bracket.jsx     # /bracket — bracket results view
-│       ├── Standings.jsx   # /standings — leaderboard
-│       ├── MyTeams.jsx     # /my-teams — owned teams per participant
-│       ├── Admin.jsx       # /admin — tab shell, imports sub-tabs
-│       └── admin/
-│           ├── AuctionTab.jsx
-│           ├── BracketAdminTab.jsx
-│           ├── ParticipantsTab.jsx
-│           ├── PayoutsTab.jsx
-│           ├── SettingsTab.jsx
-│           ├── TeamsTab.jsx
-│           └── TournamentsTab.jsx
-│
-├── .env                  # Not in git — contains ADMIN_PASSWORD, ANTHROPIC_API_KEY
-├── railway.toml
-└── package.json          # Root: runs `concurrently` for dev, `node server/index.js` for prod
-```
-
----
-
-## Database Schema
-
-The database lives at `server/calcutta.db`. All schema creation and migrations are in `server/db.js` inside the `init()` function.
-
-### Key tables
-
-**`tournaments`** — one row per tournament (app supports multiple, only one is "active" at a time)
-```
-id, name, invite_code,
-auction_timer_seconds (default 30),
-auction_grace_seconds (default 15),
-auction_status         ('waiting' | 'open' | 'paused'),
-tournament_started     (0 | 1),
-auction_order          ('random' | 'seed_asc' | 'seed_desc' | 'region'),
-auction_auto_advance   (0 | 1),
-ai_commentary_enabled  (0 | 1, default 1),
-ai_commentary_end_of_round (0 | 1, default 1),
-auction_scheduled_start (unix ms | NULL),
-created_at, archived_at
-```
-
-**`settings`** — global key/value store. Only one meaningful row: `active_tournament_id`.
-
-**`participants`** — global across all tournaments
-```
-id, name, color (hex), is_admin (0|1), session_token, created_at
-```
-
-**`tournament_participants`** — junction: which participants are in which tournament
-```
-tournament_id, participant_id, joined_at
-```
-
-**`teams`** — scoped to tournament_id
-```
-id, name, seed, region ('East'|'West'|'South'|'Midwest'), eliminated (0|1),
-espn_id, color, tournament_id
-```
-
-**`auction_items`** — one per team per tournament
-```
-id, team_id, tournament_id,
-status ('pending' | 'active' | 'sold'),
-current_price, current_leader_id, bid_end_time (unix ms),
-final_price, winner_id, queue_order
-```
-
-**`bids`** — full bid history
-```
-id, team_id, participant_id, amount, tournament_id, created_at
-```
-
-**`ownership`** — final sale records; UNIQUE(tournament_id, team_id)
-```
-id, tournament_id, team_id, participant_id, purchase_price
-```
-
-**`games`** — bracket matchups and results
-```
-id, round (1-6), region, position, team1_id, team2_id, winner_id,
-tipoff_at, tv_network, played_at, tournament_id
-```
-
-**`payout_config`** — per round per tournament; UNIQUE(tournament_id, round_number)
-```
-id, tournament_id, round_number (1-6), round_name, amount, payout_type ('fixed'|'percent')
-```
-
-**`earnings`** — computed per game win (recalculated on demand)
-```
-id, participant_id, team_id, game_id, round_number, amount, tournament_id
-```
-
-### Adding new tournament settings
-
-All tournament-scoped settings live as **columns on the `tournaments` table**, not in `settings`.
-
-To add a new setting:
-1. Add the column name to `TOURNAMENT_SETTING_KEYS` array in `db.js`
-2. Add a migration in `init()` using `columnExists()` guard:
-   ```js
-   if (!columnExists('tournaments', 'my_new_setting')) {
-     db.exec('ALTER TABLE tournaments ADD COLUMN my_new_setting INTEGER NOT NULL DEFAULT 0');
-   }
-   ```
-3. Add the column to the `INSERT` in `createTournament()`
-4. Add the key to the `allowed` array in `PATCH /api/admin/settings` in `routes/admin.js`
-5. Add UI to `client/src/pages/admin/SettingsTab.jsx`
-
-`getTournamentSetting(tid, key)` and `setTournamentSetting(tid, key, val)` always cast to/from String.
-
----
-
-## Authentication
-
-- Cookie-based: `session` httpOnly cookie containing a UUID token
-- `getParticipantByToken(token)` looks up participant by that token
-- Admin login: `POST /api/auth/admin` with `ADMIN_PASSWORD` env var (default: `admin123`)
-- Participant join: `POST /api/auth/join` with name + invite code
-- `requireAuth` middleware: checks cookie, attaches `req.participant`
-- `requireAdmin` middleware: checks `req.participant.is_admin === 1`
-- Socket.io auth: same token passed via `socket.handshake.auth.token` or cookie
-
----
-
-## API Routes
-
-All routes are prefixed with `/api`.
-
-| Method | Path | Auth | Description |
-|---|---|---|---|
-| GET | `/auth/me` | none | Check current session |
-| POST | `/auth/join` | none | Join with name + invite code |
-| POST | `/auth/admin` | none | Admin login with password |
-| POST | `/auth/logout` | none | Clear session cookie |
-| GET | `/auction` | auth | Current auction state + queue |
-| GET | `/auction/items` | auth | Full auction item list |
-| GET | `/bracket` | auth | Games + payout config |
-| POST | `/bracket/result` | admin | Set a game winner |
-| POST | `/bracket/unset` | admin | Remove a game result |
-| GET | `/standings` | auth | Full leaderboard |
-| GET | `/standings/ownership` | auth | Team ownership list |
-| GET | `/standings/participant/:id` | auth | Participant teams + spend/earn + game metadata |
-| GET | `/admin/settings` | admin | All tournament settings |
-| PATCH | `/admin/settings` | admin | Update settings |
-| POST | `/admin/invite-code/regenerate` | admin | New invite code |
-| GET | `/admin/participants` | admin | List participants |
-| DELETE | `/admin/participants/:id` | admin | Remove participant |
-| GET | `/admin/payouts` | admin | Payout config |
-| PATCH | `/admin/payouts` | admin | Update payouts |
-| POST | `/admin/payouts/recalc` | admin | Recalculate earnings |
-| GET | `/admin/auction/queue` | admin | Queue with full details |
-| PATCH | `/admin/auction/queue` | admin | Reorder pending items |
-| POST | `/admin/auction/start` | admin | Open auction |
-| POST | `/admin/auction/pause` | admin | Pause auction |
-| POST | `/admin/auction/next` | admin | Start next team (or specific teamId) |
-| POST | `/admin/auction/close` | admin | Close current auction item |
-| POST | `/admin/bracket/initialize` | admin | Create round 1 matchups |
-| POST | `/admin/bracket/reset` | admin | Wipe bracket + earnings |
-| POST | `/admin/teams/import` | admin | Import 64 teams |
-| POST | `/admin/testing/load-fixture` | admin | Seed fixture participants and mark N teams sold |
-| POST | `/admin/testing/clear-fixture` | admin | Remove fixture participants and reset tournament state |
-| GET | `/admin/export/csv` | admin | Download results CSV |
-| GET | `/tournaments` | admin | List all tournaments |
-| POST | `/tournaments` | admin | Create new tournament |
-| POST | `/tournaments/:id/activate` | admin | Switch active tournament |
-
----
-
-## Socket.io Events
-
-### Server → Client (emitted via `io.emit`)
-
-| Event | Payload | When |
-|---|---|---|
-| `auction:state` | `{ active, recentBids, auctionStatus, scheduledStart }` | On connect |
-| `auction:started` | `{ itemId, teamId, endTime }` | New team up for bid |
-| `auction:update` | `{ itemId, teamId, currentPrice, leaderId, leaderName, leaderColor, endTime, recentBids }` | New bid placed |
-| `auction:sold` | `{ itemId, teamId, teamName, winnerId, winnerName, winnerColor, finalPrice, aiCommentaryEnabled }` | Timer expired with bids |
-| `auction:nobids` | `{ itemId }` | Timer expired with no bids |
-| `auction:complete` | — | All teams sold |
-| `auction:status` | `{ status }` | Auction opened/paused |
-| `auction:scheduled_start` | `{ ts }` | Schedule set or cleared |
-| `auction:commentary:chunk` | `{ token }` | AI sale commentary chunk (rendered inside sold banner) |
-| `auction:commentary:done` | `{ text }` | AI sale commentary complete |
-| `bracket:update` | `{ gameId, winnerId, loserId }` | Game result entered |
-| `bracket:initialized` | — | Bracket created |
-| `bracket:reset` | — | Bracket wiped |
-| `bracket:recap:chunk` | `{ token }` | AI round recap chunk |
-| `bracket:recap:done` | `{ text }` | AI round recap complete |
-| `standings:update` | — | Earnings/payouts changed |
-| `teams:imported` | — | Teams imported |
-
-### Client → Server
-
-| Event | Payload | Description |
-|---|---|---|
-| `auction:bid` | `{ amount }` | Place a bid |
-
----
-
-## Auction Flow Logic (`server/services/auctionService.js`)
-
-- Auction business logic is centralized in `auctionService` and reused by both:
-  - admin routes (`/api/admin/auction/next`, `/api/admin/auction/close`)
-  - Socket.io `auction:bid` handling
-- Core methods: `startAuction`, `closeAuction`, `closeActiveAuction`, `placeBid`, `restoreTimerOnStartup`
-- Timer behavior:
-  - one active timer at a time
-  - on bid, timer extends by grace period (`Math.max(now + graceSeconds, currentEndTime)`)
-  - auto-advance starts next item after sale when enabled
-- `server/socket.js` now primarily handles auth and delegates domain logic to the service.
-
----
-
-## AI Integration (`server/ai.js`)
-
-Uses `@anthropic-ai/sdk`. Requires `ANTHROPIC_API_KEY` env var. If absent, AI features are silently skipped.
-
-Two core functions:
-
-**`generateAuctionCommentary(data, io)`** — called after each team sells. Emits `auction:commentary:chunk` + `auction:commentary:done`. Gated by `ai_commentary_enabled` in auction service.
-- Client behavior: `Auction.jsx` shows this commentary inside the sold banner (with a loading spinner while streaming) and keeps the sold banner visible until the next `auction:started`.
-
-**`streamRoundRecap(data, io)`** — called at end-of-round (not each game). Emits `bracket:recap:chunk` + `bracket:recap:done`. Gated by `ai_commentary_end_of_round`.
-- Recap payload now includes per-team summaries for that completed round (advanced/eliminated, owner, purchase price, round earnings).
-
-Model used: `claude-sonnet-4-5-20250929`
-
----
-
-## Client Patterns
-
-### API calls
-All API calls go through `api()` from `utils.js`:
-```js
-import { api } from '../../utils';
-const r = await api('/admin/settings');        // GET
-await api('/admin/settings', { method: 'PATCH', body: JSON.stringify({...}) });
-```
-This wraps `fetch('/api' + path, { credentials: 'include', ... })`.
-
-### Invite links
-- Admin Settings exposes both raw invite code and a shareable URL:
-  - `https://<host>/join?invite=CODE`
-- `Join.jsx` reads `invite` query param, uppercases/truncates it, and pre-fills participant join form.
-
-### Dollar formatting
-Always use `fmt(n)` from `utils.js` for display. Shows no cents for whole numbers.
-
-### Contexts
-- `useAuth()` — `{ participant, join, adminLogin, logout }`
-- `useSocket()` — the raw socket.io client instance
-- `useTournament()` — tournament metadata (name, status, etc.)
-
-### Tailwind custom classes
-Defined in `client/src/index.css`. Key classes:
-- `btn-primary`, `btn-secondary`, `btn-danger` — buttons
-- `skeleton` — loading placeholder
-- `text-status-success`, `text-status-error` — status colors
-
-There are also semantic color tokens (`bg-surface-base`, `text-text-primary`, etc.) that are referenced in newer code. Some may not yet be fully wired into `tailwind.config.js` — check before using.
-
-### Toggle switches (admin settings pattern)
-Settings stored as `'0'` or `'1'` strings. The canonical toggle pattern:
-```jsx
-<button
-  role="switch"
-  aria-checked={settings.some_setting !== '0'}
-  onClick={() => setSettings(s => ({
-    ...s,
-    some_setting: s.some_setting === '0' ? '1' : '0'
-  }))}
-  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors shrink-0 ml-4 ${
-    settings.some_setting !== '0' ? 'bg-orange-500' : 'bg-slate-600'
-  }`}
->
-  <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
-    settings.some_setting !== '0' ? 'translate-x-6' : 'translate-x-1'
-  }`} />
-</button>
-```
-
----
-
-## Tournament Lifecycle
-
-1. **Setup** — Admin creates tournament (or uses default id=1), sets invite code, and can share `/join?invite=CODE` link
-2. **Waiting** — `auction_status = 'waiting'`. Players join with invite code
-3. **Import** — Admin imports 64 teams via TeamsTab (uses `TEAMS_2025` data or custom)
-4. **Auction** — Admin opens auction (`auction_status = 'open'`), starts teams one at a time
-5. **Bracket** — After all teams sold, admin initializes bracket (creates Round 1 games)
-6. **Play** — Admin enters game results; earnings auto-calculated; AI recaps fire
-7. **Complete** — All 63 games played; standings finalized; CSV export available
-
-Bracket UX note:
-- `client/src/pages/Bracket.jsx` has two views:
-  - desktop board-style bracket (fit-to-width, no horizontal page scroll)
-  - compact fallback for smaller screens
-- game metadata (`tipoff_at`, `tv_network`) is shown on:
-  - bracket cards (`Bracket.jsx`)
-  - my teams cards (`MyTeams.jsx`, next/last game)
-  - admin bracket game rows (`admin/BracketAdminTab.jsx`)
-
----
-
-## Environment Variables
-
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `ADMIN_PASSWORD` | no | `admin123` | Admin login password |
-| `ANTHROPIC_API_KEY` | no | — | Enables AI commentary features |
-| `PORT` | no | `3001` | Server port |
-| `NODE_ENV` | no | — | Set to `production` to serve static build |
-| `DB_PATH` | no | `server/calcutta.db` | SQLite file path |
-| `CLIENT_ORIGIN` | no | `http://localhost:5173` | CORS origin for dev |
-
-`.env` is loaded from the **project root** (not `server/`) via:
-```js
-require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') })
-```
-
----
-
-## Dev Setup
-
-```bash
-npm install                    # root
-cd server && npm install && cd ..
-cd client && npm install && cd ..
-# Create .env at project root with ADMIN_PASSWORD and optionally ANTHROPIC_API_KEY
-npm run dev                    # starts both server (3001) and client (5173) via concurrently
-```
-
-Client proxies `/api` and `/socket.io` to `localhost:3001` (configured in `client/vite.config.js`).
-
----
-
-## Known Gotchas
-
-- **Settings are strings** — `getTournamentSetting` always returns a string or null. Compare with `=== '0'`, `=== '1'`, not booleans.
-- **Participants are global** — A participant who joins tournament 1 and then joins tournament 2 with the same name gets the same DB record. Their session token is reused.
-- **Admin is not scoped to a tournament** — There is one admin account (`is_admin = 1`). It automatically joins every tournament.
-- **Bracket round 5 = Final Four, round 6 = Championship** — regions for rounds 5-6 are `'Final Four'` and `'Championship'` strings (not the regional names).
-- **`recalcEarnings` is idempotent** — it deletes all earnings for a tournament and reinserts. Safe to call multiple times.
-- **2025 schedule metadata is explicit; future years are not** — `gameSchedule2025.js` backfills date/time/network by bracket slot. New-year imports (for example 2026) need a new schedule map or games will show blank metadata.
-- **Fixture tools are destructive for active tournament state** — `load-fixture` and `clear-fixture` reset auction/bracket/earnings and remove non-admin participants from the active tournament.
-- **Sold banner behavior is intentional** — it persists after a sale and clears when the next team starts (`auction:started`), not on a timer.
-
----
-
-## Refactor Backlog (Captured 2026-03-03)
-
-Status update:
-- Completed: auction start/close/bid logic consolidated into `server/services/auctionService.js`, with focused server tests in `server/tests/auctionService.test.js`.
-
-Remaining refactor TODOs:
-1. Split `server/db.js` into focused modules:
-   - migrations (`init` + column/table upgrades),
-   - repositories (query/read-write functions),
-   - domain services (payout/earnings/bracket helpers).
-2. Refactor `GET /api/standings/participant/:id` query to remove many correlated subqueries and replace with CTE/join-based query blocks for readability and performance.
-3. Move complex auction UI state in `client/src/pages/Auction.jsx` to a reducer/custom hook (`useAuctionRealtime`) so socket event transitions are centralized and easier to test.
-4. Componentize repeated admin settings UI patterns in `client/src/pages/admin/SettingsTab.jsx`:
-   - reusable toggle row component,
-   - reusable async action/message helper hook.
-5. Add request and socket payload validation (for example with Zod) for admin, bracket, auth, and auction socket inputs with a consistent error response format.
-6. Expand automated tests beyond auction service:
-   - bracket advance/unset behavior,
-   - round recap trigger timing,
-   - fixture load/clear behavior,
-   - game schedule metadata assignment/backfill behavior.
+# NCAA App - Developer Handoff
+
+This document is specific to the NCAA app under `apps/ncaa`.
+
+## Scope
+
+- Product: March Madness Calcutta
+- Paths: `apps/ncaa/server`, `apps/ncaa/client`
+- Deployment target: NCAA Railway service
+
+Important: NCAA styling is intentionally frozen except explicit NCAA UI work. See root style-freeze guard.
+
+## Tech stack
+
+- Server: Node.js, Express, Socket.io, better-sqlite3
+- Client: React (Vite), Tailwind CSS
+- AI: Anthropic SDK (auction/round commentary)
+- DB: SQLite (`DB_PATH`), default `apps/ncaa/server/calcutta.db`
+
+## Repository layout (NCAA app)
+
+- `server/index.js`: Express + Socket.io entrypoint
+- `server/db.js`: schema, migrations, query helpers
+- `server/services/auctionService.js`: auction lifecycle logic
+- `server/routes/*`: auth/admin/auction/bracket/standings/tournaments/export
+- `server/data/teams2025.js`, `server/data/gameSchedule2025.js`: seeded NCAA data
+- `server/tests/auctionService.test.js`: auction integration tests
+- `client/src/pages/*`: Join/Auction/Bracket/Standings/MyTeams/Admin
+- `client/src/pages/admin/*`: admin tabs
+
+## Core behavior
+
+- Live ascending auction for teams
+- Bracket initialization and game result advancement
+- Round-based payouts and standings recalculation
+- Tournament switching for historical views
+
+## Development commands
+
+From repo root:
+
+- `npm run dev:ncaa`
+- `npm run test:ncaa`
+- `npm run build:ncaa`
+
+From app root (`apps/ncaa`):
+
+- `npm run dev`
+- `npm run build`
+
+## Deployment notes
+
+- Preferred DB env: `DB_PATH=/data/calcutta.db`
+- Health endpoint: `/api/health`
+- Railway config files:
+  - root fallback: `/railway.toml`
+  - app-local: `apps/ncaa/railway.toml`
+
+## Monorepo boundary
+
+Do not import runtime NCAA code from `apps/f1`.
+
+If a change is NCAA-only, avoid edits to:
+
+- `apps/f1/**`
+- `packages/core/**` (unless truly shared and required)


### PR DESCRIPTION
## Summary
- split repository into monorepo structure with separate `apps/ncaa` and `apps/f1` apps
- preserved NCAA behavior/styling and added NCAA style-freeze CI guard
- implemented dedicated F1 backend/domain (auction, event scoring, sync endpoints, standings, season bonuses)
- built dedicated F1 frontend with telemetry-dark race vibe UI
- added root and app-level Railway TOML configs for NCAA and F1 services
- fixed F1 deploy/runtime issues (lockfiles + self-contained server imports for subdirectory deploy)
- updated handoff docs with split architecture and operator runbook

## Validation
- `npm run test`
- `npm run build`
- `npm run check:ncaa-style-freeze`
- local Railway-equivalent F1 install/test/build flow

## Notes
- F1 Railway service should use `apps/f1/railway.toml` and bind to Railway `PORT`
- NCAA continues to deploy from root `railway.toml`
