### PR TITLE
Add F1 guide page and clarify payout summary

### DIFF
--- a/apps/f1/client/src/App.jsx
+++ b/apps/f1/client/src/App.jsx
@@ -4,6 +4,7 @@ import { AuthProvider, useAuth } from './context/AuthContext';
 import { SocketProvider } from './context/SocketContext';
 import Nav from './components/Nav';
 import Join from './pages/Join';
+import Guide from './pages/Guide';
 import Auction from './pages/Auction';
 import Events from './pages/Events';
 import Standings from './pages/Standings';
@@ -42,6 +43,7 @@ function AppRoutes() {
       <main className="page-shell">
         <Routes>
           <Route path="/join" element={participant ? <Navigate to={participant.isAdmin ? '/admin' : '/auction'} replace /> : <Join />} />
+          <Route path="/guide" element={<Guide />} />
           <Route path="/" element={<Navigate to="/auction" replace />} />
           <Route path="/auction" element={<ProtectedRoute><Auction /></ProtectedRoute>} />
           <Route path="/events" element={<ProtectedRoute><Events /></ProtectedRoute>} />

--- a/apps/f1/client/src/content/guideContent.js
+++ b/apps/f1/client/src/content/guideContent.js
@@ -1,0 +1,71 @@
+export const GUIDE_EVENT_PAYOUTS = {
+  grandPrix: {
+    title: 'Grand Prix',
+    totalBps: 350,
+    totalPercent: '3.5%',
+    rows: [
+      { category: 'Race Winner', bps: 50 },
+      { category: '2nd Place', bps: 25 },
+      { category: '3rd Place', bps: 25 },
+      { category: 'Best P6+', bps: 50 },
+      { category: 'Best P11+', bps: 50 },
+      { category: 'Most Positions Gained', bps: 50 },
+      { category: '2nd Most Positions Gained', bps: 25 },
+      { category: 'Random Position Bonus (P4+)', bps: 75 },
+    ],
+  },
+  sprint: {
+    title: 'Sprint',
+    totalBps: 150,
+    totalPercent: '1.5%',
+    rows: [
+      { category: 'Sprint Winner', bps: 25 },
+      { category: 'Best P6+', bps: 25 },
+      { category: 'Most Positions Gained', bps: 25 },
+      { category: 'Random Position Bonus (P4+)', bps: 75 },
+    ],
+  },
+  seasonBonus: {
+    title: 'Season Bonus',
+    totalBps: 700,
+    totalPercent: '7.0%',
+    rows: [
+      { category: 'Drivers Champion', bps: 150 },
+      { category: 'Most Race Wins', bps: 100 },
+      { category: 'Most Top-10 Finishes Outside Top 4', bps: 150 },
+      { category: 'Season Random Standing Position', bps: 200 },
+      { category: 'Biggest Single-Race Climb', bps: 100 },
+    ],
+  },
+};
+
+export const GUIDE_FAQ = [
+  {
+    question: 'Do I need to know F1 to play?',
+    answer: 'No. The app tracks race outcomes and payouts for you. If you understand bidding and simple risk/reward, you can compete.',
+  },
+  {
+    question: 'Can I win if I do not buy the top drivers?',
+    answer: 'Yes. Many categories reward value drivers and race-to-race movement, not only podium finishers.',
+  },
+  {
+    question: 'What happens on ties?',
+    answer: 'When multiple drivers tie for a category, the category payout is split evenly among tied winners. Any extra cents are distributed fairly by the split logic.',
+  },
+  {
+    question: 'When are results and payouts updated?',
+    answer: 'The admin syncs or enters results, then scoring runs and payouts appear in Events, Standings, and My Drivers.',
+  },
+  {
+    question: 'Can rules change mid-season?',
+    answer: 'Rules are managed by the admin. The live pool follows the current configured settings in the app.',
+  },
+];
+
+export const GUIDE_SECTION_LINKS = [
+  { id: 'what-is-calcutta', label: 'What Is a Calcutta' },
+  { id: 'auction-format', label: 'Auction Format' },
+  { id: 'payout-model', label: 'Payout Model' },
+  { id: 'season-bonus', label: 'Season Bonus' },
+  { id: 'faq', label: 'FAQ' },
+];

--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -439,6 +439,154 @@ button {
   margin-top: 0.7rem;
 }
 
+.join-guide-links {
+  display: flex;
+  align-items: center;
+}
+
+.join-guide-secondary {
+  margin: 0.15rem 0 0;
+}
+
+.join-guide-link-inline {
+  color: #d5b2b4;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.join-guide-link-inline:hover {
+  color: #e7cfd0;
+}
+
+.guide-page {
+  max-width: 980px;
+  margin: 0 auto;
+}
+
+.guide-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(200px, 250px);
+  gap: var(--space-4);
+  align-items: start;
+}
+
+.guide-hero-main {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.guide-hero-main p {
+  margin: 0;
+}
+
+.guide-section-nav {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.guide-section-link {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(11, 16, 23, 0.62);
+  border-radius: var(--radius-sm);
+  padding: 0.42rem 0.54rem;
+  color: #c4cedb;
+  font-size: var(--text-sm);
+  line-height: 1.2;
+}
+
+.guide-section-link:hover {
+  border-color: rgba(159, 63, 67, 0.45);
+  color: #eceff4;
+}
+
+.guide-section h2,
+.guide-section h3 {
+  margin: 0;
+}
+
+.guide-section p {
+  margin: 0;
+}
+
+.guide-list {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.38rem;
+}
+
+.guide-disclaimer {
+  margin: 0;
+}
+
+.guide-table-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--space-3);
+}
+
+.guide-table-panel {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.guide-table-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.guide-table-total {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  color: #c7d0dc;
+  font-size: var(--text-sm);
+}
+
+.guide-table-total strong {
+  color: #e9edf3;
+}
+
+.guide-note h3 {
+  margin: 0 0 0.25rem;
+}
+
+.guide-note p {
+  margin: 0;
+  color: #cdd6e1;
+}
+
+.guide-faq {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.guide-faq-item {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 17, 26, 0.66);
+  border-radius: var(--radius-sm);
+  padding: 0.62rem 0.68rem;
+}
+
+.guide-faq-item h3 {
+  margin: 0 0 0.25rem;
+}
+
+.guide-faq-item p {
+  margin: 0;
+}
+
+.guide-footer-cta {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.guide-footer-cta p {
+  margin: 0;
+}
+
 .admin-header p {
   margin: var(--space-2) 0 0;
   max-width: 56ch;
@@ -1671,6 +1819,14 @@ tbody tr:hover {
     overflow: visible;
     padding-right: 0;
   }
+
+  .guide-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .guide-section-nav {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
 }
 
 @media (max-width: 560px) {
@@ -1681,6 +1837,14 @@ tbody tr:hover {
 
   .join-hero-cards {
     grid-template-columns: repeat(2, minmax(120px, 1fr));
+  }
+
+  .guide-table-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .guide-section-nav {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/apps/f1/client/src/pages/Guide.jsx
+++ b/apps/f1/client/src/pages/Guide.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { GUIDE_EVENT_PAYOUTS, GUIDE_FAQ, GUIDE_SECTION_LINKS } from '../content/guideContent';
+
+const bpsToPercent = (bps) => `${(Number(bps || 0) / 100).toFixed(2)}%`;
+
+function PayoutTable({ title, totalBps, totalPercent, rows }) {
+  return (
+    <section className="panel guide-table-panel">
+      <div className="guide-table-head">
+        <h3>{title}</h3>
+        <div className="guide-table-total">
+          <span>{totalBps} bps</span>
+          <strong>{totalPercent}</strong>
+        </div>
+      </div>
+      <div className="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>BPS</th>
+              <th>% of Pot</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={`${title}-${row.category}`}>
+                <td>{row.category}</td>
+                <td>{row.bps}</td>
+                <td>{bpsToPercent(row.bps)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export default function Guide() {
+  return (
+    <div className="guide-page fade-in stack-lg">
+      <section className="panel panel-hero guide-hero">
+        <div className="guide-hero-main">
+          <div className="hero-kicker">Before You Join</div>
+          <h1>How F1 Calcutta Works</h1>
+          <p className="muted">
+            This guide explains what a Calcutta is, how the F1 auction runs, and exactly how race and season payouts are earned.
+          </p>
+          <div className="row wrap gap-sm">
+            <Link className="btn" to="/join">Join Pool</Link>
+            <Link className="btn btn-outline" to="/join">Admin Login</Link>
+          </div>
+          <p className="muted small">Admin login uses the Admin tab on the join screen.</p>
+        </div>
+        <nav className="guide-section-nav" aria-label="Guide sections">
+          {GUIDE_SECTION_LINKS.map((section) => (
+            <a key={section.id} href={`#${section.id}`} className="guide-section-link">
+              {section.label}
+            </a>
+          ))}
+        </nav>
+      </section>
+
+      <section id="what-is-calcutta" className="panel stack guide-section">
+        <h2>What Is a Calcutta?</h2>
+        <p>
+          A Calcutta is an auction-style pool. Instead of drafting teams, you bid real dollars on drivers.
+          Your winnings come from performance categories paid out of the shared auction purse.
+        </p>
+        <p className="muted">
+          In short: buy drivers you believe are undervalued, then earn payouts when they hit category outcomes.
+        </p>
+      </section>
+
+      <section id="auction-format" className="panel stack guide-section">
+        <h2>Auction Format in This App</h2>
+        <ul className="list guide-list">
+          <li>Drivers are auctioned live, one at a time.</li>
+          <li>Bids increase the current price until the bid clock expires.</li>
+          <li>Clock and grace-extension settings are controlled by the admin.</li>
+          <li>The final highest bidder owns that driver for the season.</li>
+          <li>When all drivers are sold, rosters lock and race payouts begin.</li>
+        </ul>
+      </section>
+
+      <section id="payout-model" className="stack guide-section">
+        <h2>Event Payout Model</h2>
+        <p className="muted guide-disclaimer">
+          Event payouts are percentages of the total auction pot. Random position bonuses use a non-podium draw (P4+).
+        </p>
+        <div className="guide-table-grid">
+          <PayoutTable {...GUIDE_EVENT_PAYOUTS.grandPrix} />
+          <PayoutTable {...GUIDE_EVENT_PAYOUTS.sprint} />
+        </div>
+        <section className="panel guide-note">
+          <h3>Tie Splits</h3>
+          <p>
+            If multiple drivers tie for a category, the category pot is split evenly among winners.
+            Split math handles cents fairly so total distributed amount stays accurate.
+          </p>
+        </section>
+      </section>
+
+      <section id="season-bonus" className="stack guide-section">
+        <h2>Season Bonus Model</h2>
+        <PayoutTable {...GUIDE_EVENT_PAYOUTS.seasonBonus} />
+      </section>
+
+      <section className="panel stack guide-section">
+        <h2>End-to-End Example</h2>
+        <p className="muted">
+          Example: if the pool pot is <strong>$600</strong>, a 50 bps category pays <strong>$3.00</strong> (0.50% of pot).
+          If your driver wins that category, that payout is credited to your totals.
+        </p>
+      </section>
+
+      <section id="faq" className="panel stack guide-section">
+        <h2>FAQ</h2>
+        <div className="guide-faq">
+          {GUIDE_FAQ.map((item) => (
+            <article key={item.question} className="guide-faq-item">
+              <h3>{item.question}</h3>
+              <p className="muted">{item.answer}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="panel panel-hero guide-footer-cta">
+        <h2>Ready to join?</h2>
+        <p className="muted">Live pool settings and race sync timing are controlled by the admin.</p>
+        <div className="row wrap gap-sm">
+          <Link className="btn" to="/join">Join Pool</Link>
+          <Link className="btn btn-outline" to="/join">Go to Login</Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/f1/client/src/pages/Join.jsx
+++ b/apps/f1/client/src/pages/Join.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 export default function Join() {
@@ -52,6 +53,9 @@ export default function Join() {
         <p>
           Own drivers, track every race weekend, and cash in on category payouts from the shared pool.
         </p>
+        <div className="join-guide-links">
+          <Link className="btn btn-outline" to="/guide">How It Works</Link>
+        </div>
         <div className="join-hero-cards">
           <div>
             <span className="label">Format</span>
@@ -136,6 +140,9 @@ export default function Join() {
           </form>
         )}
         {error ? <p className="error-text">{error}</p> : null}
+        <p className="small muted join-guide-secondary">
+          New here? <Link className="join-guide-link-inline" to="/guide">Read the F1 Calcutta guide</Link> before joining.
+        </p>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- add the `/guide` route, new content module, responsive styles, and CTA hooks so the public F1 landing page explains how the Calcutta works before joining
- refresh the payout summary copy so the distributed/undistributed boxes are gone, the rules read more straightforwardly, and the example pot uses $600

## Testing
- Not run (not requested)