### PR TITLE
Split F1 Admin into routed shell with secondary navigation

### DIFF
--- a/apps/f1/client/src/App.jsx
+++ b/apps/f1/client/src/App.jsx
@@ -9,6 +9,10 @@ import Events from './pages/Events';
 import Standings from './pages/Standings';
 import MyDrivers from './pages/MyDrivers';
 import Admin from './pages/Admin';
+import OverviewPage from './pages/admin/OverviewPage';
+import AuctionPage from './pages/admin/AuctionPage';
+import ResultsPage from './pages/admin/ResultsPage';
+import PayoutRulesPage from './pages/admin/PayoutRulesPage';
 
 function ProtectedRoute({ children, adminOnly = false }) {
   const { participant } = useAuth();
@@ -40,7 +44,14 @@ function AppRoutes() {
           <Route path="/events" element={<ProtectedRoute><Events /></ProtectedRoute>} />
           <Route path="/standings" element={<ProtectedRoute><Standings /></ProtectedRoute>} />
           <Route path="/my-drivers" element={<ProtectedRoute><MyDrivers /></ProtectedRoute>} />
-          <Route path="/admin" element={<ProtectedRoute adminOnly><Admin /></ProtectedRoute>} />
+          <Route path="/admin" element={<ProtectedRoute adminOnly><Admin /></ProtectedRoute>}>
+            <Route index element={<Navigate to="overview" replace />} />
+            <Route path="overview" element={<OverviewPage />} />
+            <Route path="auction" element={<AuctionPage />} />
+            <Route path="results" element={<ResultsPage />} />
+            <Route path="payouts" element={<PayoutRulesPage />} />
+            <Route path="*" element={<Navigate to="overview" replace />} />
+          </Route>
           <Route path="*" element={<Navigate to="/auction" replace />} />
         </Routes>
       </main>

--- a/apps/f1/client/src/components/Nav.jsx
+++ b/apps/f1/client/src/components/Nav.jsx
@@ -17,6 +17,11 @@ export default function Nav() {
     ? [...BASE_LINKS, { to: '/admin', label: 'Admin' }]
     : BASE_LINKS;
 
+  const isLinkActive = (to) => {
+    if (to === '/admin') return location.pathname === '/admin' || location.pathname.startsWith('/admin/');
+    return location.pathname === to;
+  };
+
   return (
     <header className="top-nav">
       <div className="top-nav-inner">
@@ -25,7 +30,7 @@ export default function Nav() {
           {links.map((link) => (
             <Link
               key={link.to}
-              className={`nav-link ${location.pathname === link.to ? 'active' : ''}`}
+              className={`nav-link ${isLinkActive(link.to) ? 'active' : ''}`}
               to={link.to}
             >
               {link.label}

--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -198,6 +198,229 @@ button {
   margin-bottom: 0.5rem;
 }
 
+.join-landing {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 420px);
+  gap: 1rem;
+  min-height: clamp(460px, 66vh, 700px);
+  padding: 1rem;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  background: linear-gradient(145deg, rgba(8, 11, 16, 0.86), rgba(13, 17, 24, 0.95));
+}
+
+.join-bg-graphic {
+  position: absolute;
+  inset: -5% 32% -3% -16%;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.92;
+}
+
+.join-bg-graphic::before {
+  content: '';
+  position: absolute;
+  inset: 8% -5% 20% 10%;
+  background: radial-gradient(ellipse at center, rgba(225, 6, 0, 0.28), transparent 70%);
+  filter: blur(10px);
+}
+
+.join-bg-graphic svg {
+  width: 100%;
+  height: 100%;
+}
+
+.track-line {
+  animation: trackDrift 7s ease-in-out infinite alternate;
+}
+
+.track-line-alt {
+  animation: trackDrift 9s ease-in-out infinite alternate-reverse;
+}
+
+.join-car {
+  transform-origin: 475px 390px;
+  animation: carGlide 4.2s ease-in-out infinite;
+}
+
+.join-hero {
+  position: relative;
+  z-index: 1;
+  min-height: 100%;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.9rem;
+}
+
+.join-hero p {
+  margin: 0;
+  max-width: 40ch;
+  color: #c3cdda;
+}
+
+.join-hero-cards {
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(3, minmax(120px, 1fr));
+}
+
+.join-hero-cards > div {
+  padding: 0.62rem 0.7rem;
+  border-radius: 11px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(9, 13, 20, 0.55);
+}
+
+.join-hero-cards .value {
+  font-size: 1.05rem;
+}
+
+.join-auth-panel {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 420px);
+  align-self: center;
+  padding: 1rem;
+  border-color: rgba(225, 6, 0, 0.26);
+  background:
+    linear-gradient(145deg, rgba(225, 6, 0, 0.08), transparent 42%),
+    rgba(16, 22, 32, 0.96);
+}
+
+.join-toggle {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.3rem;
+  margin-bottom: 0.95rem;
+  padding: 0.3rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(9, 13, 20, 0.75);
+}
+
+.join-toggle-btn {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.47rem 0.8rem;
+  background: transparent;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: color 160ms ease, background 160ms ease;
+}
+
+.join-toggle-btn:hover {
+  color: var(--text);
+}
+
+.join-toggle-btn.active {
+  background: linear-gradient(135deg, #d90404, #a70303);
+  color: #fff;
+}
+
+.join-mode-copy {
+  margin: -0.05rem 0 0.4rem;
+}
+
+.join-auth-panel .error-text {
+  margin-top: 0.7rem;
+}
+
+.admin-header p {
+  margin: 0.5rem 0 0;
+  max-width: 56ch;
+  color: #c3cdda;
+}
+
+.admin-layout {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+  align-items: start;
+}
+
+.admin-sidebar {
+  position: sticky;
+  top: 5rem;
+  padding: 0.75rem;
+}
+
+.admin-main {
+  min-width: 0;
+}
+
+.admin-secondary-nav {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.admin-nav-link {
+  display: grid;
+  gap: 0.18rem;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 0.62rem 0.72rem;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.02);
+  transition: border-color 150ms ease, color 150ms ease, background 150ms ease;
+}
+
+.admin-nav-link:hover {
+  color: var(--text);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.admin-nav-link.active {
+  color: #fff;
+  border-color: rgba(225, 6, 0, 0.55);
+  background: rgba(225, 6, 0, 0.16);
+}
+
+.admin-nav-label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.admin-nav-desc {
+  font-size: 0.76rem;
+  color: #acb5c2;
+}
+
+.admin-nav-link.active .admin-nav-desc {
+  color: #ffd7d7;
+}
+
+.admin-secondary-nav-mobile {
+  display: none;
+}
+
+.admin-nav-pill {
+  white-space: nowrap;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  padding: 0.45rem 0.8rem;
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: rgba(10, 14, 20, 0.6);
+}
+
+.admin-nav-pill.active {
+  color: #fff;
+  border-color: rgba(225, 6, 0, 0.65);
+  background: rgba(225, 6, 0, 0.2);
+}
+
 .join-grid {
   display: grid;
   gap: 1rem;
@@ -629,6 +852,63 @@ tbody tr:hover {
 @keyframes pulseLive {
   0%, 100% { box-shadow: 0 14px 40px rgba(2, 4, 8, 0.35); }
   50% { box-shadow: 0 16px 44px rgba(225, 6, 0, 0.22); }
+}
+
+@keyframes trackDrift {
+  from { transform: translateX(-14px); }
+  to { transform: translateX(14px); }
+}
+
+@keyframes carGlide {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+@media (max-width: 980px) {
+  .join-landing {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .join-bg-graphic {
+    inset: 0;
+    opacity: 0.4;
+  }
+
+  .join-hero {
+    min-height: 280px;
+  }
+
+  .join-auth-panel {
+    width: min(100%, 560px);
+    justify-self: center;
+  }
+
+  .admin-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-sidebar {
+    display: none;
+  }
+
+  .admin-secondary-nav-mobile {
+    display: flex;
+    gap: 0.5rem;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .join-hero {
+    min-height: 250px;
+    padding: 1rem;
+  }
+
+  .join-hero-cards {
+    grid-template-columns: repeat(2, minmax(120px, 1fr));
+  }
 }
 
 @media (max-width: 760px) {

--- a/apps/f1/client/src/pages/Admin.jsx
+++ b/apps/f1/client/src/pages/Admin.jsx
@@ -1,5 +1,20 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { api, categoryLabel, fmtCents } from '../utils';
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
+import { NavLink, Outlet } from 'react-router-dom';
+import { api } from '../utils';
+
+const ADMIN_SECTIONS = [
+  { path: 'overview', label: 'Overview', description: 'Season status and pool summary' },
+  { path: 'auction', label: 'Auction', description: 'Controls and timing settings' },
+  { path: 'results', label: 'Results Sync', description: 'Sync event outcomes and payouts' },
+  { path: 'payouts', label: 'Payout Rules', description: 'Adjust basis-point distribution' },
+];
+
+async function readApi(path) {
+  const response = await api(path);
+  const data = await response.json();
+  if (!response.ok) throw new Error(data.error || 'Request failed');
+  return data;
+}
 
 export default function Admin() {
   const [settings, setSettings] = useState(null);
@@ -7,29 +22,40 @@ export default function Admin() {
   const [events, setEvents] = useState([]);
   const [rules, setRules] = useState(null);
   const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [hasLoaded, setHasLoaded] = useState(false);
 
-  const loadAll = useCallback(async () => {
-    const [s, p, e, r] = await Promise.all([
-      api('/admin/settings').then((res) => res.json()),
-      api('/admin/participants').then((res) => res.json()),
-      api('/events').then((res) => res.json()),
-      api('/admin/payout-rules').then((res) => res.json()),
-    ]);
-    setSettings(s);
-    setParticipants(p);
-    setEvents(e);
-    setRules(r);
+  const loadAll = useCallback(async ({ silent = false } = {}) => {
+    if (!silent) setLoading(true);
+    try {
+      const [s, p, e, r] = await Promise.all([
+        readApi('/admin/settings'),
+        readApi('/admin/participants'),
+        readApi('/events'),
+        readApi('/admin/payout-rules'),
+      ]);
+      setSettings(s);
+      setParticipants(Array.isArray(p) ? p : []);
+      setEvents(Array.isArray(e) ? e : []);
+      setRules(r);
+      setHasLoaded(true);
+    } catch (error) {
+      setMessage(error.message || 'Failed to load admin data.');
+    } finally {
+      if (!silent) setLoading(false);
+    }
   }, []);
 
   useEffect(() => {
-    loadAll().catch((e) => setMessage(e.message));
+    loadAll();
   }, [loadAll]);
 
-  const setField = (field, value) => {
-    setSettings((prev) => ({ ...prev, [field]: value }));
-  };
+  const setField = useCallback((field, value) => {
+    setSettings((prev) => ({ ...(prev || {}), [field]: value }));
+  }, []);
 
-  const saveSettings = async () => {
+  const saveSettings = useCallback(async () => {
+    if (!settings) return;
     try {
       const response = await api('/admin/settings', {
         method: 'PATCH',
@@ -42,63 +68,66 @@ export default function Admin() {
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || 'Failed to save settings');
       setMessage('Settings saved.');
-      loadAll().catch(() => {});
+      loadAll({ silent: true });
     } catch (error) {
       setMessage(error.message || 'Failed to save settings.');
     }
-  };
+  }, [loadAll, settings]);
 
-  const runAuctionAction = async (endpoint) => {
+  const runAuctionAction = useCallback(async (endpoint) => {
     try {
       const response = await api(endpoint, { method: 'POST', body: '{}' });
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || 'Action failed');
       setMessage('Auction action applied.');
-      loadAll().catch(() => {});
+      loadAll({ silent: true });
     } catch (error) {
       setMessage(error.message || 'Auction action failed.');
     }
-  };
+  }, [loadAll]);
 
-  const syncNext = async () => {
+  const syncNext = useCallback(async () => {
     try {
       const response = await api('/admin/results/sync-next', { method: 'POST', body: '{}' });
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || 'Sync failed');
       setMessage('Synced next event.');
-      loadAll().catch(() => {});
+      loadAll({ silent: true });
     } catch (error) {
       setMessage(error.message || 'Sync failed.');
     }
-  };
+  }, [loadAll]);
 
-  const syncEvent = async (eventId) => {
+  const syncEvent = useCallback(async (eventId) => {
     try {
       const response = await api(`/admin/results/sync-event/${eventId}`, { method: 'POST', body: '{}' });
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || 'Sync failed');
       setMessage('Event synced.');
-      loadAll().catch(() => {});
+      loadAll({ silent: true });
     } catch (error) {
       setMessage(error.message || 'Event sync failed.');
     }
-  };
+  }, [loadAll]);
 
-  const updateRules = (group, id, field, value) => {
-    setRules((prev) => ({
-      ...prev,
-      [group]: prev[group].map((rule) => (rule.id === id ? { ...rule, [field]: value } : rule)),
-    }));
-  };
+  const updateRules = useCallback((group, id, field, value) => {
+    setRules((prev) => {
+      if (!prev?.[group]) return prev;
+      return {
+        ...prev,
+        [group]: prev[group].map((rule) => (rule.id === id ? { ...rule, [field]: value } : rule)),
+      };
+    });
+  }, []);
 
-  const saveRules = async () => {
+  const saveRules = useCallback(async () => {
+    if (!rules) return;
     try {
       const payload = {
-        grand_prix: rules.grand_prix.map((r) => ({ ...r, bps: Number(r.bps) || 0 })),
-        sprint: rules.sprint.map((r) => ({ ...r, bps: Number(r.bps) || 0 })),
-        season_bonus: rules.season_bonus.map((r) => ({ ...r, bps: Number(r.bps) || 0 })),
+        grand_prix: (rules.grand_prix || []).map((r) => ({ ...r, bps: Number(r.bps) || 0 })),
+        sprint: (rules.sprint || []).map((r) => ({ ...r, bps: Number(r.bps) || 0 })),
+        season_bonus: (rules.season_bonus || []).map((r) => ({ ...r, bps: Number(r.bps) || 0 })),
       };
-
       const response = await api('/admin/payout-rules', {
         method: 'PATCH',
         body: JSON.stringify(payload),
@@ -106,161 +135,88 @@ export default function Admin() {
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || 'Failed to save rules');
       setMessage('Payout rules saved and standings recalculated.');
-      loadAll().catch(() => {});
+      loadAll({ silent: true });
     } catch (error) {
       setMessage(error.message || 'Failed to save payout rules.');
     }
-  };
+  }, [loadAll, rules]);
 
-  const gpTotal = useMemo(() => (rules?.grand_prix || []).reduce((sum, rule) => sum + Number(rule.bps || 0), 0), [rules]);
-  const sprintTotal = useMemo(() => (rules?.sprint || []).reduce((sum, rule) => sum + Number(rule.bps || 0), 0), [rules]);
-  const bonusTotal = useMemo(() => (rules?.season_bonus || []).reduce((sum, rule) => sum + Number(rule.bps || 0), 0), [rules]);
+  const contextValue = useMemo(() => ({
+    settings,
+    participants,
+    events,
+    rules,
+    message,
+    loading,
+    hasLoaded,
+    refresh: () => loadAll(),
+    setField,
+    setMessage,
+    saveSettings,
+    runAuctionAction,
+    syncNext,
+    syncEvent,
+    updateRules,
+    saveRules,
+  }), [
+    settings,
+    participants,
+    events,
+    rules,
+    message,
+    loading,
+    hasLoaded,
+    loadAll,
+    setField,
+    saveSettings,
+    runAuctionAction,
+    syncNext,
+    syncEvent,
+    updateRules,
+    saveRules,
+  ]);
 
   return (
     <div className="stack-lg">
-      <section className="panel telemetry-strip">
-        <div className="strip-item">
-          <span className="label">Invite Code</span>
-          <strong>{settings?.invite_code}</strong>
-        </div>
-        <div className="strip-item">
-          <span className="label">Auction Status</span>
-          <strong className={`status-text status-${settings?.auction_status}`}>{settings?.auction_status}</strong>
-        </div>
-        <div className="strip-item">
-          <span className="label">Participants</span>
-          <strong>{participants.length}</strong>
-        </div>
+      <section className="panel panel-hero admin-header">
+        <div className="hero-kicker">Race Control</div>
+        <h1>Admin Console</h1>
+        <p>Use sectioned controls to run the auction, sync races, and tune payout models.</p>
       </section>
 
       {message ? <section className="panel note-panel">{message}</section> : null}
 
-      <section className="panel stack">
-        <h2>Auction Controls</h2>
-        <div className="row wrap gap-sm">
-          <button className="btn" onClick={() => runAuctionAction('/admin/auction/start')}>Open</button>
-          <button className="btn btn-outline" onClick={() => runAuctionAction('/admin/auction/pause')}>Pause</button>
-          <button className="btn btn-outline" onClick={() => runAuctionAction('/admin/auction/next')}>Start Next Driver</button>
-          <button className="btn btn-outline" onClick={() => runAuctionAction('/admin/auction/close')}>Close Active</button>
-        </div>
-      </section>
+      <div className="admin-layout">
+        <aside className="panel admin-sidebar">
+          <nav className="admin-secondary-nav" aria-label="Admin sections">
+            {ADMIN_SECTIONS.map((section) => (
+              <NavLink
+                key={section.path}
+                to={section.path}
+                className={({ isActive }) => `admin-nav-link ${isActive ? 'active' : ''}`}
+              >
+                <span className="admin-nav-label">{section.label}</span>
+                <span className="admin-nav-desc">{section.description}</span>
+              </NavLink>
+            ))}
+          </nav>
+        </aside>
 
-      <section className="panel stack">
-        <h2>Auction Settings</h2>
-        <div className="grid-3">
-          <label>
-            Timer (sec)
-            <input
-              value={settings?.auction_timer_seconds ?? ''}
-              onChange={(e) => setField('auction_timer_seconds', e.target.value)}
-            />
-          </label>
-          <label>
-            Grace (sec)
-            <input
-              value={settings?.auction_grace_seconds ?? ''}
-              onChange={(e) => setField('auction_grace_seconds', e.target.value)}
-            />
-          </label>
-          <label className="checkbox-row">
-            <input
-              type="checkbox"
-              checked={String(settings?.auction_auto_advance) === '1' || settings?.auction_auto_advance === 1 || settings?.auction_auto_advance === true}
-              onChange={(e) => setField('auction_auto_advance', e.target.checked ? 1 : 0)}
-            />
-            Auto Advance
-          </label>
-        </div>
-        <button className="btn" onClick={saveSettings}>Save Settings</button>
-      </section>
-
-      <section className="panel stack">
-        <div className="row between">
-          <h2>Results Sync</h2>
-          <button className="btn" onClick={syncNext}>Sync Next Event</button>
-        </div>
-        <ul className="list">
-          {events.map((event) => (
-            <li key={event.id}>
-              <div>
-                <strong>R{event.round_number}</strong> {event.name}
-                <div className="muted small">{event.type} • {event.status} • payout {fmtCents(event.total_payout_cents || 0)}</div>
-              </div>
-              <button className="btn btn-outline" onClick={() => syncEvent(event.id)}>Sync</button>
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <section className="panel stack">
-        <h2>Payout Rules</h2>
-        <p className="muted">1% = 100 bps. GP target 300 bps, Sprint target 100 bps, Season bonus target 10,000 bps.</p>
-
-        {rules ? (
-          <>
-            <h3>Grand Prix ({gpTotal} bps)</h3>
-            <div className="table-wrap">
-              <table>
-                <thead><tr><th>Category</th><th>BPS</th></tr></thead>
-                <tbody>
-                  {rules.grand_prix.map((rule) => (
-                    <tr key={rule.id}>
-                      <td>{categoryLabel(rule.category)}</td>
-                      <td>
-                        <input
-                          value={rule.bps}
-                          onChange={(e) => updateRules('grand_prix', rule.id, 'bps', e.target.value)}
-                        />
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-
-            <h3>Sprint ({sprintTotal} bps)</h3>
-            <div className="table-wrap">
-              <table>
-                <thead><tr><th>Category</th><th>BPS</th></tr></thead>
-                <tbody>
-                  {rules.sprint.map((rule) => (
-                    <tr key={rule.id}>
-                      <td>{categoryLabel(rule.category)}</td>
-                      <td>
-                        <input
-                          value={rule.bps}
-                          onChange={(e) => updateRules('sprint', rule.id, 'bps', e.target.value)}
-                        />
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-
-            <h3>Season Bonuses ({bonusTotal} bps)</h3>
-            <div className="table-wrap">
-              <table>
-                <thead><tr><th>Category</th><th>BPS</th></tr></thead>
-                <tbody>
-                  {rules.season_bonus.map((rule) => (
-                    <tr key={rule.id}>
-                      <td>{categoryLabel(rule.category)}</td>
-                      <td>
-                        <input
-                          value={rule.bps}
-                          onChange={(e) => updateRules('season_bonus', rule.id, 'bps', e.target.value)}
-                        />
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-            <button className="btn" onClick={saveRules}>Save Rules</button>
-          </>
-        ) : null}
-      </section>
+        <section className="admin-main stack-lg">
+          <nav className="admin-secondary-nav-mobile" aria-label="Admin sections">
+            {ADMIN_SECTIONS.map((section) => (
+              <NavLink
+                key={section.path}
+                to={section.path}
+                className={({ isActive }) => `admin-nav-pill ${isActive ? 'active' : ''}`}
+              >
+                {section.label}
+              </NavLink>
+            ))}
+          </nav>
+          <Outlet context={contextValue} />
+        </section>
+      </div>
     </div>
   );
 }

--- a/apps/f1/client/src/pages/Join.jsx
+++ b/apps/f1/client/src/pages/Join.jsx
@@ -3,6 +3,7 @@ import { useAuth } from '../context/AuthContext';
 
 export default function Join() {
   const { join, adminLogin } = useAuth();
+  const [mode, setMode] = useState('join');
   const [name, setName] = useState('');
   const [inviteCode, setInviteCode] = useState('');
   const [password, setPassword] = useState('');
@@ -36,39 +37,142 @@ export default function Join() {
   };
 
   return (
-    <div className="join-grid">
-      <section className="panel panel-hero fade-in">
+    <div className="join-landing fade-in">
+      <div className="join-bg-graphic" aria-hidden="true">
+        <svg viewBox="0 0 1200 700" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <linearGradient id="trackStroke" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stopColor="rgba(255,255,255,0.06)" />
+              <stop offset="50%" stopColor="rgba(225,6,0,0.55)" />
+              <stop offset="100%" stopColor="rgba(255,255,255,0.06)" />
+            </linearGradient>
+            <linearGradient id="carFill" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stopColor="#960000" />
+              <stop offset="55%" stopColor="#e10600" />
+              <stop offset="100%" stopColor="#7a0000" />
+            </linearGradient>
+          </defs>
+          <path
+            className="track-line"
+            d="M-80 530 C 240 435, 390 615, 695 470 S 1230 355, 1330 430"
+            stroke="url(#trackStroke)"
+            strokeWidth="26"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <path
+            className="track-line-alt"
+            d="M-120 600 C 210 500, 420 690, 735 550 S 1230 450, 1370 520"
+            stroke="rgba(255,255,255,0.08)"
+            strokeWidth="10"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <g className="join-car">
+            <path
+              d="M220 338 L318 300 L570 300 L670 338 L800 338 L854 374 L800 410 L670 410 L570 450 L318 450 L220 410 L145 410 L96 374 L145 338 Z"
+              fill="url(#carFill)"
+            />
+            <rect x="394" y="272" width="102" height="29" rx="8" fill="#f6f7fb" opacity="0.8" />
+            <path d="M245 326 L140 357 L140 390 L245 390 Z" fill="#d9dbe3" opacity="0.85" />
+            <rect x="580" y="326" width="124" height="18" rx="8" fill="#0f131a" opacity="0.65" />
+            <circle cx="246" cy="432" r="42" fill="#0e1219" />
+            <circle cx="246" cy="432" r="21" fill="#2f3a4f" />
+            <circle cx="642" cy="432" r="42" fill="#0e1219" />
+            <circle cx="642" cy="432" r="21" fill="#2f3a4f" />
+          </g>
+        </svg>
+      </div>
+
+      <section className="panel panel-hero join-hero">
         <div className="hero-kicker">Telemetry Dark</div>
         <h1>F1 Season Calcutta</h1>
         <p>
           Own drivers, track every race weekend, and cash in on category payouts from the shared pool.
         </p>
+        <div className="join-hero-cards">
+          <div>
+            <span className="label">Format</span>
+            <div className="value">Live Driver Auction</div>
+          </div>
+          <div>
+            <span className="label">Payouts</span>
+            <div className="value">Sprint + Grand Prix</div>
+          </div>
+          <div>
+            <span className="label">Season</span>
+            <div className="value">2026</div>
+          </div>
+        </div>
       </section>
 
-      <section className="panel stagger-in">
-        <h2>Join Pool</h2>
-        <form onSubmit={handleJoin} className="stack">
-          <label>
-            Name
-            <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Your name" />
-          </label>
-          <label>
-            Invite Code
-            <input value={inviteCode} onChange={(e) => setInviteCode(e.target.value.toUpperCase())} placeholder="ABC123" />
-          </label>
-          <button className="btn" disabled={loading}>{loading ? 'Joining...' : 'Join'}</button>
-        </form>
-      </section>
+      <section className="panel join-auth-panel stagger-in">
+        <div className="join-toggle" role="tablist" aria-label="Entry mode">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'join'}
+            className={`join-toggle-btn ${mode === 'join' ? 'active' : ''}`}
+            onClick={() => { setMode('join'); setError(''); }}
+          >
+            Join Pool
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'admin'}
+            className={`join-toggle-btn ${mode === 'admin' ? 'active' : ''}`}
+            onClick={() => { setMode('admin'); setError(''); }}
+          >
+            Admin
+          </button>
+        </div>
 
-      <section className="panel stagger-in delay-2">
-        <h2>Admin Login</h2>
-        <form onSubmit={handleAdmin} className="stack">
-          <label>
-            Password
-            <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Admin password" />
-          </label>
-          <button className="btn btn-outline" disabled={loading}>{loading ? 'Signing in...' : 'Sign In'}</button>
-        </form>
+        {mode === 'join' ? (
+          <form onSubmit={handleJoin} className="stack">
+            <h2>Join Pool</h2>
+            <p className="muted small join-mode-copy">
+              Enter your invite code to start bidding for drivers.
+            </p>
+            <label>
+              Name
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Your name"
+                autoComplete="name"
+              />
+            </label>
+            <label>
+              Invite Code
+              <input
+                value={inviteCode}
+                onChange={(e) => setInviteCode(e.target.value.toUpperCase())}
+                placeholder="ABC123"
+                autoComplete="one-time-code"
+              />
+            </label>
+            <button className="btn" disabled={loading}>{loading ? 'Joining...' : 'Join Pool'}</button>
+          </form>
+        ) : (
+          <form onSubmit={handleAdmin} className="stack">
+            <h2>Admin Login</h2>
+            <p className="muted small join-mode-copy">
+              Sign in to control auctions, events, and season settings.
+            </p>
+            <label>
+              Password
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Admin password"
+                autoComplete="current-password"
+              />
+            </label>
+            <button className="btn btn-outline" disabled={loading}>{loading ? 'Signing in...' : 'Sign In'}</button>
+          </form>
+        )}
         {error ? <p className="error-text">{error}</p> : null}
       </section>
     </div>

--- a/apps/f1/client/src/pages/admin/AuctionPage.jsx
+++ b/apps/f1/client/src/pages/admin/AuctionPage.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import useAdminOutletContext from './useAdminOutletContext';
+
+export default function AuctionPage() {
+  const { settings, setField, saveSettings, runAuctionAction, loading, hasLoaded } = useAdminOutletContext();
+
+  if (loading && !hasLoaded) {
+    return <section className="loading-panel">Loading admin data...</section>;
+  }
+
+  return (
+    <div className="stack-lg">
+      <section className="panel stack">
+        <h2>Auction Controls</h2>
+        <div className="row wrap gap-sm">
+          <button className="btn" onClick={() => runAuctionAction('/admin/auction/start')}>Open</button>
+          <button className="btn btn-outline" onClick={() => runAuctionAction('/admin/auction/pause')}>Pause</button>
+          <button className="btn btn-outline" onClick={() => runAuctionAction('/admin/auction/next')}>Start Next Driver</button>
+          <button className="btn btn-outline" onClick={() => runAuctionAction('/admin/auction/close')}>Close Active</button>
+        </div>
+      </section>
+
+      <section className="panel stack">
+        <h2>Auction Settings</h2>
+        <div className="grid-3">
+          <label>
+            Timer (sec)
+            <input
+              value={settings?.auction_timer_seconds ?? ''}
+              onChange={(e) => setField('auction_timer_seconds', e.target.value)}
+            />
+          </label>
+          <label>
+            Grace (sec)
+            <input
+              value={settings?.auction_grace_seconds ?? ''}
+              onChange={(e) => setField('auction_grace_seconds', e.target.value)}
+            />
+          </label>
+          <label className="checkbox-row">
+            <input
+              type="checkbox"
+              checked={String(settings?.auction_auto_advance) === '1' || settings?.auction_auto_advance === 1 || settings?.auction_auto_advance === true}
+              onChange={(e) => setField('auction_auto_advance', e.target.checked ? 1 : 0)}
+            />
+            Auto Advance
+          </label>
+        </div>
+        <button className="btn" onClick={saveSettings}>Save Settings</button>
+      </section>
+    </div>
+  );
+}

--- a/apps/f1/client/src/pages/admin/OverviewPage.jsx
+++ b/apps/f1/client/src/pages/admin/OverviewPage.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import useAdminOutletContext from './useAdminOutletContext';
+
+export default function OverviewPage() {
+  const { settings, participants, events, rules, loading, hasLoaded } = useAdminOutletContext();
+
+  if (loading && !hasLoaded) {
+    return <section className="loading-panel">Loading admin data...</section>;
+  }
+
+  return (
+    <div className="stack-lg">
+      <section className="panel telemetry-strip">
+        <div className="strip-item">
+          <span className="label">Invite Code</span>
+          <strong>{settings?.invite_code || '—'}</strong>
+        </div>
+        <div className="strip-item">
+          <span className="label">Auction Status</span>
+          <strong className={`status-text status-${settings?.auction_status}`}>{settings?.auction_status || 'unknown'}</strong>
+        </div>
+        <div className="strip-item">
+          <span className="label">Participants</span>
+          <strong>{participants?.length || 0}</strong>
+        </div>
+      </section>
+
+      <section className="panel stack">
+        <h2>Season Summary</h2>
+        <div className="grid-3">
+          <div className="strip-item">
+            <span className="label">Race Events</span>
+            <strong>{events?.length || 0}</strong>
+          </div>
+          <div className="strip-item">
+            <span className="label">GP Rule Rows</span>
+            <strong>{rules?.grand_prix?.length || 0}</strong>
+          </div>
+          <div className="strip-item">
+            <span className="label">Sprint Rule Rows</span>
+            <strong>{rules?.sprint?.length || 0}</strong>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/f1/client/src/pages/admin/PayoutRulesPage.jsx
+++ b/apps/f1/client/src/pages/admin/PayoutRulesPage.jsx
@@ -1,0 +1,88 @@
+import React, { useMemo } from 'react';
+import { categoryLabel } from '../../utils';
+import useAdminOutletContext from './useAdminOutletContext';
+
+export default function PayoutRulesPage() {
+  const { rules, updateRules, saveRules, loading, hasLoaded } = useAdminOutletContext();
+
+  const gpTotal = useMemo(() => (rules?.grand_prix || []).reduce((sum, rule) => sum + Number(rule.bps || 0), 0), [rules]);
+  const sprintTotal = useMemo(() => (rules?.sprint || []).reduce((sum, rule) => sum + Number(rule.bps || 0), 0), [rules]);
+  const bonusTotal = useMemo(() => (rules?.season_bonus || []).reduce((sum, rule) => sum + Number(rule.bps || 0), 0), [rules]);
+
+  if (loading && !hasLoaded) {
+    return <section className="loading-panel">Loading admin data...</section>;
+  }
+
+  if (!rules) {
+    return <section className="loading-panel">No payout rules found.</section>;
+  }
+
+  return (
+    <section className="panel stack">
+      <h2>Payout Rules</h2>
+      <p className="muted">1% = 100 bps. GP target 300 bps, Sprint target 100 bps, Season bonus target 10,000 bps.</p>
+
+      <h3>Grand Prix ({gpTotal} bps)</h3>
+      <div className="table-wrap">
+        <table>
+          <thead><tr><th>Category</th><th>BPS</th></tr></thead>
+          <tbody>
+            {(rules.grand_prix || []).map((rule) => (
+              <tr key={rule.id}>
+                <td>{categoryLabel(rule.category)}</td>
+                <td>
+                  <input
+                    value={rule.bps}
+                    onChange={(e) => updateRules('grand_prix', rule.id, 'bps', e.target.value)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Sprint ({sprintTotal} bps)</h3>
+      <div className="table-wrap">
+        <table>
+          <thead><tr><th>Category</th><th>BPS</th></tr></thead>
+          <tbody>
+            {(rules.sprint || []).map((rule) => (
+              <tr key={rule.id}>
+                <td>{categoryLabel(rule.category)}</td>
+                <td>
+                  <input
+                    value={rule.bps}
+                    onChange={(e) => updateRules('sprint', rule.id, 'bps', e.target.value)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Season Bonuses ({bonusTotal} bps)</h3>
+      <div className="table-wrap">
+        <table>
+          <thead><tr><th>Category</th><th>BPS</th></tr></thead>
+          <tbody>
+            {(rules.season_bonus || []).map((rule) => (
+              <tr key={rule.id}>
+                <td>{categoryLabel(rule.category)}</td>
+                <td>
+                  <input
+                    value={rule.bps}
+                    onChange={(e) => updateRules('season_bonus', rule.id, 'bps', e.target.value)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <button className="btn" onClick={saveRules}>Save Rules</button>
+    </section>
+  );
+}

--- a/apps/f1/client/src/pages/admin/ResultsPage.jsx
+++ b/apps/f1/client/src/pages/admin/ResultsPage.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { fmtCents } from '../../utils';
+import useAdminOutletContext from './useAdminOutletContext';
+
+export default function ResultsPage() {
+  const { events, syncNext, syncEvent, loading, hasLoaded } = useAdminOutletContext();
+
+  if (loading && !hasLoaded) {
+    return <section className="loading-panel">Loading admin data...</section>;
+  }
+
+  return (
+    <section className="panel stack">
+      <div className="row between">
+        <h2>Results Sync</h2>
+        <button className="btn" onClick={syncNext}>Sync Next Event</button>
+      </div>
+      <ul className="list">
+        {(events || []).map((event) => (
+          <li key={event.id}>
+            <div>
+              <strong>R{event.round_number}</strong> {event.name}
+              <div className="muted small">{event.type} • {event.status} • payout {fmtCents(event.total_payout_cents || 0)}</div>
+            </div>
+            <button className="btn btn-outline" onClick={() => syncEvent(event.id)}>Sync</button>
+          </li>
+        ))}
+      </ul>
+      {(!events || events.length === 0) ? <p className="muted small">No events available to sync.</p> : null}
+    </section>
+  );
+}

--- a/apps/f1/client/src/pages/admin/useAdminOutletContext.js
+++ b/apps/f1/client/src/pages/admin/useAdminOutletContext.js
@@ -1,0 +1,5 @@
+import { useOutletContext } from 'react-router-dom';
+
+export default function useAdminOutletContext() {
+  return useOutletContext();
+}


### PR DESCRIPTION
## Summary
- convert the F1 admin page into a layout shell that renders nested routes with a sidebar submenu on desktop and responsive nav on mobile
- wire up nested admin pages under `/admin/*` with redirects to keep behavior consistent and surface the existing tabs as individual components
- update the top navigation so the Admin link stays active for `/admin` and any nested admin paths
## Testing
- Not run (not requested)