### PR TITLE
Refactor F1 admin and persistence layout

### DIFF
--- a/apps/f1/server/index.js
+++ b/apps/f1/server/index.js
@@ -81,23 +81,38 @@ httpServer.listen(PORT, () => {
 });
 
 let isShuttingDown = false;
+let forceExitTimer = null;
 function shutdown(signal) {
   if (isShuttingDown) return;
   isShuttingDown = true;
 
   console.log(`[shutdown] Received ${signal}, closing server...`);
 
-  io.close(() => {
-    httpServer.close((err) => {
-      if (err) {
+  const finish = (code) => {
+    if (forceExitTimer) clearTimeout(forceExitTimer);
+    process.exit(code);
+  };
+
+  const closeHttpServer = () => {
+    if (!httpServer.listening) {
+      console.log('[shutdown] HTTP server already stopped');
+      return finish(0);
+    }
+
+    return httpServer.close((err) => {
+      if (err && err.code !== 'ERR_SERVER_NOT_RUNNING') {
         console.error('[shutdown] HTTP close failed', err);
-        process.exit(1);
+        return finish(1);
       }
-      process.exit(0);
+      return finish(0);
     });
+  };
+
+  io.close(() => {
+    closeHttpServer();
   });
 
-  setTimeout(() => process.exit(1), 10000).unref();
+  forceExitTimer = setTimeout(() => process.exit(1), 10000).unref();
 }
 
 process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/apps/ncaa/server/index.js
+++ b/apps/ncaa/server/index.js
@@ -76,24 +76,39 @@ httpServer.listen(PORT, () => {
 });
 
 let isShuttingDown = false;
+let forceExitTimer = null;
 function shutdown(signal) {
   if (isShuttingDown) return;
   isShuttingDown = true;
   console.log(`[shutdown] Received ${signal}, closing server...`);
 
-  io.close(() => {
-    httpServer.close((err) => {
-      if (err) {
+  const finish = (code) => {
+    if (forceExitTimer) clearTimeout(forceExitTimer);
+    process.exit(code);
+  };
+
+  const closeHttpServer = () => {
+    if (!httpServer.listening) {
+      console.log('[shutdown] HTTP server already stopped');
+      return finish(0);
+    }
+
+    return httpServer.close((err) => {
+      if (err && err.code !== 'ERR_SERVER_NOT_RUNNING') {
         console.error('[shutdown] Error closing HTTP server', err);
-        process.exit(1);
+        return finish(1);
       }
       console.log('[shutdown] Server closed cleanly');
-      process.exit(0);
+      return finish(0);
     });
+  };
+
+  io.close(() => {
+    closeHttpServer();
   });
 
   // Safety timeout in case close hangs due to open handles.
-  setTimeout(() => {
+  forceExitTimer = setTimeout(() => {
     console.error('[shutdown] Force exiting after timeout');
     process.exit(1);
   }, 10000).unref();


### PR DESCRIPTION
Summary
- remove the dead MyTeams page while keeping routes untouched and prepare for the planned admin client/data decomposition
- split the server persistence layer behind a stable `db.js` facade and decompose admin routes into focused services per the refactor plan
- drafted the NCAA payouts default-value story for the ADO backlog entry (need AZDO PAT to actually create it through the ado-backlog skill)

Testing
- Not run (not requested)