### PR TITLE
Implement nested F1 admin shell and payout rules preparation

### DIFF
--- a/apps/f1/client/src/App.jsx
+++ b/apps/f1/client/src/App.jsx
@@ -45,12 +45,12 @@ function AppRoutes() {
           <Route path="/standings" element={<ProtectedRoute><Standings /></ProtectedRoute>} />
           <Route path="/my-drivers" element={<ProtectedRoute><MyDrivers /></ProtectedRoute>} />
           <Route path="/admin" element={<ProtectedRoute adminOnly><Admin /></ProtectedRoute>}>
-            <Route index element={<Navigate to="overview" replace />} />
+            <Route index element={<Navigate to="/admin/overview" replace />} />
             <Route path="overview" element={<OverviewPage />} />
             <Route path="auction" element={<AuctionPage />} />
             <Route path="results" element={<ResultsPage />} />
             <Route path="payouts" element={<PayoutRulesPage />} />
-            <Route path="*" element={<Navigate to="overview" replace />} />
+            <Route path="*" element={<Navigate to="/admin/overview" replace />} />
           </Route>
           <Route path="*" element={<Navigate to="/auction" replace />} />
         </Routes>

--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -739,6 +739,38 @@ tbody tr:hover {
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.bps-summary {
+  margin-top: 0.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.bps-summary h3 {
+  margin: 0;
+}
+
+.bps-pill {
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.26rem 0.58rem;
+}
+
+.bps-pill.ok {
+  border-color: rgba(86, 221, 154, 0.5);
+  color: #b5ffd9;
+}
+
+.bps-pill.warn {
+  border-color: rgba(255, 120, 120, 0.5);
+  color: #ffd2d2;
+}
+
 .checkbox-row {
   flex-direction: row;
   align-items: center;

--- a/apps/f1/client/src/pages/Admin.jsx
+++ b/apps/f1/client/src/pages/Admin.jsx
@@ -192,7 +192,7 @@ export default function Admin() {
             {ADMIN_SECTIONS.map((section) => (
               <NavLink
                 key={section.path}
-                to={section.path}
+                to={`/admin/${section.path}`}
                 className={({ isActive }) => `admin-nav-link ${isActive ? 'active' : ''}`}
               >
                 <span className="admin-nav-label">{section.label}</span>
@@ -207,7 +207,7 @@ export default function Admin() {
             {ADMIN_SECTIONS.map((section) => (
               <NavLink
                 key={section.path}
-                to={section.path}
+                to={`/admin/${section.path}`}
                 className={({ isActive }) => `admin-nav-pill ${isActive ? 'active' : ''}`}
               >
                 {section.label}

--- a/apps/f1/client/src/pages/admin/OverviewPage.jsx
+++ b/apps/f1/client/src/pages/admin/OverviewPage.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import { fmtWhen } from '../../utils';
 import useAdminOutletContext from './useAdminOutletContext';
 
 export default function OverviewPage() {
   const { settings, participants, events, rules, loading, hasLoaded } = useAdminOutletContext();
+  const drawnAtMs = Number(settings?.season_random_bonus_drawn_at);
+  const drawnAtIso = Number.isFinite(drawnAtMs) ? new Date(drawnAtMs).toISOString() : null;
+  const drawnAt = drawnAtIso ? fmtWhen(drawnAtIso) : 'Not drawn yet';
 
   if (loading && !hasLoaded) {
     return <section className="loading-panel">Loading admin data...</section>;
@@ -39,6 +43,14 @@ export default function OverviewPage() {
           <div className="strip-item">
             <span className="label">Sprint Rule Rows</span>
             <strong>{rules?.sprint?.length || 0}</strong>
+          </div>
+          <div className="strip-item">
+            <span className="label">Season Random Standing Position</span>
+            <strong>{settings?.season_random_bonus_position || 'Not drawn'}</strong>
+          </div>
+          <div className="strip-item">
+            <span className="label">Season Random Drawn At</span>
+            <strong>{drawnAt}</strong>
           </div>
         </div>
       </section>

--- a/apps/f1/client/src/pages/admin/PayoutRulesPage.jsx
+++ b/apps/f1/client/src/pages/admin/PayoutRulesPage.jsx
@@ -2,6 +2,18 @@ import React, { useMemo } from 'react';
 import { categoryLabel } from '../../utils';
 import useAdminOutletContext from './useAdminOutletContext';
 
+const TARGETS = {
+  grand_prix: 350,
+  sprint: 150,
+  season_bonus: 700,
+};
+
+function totalDelta(total, target) {
+  const delta = total - target;
+  const sign = delta > 0 ? '+' : '';
+  return `${sign}${delta}`;
+}
+
 export default function PayoutRulesPage() {
   const { rules, updateRules, saveRules, loading, hasLoaded } = useAdminOutletContext();
 
@@ -20,9 +32,14 @@ export default function PayoutRulesPage() {
   return (
     <section className="panel stack">
       <h2>Payout Rules</h2>
-      <p className="muted">1% = 100 bps. GP target 300 bps, Sprint target 100 bps, Season bonus target 10,000 bps.</p>
+      <p className="muted">1% = 100 bps. Targets: GP 350 bps, Sprint 150 bps, Season bonus 700 bps.</p>
 
-      <h3>Grand Prix ({gpTotal} bps)</h3>
+      <div className="bps-summary">
+        <h3>Grand Prix</h3>
+        <span className={`bps-pill ${gpTotal === TARGETS.grand_prix ? 'ok' : 'warn'}`}>
+          {gpTotal} bps ({totalDelta(gpTotal, TARGETS.grand_prix)})
+        </span>
+      </div>
       <div className="table-wrap">
         <table>
           <thead><tr><th>Category</th><th>BPS</th></tr></thead>
@@ -42,7 +59,12 @@ export default function PayoutRulesPage() {
         </table>
       </div>
 
-      <h3>Sprint ({sprintTotal} bps)</h3>
+      <div className="bps-summary">
+        <h3>Sprint</h3>
+        <span className={`bps-pill ${sprintTotal === TARGETS.sprint ? 'ok' : 'warn'}`}>
+          {sprintTotal} bps ({totalDelta(sprintTotal, TARGETS.sprint)})
+        </span>
+      </div>
       <div className="table-wrap">
         <table>
           <thead><tr><th>Category</th><th>BPS</th></tr></thead>
@@ -62,7 +84,12 @@ export default function PayoutRulesPage() {
         </table>
       </div>
 
-      <h3>Season Bonuses ({bonusTotal} bps)</h3>
+      <div className="bps-summary">
+        <h3>Season Bonuses</h3>
+        <span className={`bps-pill ${bonusTotal === TARGETS.season_bonus ? 'ok' : 'warn'}`}>
+          {bonusTotal} bps ({totalDelta(bonusTotal, TARGETS.season_bonus)})
+        </span>
+      </div>
       <div className="table-wrap">
         <table>
           <thead><tr><th>Category</th><th>BPS</th></tr></thead>

--- a/apps/f1/client/src/utils.js
+++ b/apps/f1/client/src/utils.js
@@ -39,6 +39,9 @@ export const categoryLabel = (category) => {
     random_finish_bonus: 'Random Position Bonus',
     drivers_champion: 'Drivers Champion',
     most_race_wins: 'Most Race Wins',
+    most_top10_outside_top4: 'Most Top-10 Finishes Outside Top 4',
+    season_random_finish_position: 'Season Random Standing Position',
+    biggest_single_race_climb: 'Biggest Single-Race Climb',
     most_podiums: 'Most Podiums',
     best_avg_finish: 'Best Avg Finish',
   };

--- a/apps/f1/server/data/payoutRules.js
+++ b/apps/f1/server/data/payoutRules.js
@@ -1,30 +1,40 @@
+const PAYOUT_MODEL_V2 = 2;
+
 const EVENT_RULES = {
   grand_prix: [
-    { category: 'race_winner', label: 'Race Winner', bps: 40, rank_order: 1 },
+    { category: 'race_winner', label: 'Race Winner', bps: 50, rank_order: 1 },
     { category: 'second_place', label: '2nd Place Finish', bps: 25, rank_order: 1 },
-    { category: 'third_place', label: '3rd Place Finish', bps: 20, rank_order: 1 },
-    { category: 'best_p6_or_lower', label: 'Best Finisher P6 or Lower', bps: 45, rank_order: 1 },
-    { category: 'best_p11_or_lower', label: 'Best Finisher P11 or Lower', bps: 35, rank_order: 1 },
+    { category: 'third_place', label: '3rd Place Finish', bps: 25, rank_order: 1 },
+    { category: 'best_p6_or_lower', label: 'Best Finisher P6 or Lower', bps: 50, rank_order: 1 },
+    { category: 'best_p11_or_lower', label: 'Best Finisher P11 or Lower', bps: 50, rank_order: 1 },
     { category: 'most_positions_gained', label: 'Most Positions Gained', bps: 50, rank_order: 1 },
-    { category: 'second_most_positions_gained', label: '2nd Most Positions Gained', bps: 30, rank_order: 2 },
-    { category: 'random_finish_bonus', label: 'Random Finishing Position Bonus', bps: 55, rank_order: 1 },
+    { category: 'second_most_positions_gained', label: '2nd Most Positions Gained', bps: 25, rank_order: 2 },
+    { category: 'random_finish_bonus', label: 'Random Finishing Position Bonus (P4+)', bps: 75, rank_order: 1 },
   ],
   sprint: [
     { category: 'sprint_winner', label: 'Sprint Winner', bps: 25, rank_order: 1 },
-    { category: 'best_p6_or_lower', label: 'Best Finisher P6 or Lower', bps: 35, rank_order: 1 },
+    { category: 'best_p6_or_lower', label: 'Best Finisher P6 or Lower', bps: 25, rank_order: 1 },
     { category: 'most_positions_gained', label: 'Most Positions Gained', bps: 25, rank_order: 1 },
-    { category: 'random_finish_bonus', label: 'Random Finishing Position Bonus', bps: 15, rank_order: 1 },
+    { category: 'random_finish_bonus', label: 'Random Finishing Position Bonus', bps: 75, rank_order: 1 },
   ],
 };
 
 const DEFAULT_SEASON_BONUS_RULES = [
-  { category: 'drivers_champion', label: 'Drivers\' Champion', bps: 4000, rank_order: 1 },
-  { category: 'most_race_wins', label: 'Most Race Wins', bps: 2500, rank_order: 2 },
-  { category: 'most_podiums', label: 'Most Podiums', bps: 2000, rank_order: 3 },
-  { category: 'best_avg_finish', label: 'Best Average Finish', bps: 1500, rank_order: 4 },
+  { category: 'drivers_champion', label: 'Drivers Champion', bps: 150, rank_order: 1 },
+  { category: 'most_race_wins', label: 'Most Race Wins', bps: 100, rank_order: 2 },
+  { category: 'most_top10_outside_top4', label: 'Most Top-10 Finishes Outside Top 4', bps: 150, rank_order: 3 },
+  { category: 'season_random_finish_position', label: 'Random Finishing Position Bonus', bps: 200, rank_order: 4 },
+  { category: 'biggest_single_race_climb', label: 'Biggest Single-Race Climb', bps: 100, rank_order: 5 },
+];
+
+const DEPRECATED_SEASON_BONUS_CATEGORIES = [
+  'most_podiums',
+  'best_avg_finish',
 ];
 
 module.exports = {
   EVENT_RULES,
   DEFAULT_SEASON_BONUS_RULES,
+  DEPRECATED_SEASON_BONUS_CATEGORIES,
+  PAYOUT_MODEL_V2,
 };

--- a/apps/f1/server/db.js
+++ b/apps/f1/server/db.js
@@ -4,13 +4,160 @@ const path = require('path');
 const { generateInviteCode } = require('./lib/core');
 const { DRIVERS_2026 } = require('./data/drivers2026');
 const { EVENTS_2026 } = require('./data/events2026');
-const { EVENT_RULES, DEFAULT_SEASON_BONUS_RULES } = require('./data/payoutRules');
+const {
+  EVENT_RULES,
+  DEFAULT_SEASON_BONUS_RULES,
+  DEPRECATED_SEASON_BONUS_CATEGORIES,
+  PAYOUT_MODEL_V2,
+} = require('./data/payoutRules');
 
 const DB_PATH = process.env.DB_PATH || path.join(__dirname, 'f1-calcutta.db');
 const db = new Database(DB_PATH);
 
 db.pragma('journal_mode = WAL');
 db.pragma('foreign_keys = ON');
+
+function columnExists(tableName, columnName) {
+  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all();
+  return rows.some((row) => row.name === columnName);
+}
+
+function drawRandomPosition(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function applyPayoutModelV2Migration(seasonId) {
+  const season = db.prepare('SELECT id, payout_model_version FROM seasons WHERE id = ?').get(seasonId);
+  if (!season || (Number(season.payout_model_version) || 1) >= PAYOUT_MODEL_V2) {
+    return { migrated: false };
+  }
+
+  const now = Date.now();
+
+  const upsertEventRule = db.prepare(`
+    INSERT INTO event_payout_rules
+      (season_id, event_type, category, label, bps, rank_order, active)
+    VALUES (?, ?, ?, ?, ?, ?, 1)
+    ON CONFLICT(season_id, event_type, category, rank_order)
+    DO UPDATE SET
+      label = excluded.label,
+      bps = excluded.bps,
+      active = 1
+  `);
+
+  const upsertSeasonRule = db.prepare(`
+    INSERT INTO season_bonus_rules
+      (season_id, category, label, bps, rank_order, active)
+    VALUES (?, ?, ?, ?, ?, 1)
+    ON CONFLICT(season_id, category, rank_order)
+    DO UPDATE SET
+      label = excluded.label,
+      bps = excluded.bps,
+      active = 1
+  `);
+
+  const deactivateEventRule = db.prepare(`
+    UPDATE event_payout_rules
+    SET active = 0
+    WHERE season_id = ? AND id = ?
+  `);
+
+  const deactivateSeasonRule = db.prepare(`
+    UPDATE season_bonus_rules
+    SET active = 0
+    WHERE season_id = ? AND id = ?
+  `);
+
+  const updateGpRandomDraw = db.prepare(`
+    UPDATE events
+    SET random_bonus_position = ?, random_bonus_drawn_at = ?
+    WHERE id = ? AND season_id = ?
+  `);
+
+  db.transaction(() => {
+    for (const [eventType, rules] of Object.entries(EVENT_RULES)) {
+      rules.forEach((rule) => {
+        upsertEventRule.run(
+          seasonId,
+          eventType,
+          rule.category,
+          rule.label,
+          rule.bps,
+          rule.rank_order || 1
+        );
+      });
+
+      const keepKeys = new Set(rules.map((rule) => `${rule.category}|${rule.rank_order || 1}`));
+      const existing = db.prepare(`
+        SELECT id, category, rank_order
+        FROM event_payout_rules
+        WHERE season_id = ? AND event_type = ?
+      `).all(seasonId, eventType);
+
+      existing.forEach((rule) => {
+        const key = `${rule.category}|${rule.rank_order || 1}`;
+        if (!keepKeys.has(key)) {
+          deactivateEventRule.run(seasonId, rule.id);
+        }
+      });
+    }
+
+    DEFAULT_SEASON_BONUS_RULES.forEach((rule) => {
+      upsertSeasonRule.run(
+        seasonId,
+        rule.category,
+        rule.label,
+        rule.bps,
+        rule.rank_order || 1
+      );
+    });
+
+    const keepSeasonKeys = new Set(DEFAULT_SEASON_BONUS_RULES.map((rule) => `${rule.category}|${rule.rank_order || 1}`));
+    const existingSeasonRules = db.prepare(`
+      SELECT id, category, rank_order
+      FROM season_bonus_rules
+      WHERE season_id = ?
+    `).all(seasonId);
+
+    existingSeasonRules.forEach((rule) => {
+      const key = `${rule.category}|${rule.rank_order || 1}`;
+      if (!keepSeasonKeys.has(key)) {
+        deactivateSeasonRule.run(seasonId, rule.id);
+      }
+    });
+
+    if (DEPRECATED_SEASON_BONUS_CATEGORIES.length) {
+      const placeholders = DEPRECATED_SEASON_BONUS_CATEGORIES.map(() => '?').join(', ');
+      db.prepare(`
+        UPDATE season_bonus_rules
+        SET active = 0
+        WHERE season_id = ?
+          AND category IN (${placeholders})
+      `).run(seasonId, ...DEPRECATED_SEASON_BONUS_CATEGORIES);
+    }
+
+    const gpEvents = db.prepare(`
+      SELECT id, random_bonus_position
+      FROM events
+      WHERE season_id = ? AND type = 'grand_prix' AND status = 'scored'
+    `).all(seasonId);
+
+    gpEvents.forEach((event) => {
+      const pos = Number(event.random_bonus_position);
+      if (!pos || pos < 4 || pos > 20) {
+        updateGpRandomDraw.run(drawRandomPosition(4, 20), now, event.id, seasonId);
+      }
+    });
+
+    db.prepare(`
+      UPDATE seasons
+      SET payout_model_version = ?
+      WHERE id = ?
+    `).run(PAYOUT_MODEL_V2, seasonId);
+  })();
+
+  return { migrated: true };
+}
 
 function init() {
   db.exec(`
@@ -29,6 +176,9 @@ function init() {
       auction_grace_seconds INTEGER NOT NULL DEFAULT 15,
       auction_status TEXT NOT NULL DEFAULT 'waiting',
       auction_auto_advance INTEGER NOT NULL DEFAULT 0,
+      payout_model_version INTEGER NOT NULL DEFAULT 1,
+      season_random_bonus_position INTEGER,
+      season_random_bonus_drawn_at INTEGER,
       created_at INTEGER NOT NULL DEFAULT (unixepoch())
     );
 
@@ -167,6 +317,16 @@ function init() {
     );
   `);
 
+  if (!columnExists('seasons', 'payout_model_version')) {
+    db.exec('ALTER TABLE seasons ADD COLUMN payout_model_version INTEGER NOT NULL DEFAULT 1');
+  }
+  if (!columnExists('seasons', 'season_random_bonus_position')) {
+    db.exec('ALTER TABLE seasons ADD COLUMN season_random_bonus_position INTEGER');
+  }
+  if (!columnExists('seasons', 'season_random_bonus_drawn_at')) {
+    db.exec('ALTER TABLE seasons ADD COLUMN season_random_bonus_drawn_at INTEGER');
+  }
+
   const seasonCount = db.prepare('SELECT COUNT(*) as c FROM seasons').get().c;
   if (seasonCount === 0) {
     const year = new Date().getUTCFullYear();
@@ -182,6 +342,11 @@ function init() {
 
   const activeSeasonId = getActiveSeasonId();
   seedSeasonData(activeSeasonId);
+  const payoutMigration = applyPayoutModelV2Migration(activeSeasonId);
+  return {
+    activeSeasonId,
+    payoutModelMigrated: !!payoutMigration.migrated,
+  };
 }
 
 function seedSeasonData(seasonId) {
@@ -287,7 +452,10 @@ function getSeasonSettings(seasonId) {
   return db.prepare(`
     SELECT id, year, name, invite_code, status,
            auction_timer_seconds, auction_grace_seconds,
-           auction_status, auction_auto_advance
+           auction_status, auction_auto_advance,
+           payout_model_version,
+           season_random_bonus_position,
+           season_random_bonus_drawn_at
     FROM seasons
     WHERE id = ?
   `).get(seasonId);

--- a/apps/f1/server/index.js
+++ b/apps/f1/server/index.js
@@ -16,6 +16,7 @@ const { init } = require('./db');
 const { setupSocket } = require('./socket');
 const { createAuctionService } = require('./services/auctionService');
 const { createResultsProvider } = require('./providers');
+const { rescoreSeasonEvents } = require('./services/scoringService');
 
 const authRoutes = require('./routes/auth');
 const auctionRoutes = require('./routes/auction');
@@ -57,12 +58,22 @@ if (process.env.NODE_ENV === 'production') {
   });
 }
 
-init();
+const initResult = init();
 const auctionService = createAuctionService(io);
 auctionService.restoreTimerOnStartup();
 app.set('auctionService', auctionService);
 app.set('resultsProvider', createResultsProvider());
 setupSocket(io, auctionService);
+
+if (initResult?.payoutModelMigrated) {
+  const rescore = rescoreSeasonEvents({ seasonId: initResult.activeSeasonId });
+  if (!rescore.ok) {
+    console.error('[payout-model-v2] Failed to rescore season events', rescore);
+  } else {
+    io.emit('standings:update');
+    console.log(`[payout-model-v2] Rescored ${rescore.rescoredEvents} events for season ${initResult.activeSeasonId}`);
+  }
+}
 
 const PORT = process.env.F1_PORT || process.env.PORT || 3002;
 httpServer.listen(PORT, () => {

--- a/apps/f1/server/services/scoringService.js
+++ b/apps/f1/server/services/scoringService.js
@@ -1,6 +1,5 @@
 const {
   amountFromBps,
-  allocateByBps,
   splitCentsEvenly,
 } = require('../lib/core');
 const {
@@ -19,14 +18,6 @@ const SPRINT_POINTS = [8, 7, 6, 5, 4, 3, 2, 1];
 function valueForPosition(pointsTable, pos) {
   if (!pos || pos < 1 || pos > pointsTable.length) return 0;
   return pointsTable[pos - 1] || 0;
-}
-
-function keyByDriver(rows) {
-  const map = new Map();
-  for (const row of rows) {
-    map.set(row.driver_id, row);
-  }
-  return map;
 }
 
 function winnersByFinish(rows, targetPosition) {
@@ -80,8 +71,12 @@ function resolveCategoryWinners(category, rows, event, rankOrder = 1) {
 }
 
 function ensureRandomBonusPosition(event) {
-  if (event.random_bonus_position) return event.random_bonus_position;
-  const drawn = (Math.floor(Math.random() * 20) + 1);
+  const minPosition = event.type === 'grand_prix' ? 4 : 1;
+  const maxPosition = 20;
+  const existing = Number(event.random_bonus_position);
+  if (existing >= minPosition && existing <= maxPosition) return existing;
+
+  const drawn = Math.floor(Math.random() * (maxPosition - minPosition + 1)) + minPosition;
   db.prepare(`
     UPDATE events
     SET random_bonus_position = ?, random_bonus_drawn_at = ?
@@ -90,12 +85,12 @@ function ensureRandomBonusPosition(event) {
   return drawn;
 }
 
-function scoreEvent({ seasonId, eventId, skipSeasonBonuses = false }) {
+function scoreEvent({ seasonId, eventId, skipSeasonBonuses = false, ignoreLock = false }) {
   const event = getEventById(seasonId, eventId);
   if (!event) return { ok: false, status: 404, error: 'Event not found' };
 
   const lockAtMs = event.lock_at ? Date.parse(event.lock_at) : null;
-  if (Number.isFinite(lockAtMs) && Date.now() < lockAtMs) {
+  if (!ignoreLock && Number.isFinite(lockAtMs) && Date.now() < lockAtMs) {
     return { ok: false, status: 400, error: 'Event lock time has not passed yet' };
   }
 
@@ -157,11 +152,28 @@ function scoreEvent({ seasonId, eventId, skipSeasonBonuses = false }) {
 
 function getAllSeasonResultRows(seasonId) {
   return db.prepare(`
-    SELECT e.type, er.driver_id, er.finish_position
+    SELECT e.id as event_id, e.type, er.driver_id, er.finish_position, er.positions_gained
     FROM event_results er
     JOIN events e ON e.id = er.event_id
-    WHERE e.season_id = ?
+    WHERE e.season_id = ? AND e.status = 'scored'
   `).all(seasonId);
+}
+
+function getChampionshipStandings(seasonId, rows) {
+  const points = new Map(
+    db.prepare('SELECT id FROM drivers WHERE season_id = ? ORDER BY id ASC').all(seasonId)
+      .map((driver) => [driver.id, 0])
+  );
+
+  for (const row of rows) {
+    const table = row.type === 'sprint' ? SPRINT_POINTS : GP_POINTS;
+    const earned = valueForPosition(table, row.finish_position);
+    points.set(row.driver_id, (points.get(row.driver_id) || 0) + earned);
+  }
+
+  return Array.from(points.entries())
+    .map(([driver_id, total_points]) => ({ driver_id, total_points }))
+    .sort((a, b) => (b.total_points - a.total_points) || (a.driver_id - b.driver_id));
 }
 
 function getWinnersFromMetric(metricMap, comparator) {
@@ -174,18 +186,33 @@ function getWinnersFromMetric(metricMap, comparator) {
   return entries.filter(([, value]) => value === targetValue).map(([driverId]) => driverId);
 }
 
-function resolveSeasonBonusWinners(category, seasonId) {
-  const rows = getAllSeasonResultRows(seasonId);
-  if (!rows.length) return [];
+function getSeasonRandomBonusPosition(seasonId, standingsCount) {
+  if (standingsCount <= 0) return null;
+  const season = db.prepare(`
+    SELECT season_random_bonus_position
+    FROM seasons
+    WHERE id = ?
+  `).get(seasonId);
+
+  const existing = Number(season?.season_random_bonus_position);
+  if (existing >= 1 && existing <= standingsCount) {
+    return existing;
+  }
+
+  const drawn = Math.floor(Math.random() * standingsCount) + 1;
+  db.prepare(`
+    UPDATE seasons
+    SET season_random_bonus_position = ?, season_random_bonus_drawn_at = ?
+    WHERE id = ?
+  `).run(drawn, Date.now(), seasonId);
+  return drawn;
+}
+
+function resolveSeasonBonusWinners(category, seasonId, context) {
+  const { rows, standings } = context;
 
   if (category === 'drivers_champion') {
-    const points = new Map();
-    for (const row of rows) {
-      const table = row.type === 'sprint' ? SPRINT_POINTS : GP_POINTS;
-      const earned = valueForPosition(table, row.finish_position);
-      points.set(row.driver_id, (points.get(row.driver_id) || 0) + earned);
-    }
-    return getWinnersFromMetric(points, (a, b) => a > b);
+    return standings.length ? [standings[0].driver_id] : [];
   }
 
   if (category === 'most_race_wins') {
@@ -196,32 +223,32 @@ function resolveSeasonBonusWinners(category, seasonId) {
     return getWinnersFromMetric(wins, (a, b) => a > b);
   }
 
-  if (category === 'most_podiums') {
-    const podiums = new Map();
+  if (category === 'most_top10_outside_top4') {
+    const topFour = new Set(standings.slice(0, 4).map((entry) => entry.driver_id));
+    const top10Counts = new Map();
+
     rows
-      .filter((row) => row.type === 'grand_prix' && row.finish_position <= 3)
-      .forEach((row) => podiums.set(row.driver_id, (podiums.get(row.driver_id) || 0) + 1));
-    return getWinnersFromMetric(podiums, (a, b) => a > b);
+      .filter((row) => row.finish_position <= 10 && !topFour.has(row.driver_id))
+      .forEach((row) => top10Counts.set(row.driver_id, (top10Counts.get(row.driver_id) || 0) + 1));
+
+    return getWinnersFromMetric(top10Counts, (a, b) => a > b);
   }
 
-  if (category === 'best_avg_finish') {
-    const sums = new Map();
-    const counts = new Map();
+  if (category === 'season_random_finish_position') {
+    const drawnPosition = getSeasonRandomBonusPosition(seasonId, standings.length);
+    if (!drawnPosition) return [];
+    const winner = standings[drawnPosition - 1];
+    return winner ? [winner.driver_id] : [];
+  }
 
-    rows
-      .filter((row) => row.type === 'grand_prix')
-      .forEach((row) => {
-        sums.set(row.driver_id, (sums.get(row.driver_id) || 0) + row.finish_position);
-        counts.set(row.driver_id, (counts.get(row.driver_id) || 0) + 1);
-      });
-
-    const averages = new Map();
-    for (const [driverId, count] of counts.entries()) {
-      if (count > 0) {
-        averages.set(driverId, Math.round((sums.get(driverId) / count) * 1000) / 1000);
-      }
-    }
-    return getWinnersFromMetric(averages, (a, b) => a < b);
+  if (category === 'biggest_single_race_climb') {
+    if (!rows.length) return [];
+    const bestGain = Math.max(...rows.map((row) => Number(row.positions_gained) || 0));
+    return [...new Set(
+      rows
+        .filter((row) => (Number(row.positions_gained) || 0) === bestGain)
+        .map((row) => row.driver_id)
+    )];
   }
 
   return [];
@@ -234,21 +261,10 @@ function recalcSeasonBonuses({ seasonId }) {
   if (!rules.length) return { ok: true, distributedCents: 0 };
 
   const totalPot = getTotalPotCents(seasonId);
-  const eventDistributed = db.prepare(
-    'SELECT COALESCE(SUM(amount_cents), 0) as total FROM event_payouts WHERE season_id = ?'
-  ).get(seasonId).total;
+  if (totalPot <= 0) return { ok: true, distributedCents: 0 };
 
-  const remainder = Math.max(0, totalPot - eventDistributed);
-  if (remainder <= 0) return { ok: true, distributedCents: 0 };
-
-  const allocations = allocateByBps(
-    remainder,
-    rules.map((rule) => ({
-      rule,
-      bps: rule.bps,
-    }))
-  );
-
+  const rows = getAllSeasonResultRows(seasonId);
+  const standings = getChampionshipStandings(seasonId, rows);
   const ownershipMap = new Map(getOwnershipBySeason(seasonId).map((o) => [o.driver_id, o.participant_id]));
 
   const insert = db.prepare(`
@@ -258,12 +274,12 @@ function recalcSeasonBonuses({ seasonId }) {
   `);
 
   let distributed = 0;
-  allocations.forEach((allocation, idx) => {
-    const rule = rules[idx];
-    const winners = resolveSeasonBonusWinners(rule.category, seasonId);
-    if (!winners.length || allocation.cents <= 0) return;
+  rules.forEach((rule) => {
+    const payoutCents = amountFromBps(totalPot, rule.bps);
+    const winners = resolveSeasonBonusWinners(rule.category, seasonId, { rows, standings });
+    if (!winners.length || payoutCents <= 0) return;
 
-    const shares = splitCentsEvenly(allocation.cents, winners.length);
+    const shares = splitCentsEvenly(payoutCents, winners.length);
     winners.forEach((driverId, shareIdx) => {
       const participantId = ownershipMap.get(driverId);
       if (!participantId) return;
@@ -272,7 +288,43 @@ function recalcSeasonBonuses({ seasonId }) {
     });
   });
 
-  return { ok: true, distributedCents: distributed, remainderCents: remainder };
+  return { ok: true, distributedCents: distributed };
+}
+
+function rescoreSeasonEvents({ seasonId }) {
+  const eventIds = db.prepare(`
+    SELECT e.id
+    FROM events e
+    WHERE e.season_id = ?
+      AND EXISTS (
+        SELECT 1 FROM event_results er WHERE er.event_id = e.id
+      )
+    ORDER BY e.round_number ASC,
+      CASE WHEN e.type = 'sprint' THEN 0 ELSE 1 END ASC
+  `).all(seasonId).map((row) => row.id);
+
+  db.prepare('DELETE FROM event_payouts WHERE season_id = ?').run(seasonId);
+
+  let rescoredEvents = 0;
+  for (const eventId of eventIds) {
+    const result = scoreEvent({
+      seasonId,
+      eventId,
+      skipSeasonBonuses: true,
+      ignoreLock: true,
+    });
+    if (!result.ok) {
+      return result;
+    }
+    rescoredEvents += 1;
+  }
+
+  const seasonBonus = recalcSeasonBonuses({ seasonId });
+  return {
+    ok: true,
+    rescoredEvents,
+    seasonBonusDistributedCents: seasonBonus.distributedCents || 0,
+  };
 }
 
 function upsertEventResults({ seasonId, eventId, rows, manualOverride = false }) {
@@ -380,6 +432,7 @@ async function syncNextEventFromProvider({ seasonId, provider, io }) {
 module.exports = {
   scoreEvent,
   recalcSeasonBonuses,
+  rescoreSeasonEvents,
   upsertEventResults,
   syncEventFromProvider,
   syncNextEventFromProvider,

--- a/apps/f1/server/tests/scoringService.test.js
+++ b/apps/f1/server/tests/scoringService.test.js
@@ -148,3 +148,261 @@ test('auction lifecycle sells driver and records ownership', () => {
   const ownershipCount = db.prepare('SELECT COUNT(*) as c FROM ownership WHERE season_id = ?').get(seasonId).c;
   assert.equal(ownershipCount, 1);
 });
+
+test('random bonus draw ranges follow payout model v2 bounds by event type', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    upsertEventResults,
+    scoreEvent,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const gpEvent = db.prepare(`
+    SELECT id
+    FROM events
+    WHERE season_id = ? AND type = 'grand_prix'
+    ORDER BY round_number ASC
+    LIMIT 1
+  `).get(seasonId);
+  const sprintEvent = db.prepare(`
+    SELECT id
+    FROM events
+    WHERE season_id = ? AND type = 'sprint'
+    ORDER BY round_number ASC
+    LIMIT 1
+  `).get(seasonId);
+  const driver = db.prepare('SELECT id, external_id FROM drivers WHERE season_id = ? ORDER BY external_id ASC LIMIT 1').get(seasonId);
+
+  db.prepare('UPDATE events SET lock_at = ? WHERE id IN (?, ?)').run('2000-01-01T00:00:00Z', gpEvent.id, sprintEvent.id);
+
+  upsertEventResults({
+    seasonId,
+    eventId: gpEvent.id,
+    rows: [{ external_driver_id: driver.external_id, finish_position: 1, start_position: 10 }],
+  });
+  const gpScore = scoreEvent({ seasonId, eventId: gpEvent.id });
+  assert.equal(gpScore.ok, true);
+
+  upsertEventResults({
+    seasonId,
+    eventId: sprintEvent.id,
+    rows: [{ external_driver_id: driver.external_id, finish_position: 1, start_position: 8 }],
+  });
+  const sprintScore = scoreEvent({ seasonId, eventId: sprintEvent.id });
+  assert.equal(sprintScore.ok, true);
+
+  const gpDraw = db.prepare('SELECT random_bonus_position FROM events WHERE id = ?').get(gpEvent.id).random_bonus_position;
+  const sprintDraw = db.prepare('SELECT random_bonus_position FROM events WHERE id = ?').get(sprintEvent.id).random_bonus_position;
+  assert.ok(gpDraw >= 4 && gpDraw <= 20);
+  assert.ok(sprintDraw >= 1 && sprintDraw <= 20);
+});
+
+test('season bonus winners and allocations follow payout model v2', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    upsertEventResults,
+    scoreEvent,
+    recalcSeasonBonuses,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const drivers = db.prepare(`
+    SELECT id, external_id
+    FROM drivers
+    WHERE season_id = ?
+    ORDER BY external_id ASC
+    LIMIT 5
+  `).all(seasonId);
+  const [d1, d2, d3, d4, d5] = drivers;
+
+  const participants = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo'].map((name, idx) => (
+    db.prepare('INSERT INTO participants (name, color, session_token) VALUES (?, ?, ?)').run(
+      `${name}-${Date.now()}-${idx}`,
+      `#00${idx + 1}ff`,
+      `tok-${name.toLowerCase()}-${Date.now()}-${idx}`
+    ).lastInsertRowid
+  ));
+
+  participants.forEach((participantId, idx) => {
+    db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+    db.prepare(`
+      INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+      VALUES (?, ?, ?, ?)
+    `).run(seasonId, drivers[idx].id, participantId, 10000);
+  });
+
+  const [gp1, gp2] = db.prepare(`
+    SELECT id
+    FROM events
+    WHERE season_id = ? AND type = 'grand_prix'
+    ORDER BY round_number ASC
+    LIMIT 2
+  `).all(seasonId);
+  const sprint1 = db.prepare(`
+    SELECT id
+    FROM events
+    WHERE season_id = ? AND type = 'sprint'
+    ORDER BY round_number ASC
+    LIMIT 1
+  `).get(seasonId);
+
+  db.prepare('UPDATE events SET lock_at = ? WHERE id IN (?, ?, ?)').run(
+    '2000-01-01T00:00:00Z',
+    gp1.id,
+    gp2.id,
+    sprint1.id
+  );
+
+  upsertEventResults({
+    seasonId,
+    eventId: gp1.id,
+    rows: [
+      { external_driver_id: d1.external_id, finish_position: 1, start_position: 3 },
+      { external_driver_id: d2.external_id, finish_position: 2, start_position: 1 },
+      { external_driver_id: d3.external_id, finish_position: 3, start_position: 8 },
+      { external_driver_id: d4.external_id, finish_position: 4, start_position: 10 },
+      { external_driver_id: d5.external_id, finish_position: 5, start_position: 4 },
+    ],
+  });
+  upsertEventResults({
+    seasonId,
+    eventId: sprint1.id,
+    rows: [
+      { external_driver_id: d2.external_id, finish_position: 1, start_position: 2 },
+      { external_driver_id: d3.external_id, finish_position: 2, start_position: 6 },
+      { external_driver_id: d4.external_id, finish_position: 9, start_position: 15 },
+      { external_driver_id: d5.external_id, finish_position: 10, start_position: 5 },
+      { external_driver_id: d1.external_id, finish_position: 12, start_position: 1 },
+    ],
+  });
+  upsertEventResults({
+    seasonId,
+    eventId: gp2.id,
+    rows: [
+      { external_driver_id: d2.external_id, finish_position: 1, start_position: 4 },
+      { external_driver_id: d1.external_id, finish_position: 2, start_position: 1 },
+      { external_driver_id: d3.external_id, finish_position: 8, start_position: 12 },
+      { external_driver_id: d4.external_id, finish_position: 11, start_position: 20 },
+      { external_driver_id: d5.external_id, finish_position: 10, start_position: 6 },
+    ],
+  });
+
+  assert.equal(scoreEvent({ seasonId, eventId: gp1.id }).ok, true);
+  assert.equal(scoreEvent({ seasonId, eventId: sprint1.id }).ok, true);
+  assert.equal(scoreEvent({ seasonId, eventId: gp2.id }).ok, true);
+
+  db.prepare(`
+    UPDATE seasons
+    SET season_random_bonus_position = ?, season_random_bonus_drawn_at = ?
+    WHERE id = ?
+  `).run(5, 1234567890, seasonId);
+
+  const recalc = recalcSeasonBonuses({ seasonId });
+  assert.equal(recalc.ok, true);
+
+  const payouts = db.prepare(`
+    SELECT category, driver_id, amount_cents, tie_count
+    FROM season_bonus_payouts
+    WHERE season_id = ?
+    ORDER BY category ASC, driver_id ASC
+  `).all(seasonId);
+
+  const byCategory = payouts.reduce((acc, row) => {
+    acc[row.category] = acc[row.category] || [];
+    acc[row.category].push(row);
+    return acc;
+  }, {});
+
+  assert.deepEqual(byCategory.drivers_champion.map((row) => [row.driver_id, row.amount_cents]), [[d2.id, 750]]);
+  assert.deepEqual(byCategory.most_race_wins.map((row) => [row.driver_id, row.amount_cents]), [[d1.id, 250], [d2.id, 250]]);
+  assert.deepEqual(byCategory.most_top10_outside_top4.map((row) => [row.driver_id, row.amount_cents]), [[d5.id, 750]]);
+  assert.deepEqual(byCategory.season_random_finish_position.map((row) => [row.driver_id, row.amount_cents]), [[d5.id, 1000]]);
+  assert.deepEqual(byCategory.biggest_single_race_climb.map((row) => [row.driver_id, row.amount_cents]), [[d4.id, 500]]);
+
+  const season = db.prepare(`
+    SELECT season_random_bonus_position, season_random_bonus_drawn_at
+    FROM seasons
+    WHERE id = ?
+  `).get(seasonId);
+  assert.equal(season.season_random_bonus_position, 5);
+  assert.equal(season.season_random_bonus_drawn_at, 1234567890);
+});
+
+test('v2 migration normalizes rules and gp random draws for active season', () => {
+  const modules = setupDb();
+  const {
+    db,
+    getActiveSeasonId,
+    init,
+  } = modules;
+
+  const seasonId = getActiveSeasonId();
+  const gpEvent = db.prepare(`
+    SELECT id
+    FROM events
+    WHERE season_id = ? AND type = 'grand_prix'
+    ORDER BY round_number ASC
+    LIMIT 1
+  `).get(seasonId);
+
+  db.prepare(`
+    INSERT OR IGNORE INTO season_bonus_rules
+      (season_id, category, label, bps, rank_order, active)
+    VALUES (?, 'most_podiums', 'Most Podiums', 200, 90, 1)
+  `).run(seasonId);
+  db.prepare(`
+    INSERT OR IGNORE INTO season_bonus_rules
+      (season_id, category, label, bps, rank_order, active)
+    VALUES (?, 'best_avg_finish', 'Best Avg Finish', 200, 91, 1)
+  `).run(seasonId);
+  db.prepare(`
+    UPDATE season_bonus_rules
+    SET active = 1, bps = 200
+    WHERE season_id = ? AND category IN ('most_podiums', 'best_avg_finish')
+  `).run(seasonId);
+
+  db.prepare(`
+    UPDATE seasons
+    SET payout_model_version = 1
+    WHERE id = ?
+  `).run(seasonId);
+  db.prepare(`
+    UPDATE events
+    SET status = 'scored', random_bonus_position = 2
+    WHERE id = ?
+  `).run(gpEvent.id);
+
+  const rerun = init();
+  assert.equal(rerun.payoutModelMigrated, true);
+
+  const version = db.prepare('SELECT payout_model_version FROM seasons WHERE id = ?').get(seasonId).payout_model_version;
+  assert.equal(version, 2);
+
+  const deprecatedActive = db.prepare(`
+    SELECT COUNT(*) as count
+    FROM season_bonus_rules
+    WHERE season_id = ?
+      AND category IN ('most_podiums', 'best_avg_finish')
+      AND active = 1
+  `).get(seasonId).count;
+  assert.equal(deprecatedActive, 0);
+
+  const seasonCategories = db.prepare(`
+    SELECT category
+    FROM season_bonus_rules
+    WHERE season_id = ? AND active = 1
+    ORDER BY rank_order ASC
+  `).all(seasonId).map((row) => row.category);
+  assert.deepEqual(seasonCategories, [
+    'drivers_champion',
+    'most_race_wins',
+    'most_top10_outside_top4',
+    'season_random_finish_position',
+    'biggest_single_race_climb',
+  ]);
+
+  const gpDraw = db.prepare('SELECT random_bonus_position FROM events WHERE id = ?').get(gpEvent.id).random_bonus_position;
+  assert.ok(gpDraw >= 4 && gpDraw <= 20);
+});


### PR DESCRIPTION
Summary
- nest `/admin/*` behind a layout shell and secondary nav so each admin area (Overview, Auction, Results, Payouts) is independently routable while keeping the shared data/actions in the layout
- update top nav active-state detection to flag the Admin link for `/admin` and any nested path, keeping auth gating unchanged
- begin aligning payout UI/data needs for the V2 model by surfacing season random bonus info and preparing rule metadata hooks outlined in the plan

Testing
- Not run (not requested)