### PR TITLE
Align F1 docs and admin tooling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,6 +44,7 @@ Both have:
 - Separate service per app.
 - Health endpoint: `/api/health`.
 - Persistent volume-backed SQLite paths via `DB_PATH`.
+- F1 may run an optional server-side result auto-poll loop when explicitly enabled.
 
 ## Runtime Reliability Requirements
 
@@ -61,6 +62,11 @@ Both have:
   - `persistence/repositories/*`
 - F1 `db.js` remains compatibility facade.
 - F1 admin routing decomposed into domain services.
+- F1 results ingestion uses a provider adapter:
+  - `mock` for local/dev/test
+  - `openf1` for real driver, schedule, and event-result data
+- F1 provider sync state is persisted in `provider_sync_state`.
+- F1 event scoring remains admin-triggered by default; optional auto-poll calls the same sync path and does not override manual edits.
 
 ## Evolution Model
 

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -22,30 +22,33 @@ Owner: On-call engineer / active implementer
 - Admin center is modularized (`useAdminData`, admin service modules, persistence split).
 - Scoring/payout engine tests passing.
 - Service shutdown path updated to avoid false-failure exits during orchestrator stop.
+- Results provider layer now supports OpenF1, admin-triggered driver/schedule refresh, and optional result auto-poll.
 
 ## Active Priorities
 
-1. Confirm Railway deploy health with new deployment IDs after shutdown hardening.
-2. Keep docs as single source of truth (no drift back into handoff files).
-3. Maintain strict app boundary discipline.
+1. Confirm Railway deploy health with `F1_RESULTS_PROVIDER=openf1` in production.
+2. Validate F1 driver and schedule refresh against live provider data before relying on event sync.
+3. Keep docs as single source of truth (no drift back into handoff files).
 
 ## Known Risks / Watch Items
 
 1. Railway logs can show historical deployment errors; always verify by deployment ID and timestamp.
-2. Startup/shutdown race conditions are sensitive to environment timing; monitor first deploy after changes.
-3. Shared package changes can cause silent cross-app impact if not scoped carefully.
+2. OpenF1 field stability now affects driver/event mapping; mismatches fail closed and require admin correction.
+3. Auto-poll should remain opt-in until one production verification pass is complete.
+4. Shared package changes can cause silent cross-app impact if not scoped carefully.
 
 ## Recent Completed Work
 
 1. Introduced docs control plane (`AGENTS`, `SOUL`, `HEARTBEAT`, `ARCHITECTURE`, `DESIGN`, `RUNBOOK`, ADRs).
 2. Converted handoff docs to compatibility stubs.
 3. Hardened NCAA/F1 shutdown behavior to avoid false deployment-failure exits.
+4. Added F1 OpenF1 provider integration with provider diagnostics, metadata refresh controls, and optional auto-poll.
 
 ## Next Suggested Actions
 
-1. Trigger one NCAA deploy and one F1 deploy, then verify stop/start logs for clean exits.
-2. Add follow-up ADR if additional Railway-specific behavior is discovered.
-3. Enforce docs update check in PR template (optional but recommended).
+1. Run one F1 deploy with `F1_RESULTS_PROVIDER=openf1`, then verify `/api/admin/results/provider-status`.
+2. Refresh F1 drivers and schedule once in admin, then confirm event mappings before syncing results.
+3. Add follow-up ADR if additional Railway-specific behavior is discovered.
 
 ## Update Protocol
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -32,7 +32,14 @@ Operational guide for deploying, validating, and recovering NCAA/F1 services.
 - `ADMIN_PASSWORD`
 - `NODE_ENV=production`
 - `DB_PATH=/data/f1-calcutta.db`
-- optional: `F1_CLIENT_ORIGIN`, `F1_RESULTS_PROVIDER`
+- optional: `F1_CLIENT_ORIGIN`, `F1_RESULTS_PROVIDER`, `F1_AUTO_POLL_ENABLED`, `F1_AUTO_POLL_INTERVAL_SECONDS`, `OPENF1_BASE_URL`
+
+## F1 Provider Defaults
+
+1. Production should use `F1_RESULTS_PROVIDER=openf1`.
+2. `mock` is intended for local/dev/test only.
+3. Do not set `F1_PORT` in Railway.
+4. Keep `F1_AUTO_POLL_ENABLED=0` until one successful manual OpenF1 verification pass is complete.
 
 ## Deploy Validation
 
@@ -70,6 +77,13 @@ After deploy:
 1. Verify volume attachment.
 2. Verify `DB_PATH` under `/data`.
 3. Verify no accidental path changes in config.
+
+### D) F1 Provider Sync Failing
+
+1. Check `GET /api/admin/results/provider-status`.
+2. Verify `F1_RESULTS_PROVIDER=openf1` in production.
+3. Run admin `Refresh Drivers` and `Refresh Schedule` before syncing event results.
+4. If provider responses are incomplete or unmapped, use manual results entry and do not force-score partial provider data.
 
 ## Rollback Procedure
 

--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -9,7 +9,7 @@ A dedicated Formula 1 Calcutta app for a full season pool.
 - Grand Prix and Sprint scoring categories
 - Auto-drawn random finishing position bonus per event
 - Season bonus payouts from remaining pool
-- Results sync via provider adapter (`mock` provider included)
+- Results sync via provider adapter (`openf1` for real data, `mock` for local/dev/test)
 - Admin controls for auction, sync, payout rules, and settings
 
 ## Run
@@ -28,8 +28,20 @@ Server: `http://localhost:3002`
 - `GET /api/events/:id/payouts`
 - `POST /api/admin/results/sync-next`
 - `POST /api/admin/results/sync-event/:id`
+- `POST /api/admin/results/refresh-drivers`
+- `POST /api/admin/results/refresh-schedule`
+- `GET /api/admin/results/provider-status`
 - `PATCH /api/admin/results/event/:id`
 - `PATCH /api/admin/payout-rules`
+
+## Runtime Notes
+
+- Production provider: `F1_RESULTS_PROVIDER=openf1`
+- Optional auto-poll:
+  - `F1_AUTO_POLL_ENABLED=1`
+  - `F1_AUTO_POLL_INTERVAL_SECONDS=<seconds>`
+- Local/dev/test may continue using `mock`
+- Admin Test Data page can load a 2025 OpenF1 driver/event dataset for pre-2026 flow testing
 
 ## Engineering Docs
 

--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -258,6 +258,11 @@ button {
   color: var(--text);
 }
 
+.btn-danger {
+  border-color: rgba(159, 63, 67, 0.62);
+  background: linear-gradient(135deg, #6a2628, #521a1d);
+}
+
 .panel {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 35%), var(--panel);
   border: 1px solid var(--border);
@@ -340,15 +345,26 @@ button {
 
 .join-live-pill {
   align-self: flex-start;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font-size: 0.68rem;
-  font-weight: 700;
   border: 1px solid rgba(159, 63, 67, 0.62);
   color: #d2a4a8;
   background: rgba(16, 21, 31, 0.74);
-  padding: 0.26rem 0.58rem;
+  padding: 0.3rem 0.58rem 0.34rem;
   border-radius: var(--radius-sm);
+  display: grid;
+  gap: 0.08rem;
+}
+
+.join-live-pill-label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.62rem;
+  font-weight: 700;
+}
+
+.join-live-pill-value {
+  font-size: 0.84rem;
+  color: #f0cfd2;
+  line-height: 1.1;
 }
 
 .join-title-accent {
@@ -1568,6 +1584,11 @@ tbody tr:hover {
   display: grid;
   gap: var(--space-3);
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.results-provider-grid .strip-item {
+  align-content: start;
+  min-height: 112px;
 }
 
 .bps-summary {

--- a/apps/f1/client/src/pages/Events.jsx
+++ b/apps/f1/client/src/pages/Events.jsx
@@ -98,14 +98,13 @@ export default function Events() {
     const now = Date.now();
     const enriched = events.map((event) => {
       const startsAtMs = toTimestampMs(event.starts_at);
-      const isUpcoming = startsAtMs != null && startsAtMs > now;
       const isScored = event.status === 'scored' || Number(event.result_count || 0) > 0;
+      const isUpcomingByClock = startsAtMs != null && startsAtMs > now;
       return {
         ...event,
         startsAtMs,
-        isUpcoming,
-        isPast: !isUpcoming,
         isScored,
+        isUpcomingByClock,
         displayLocation: getEventLocation(event.name),
       };
     });
@@ -115,16 +114,22 @@ export default function Events() {
     ));
 
     const upcomingEvents = sortedBySchedule
-      .filter((event) => event.isUpcoming)
+      .filter((event) => !event.isScored)
       .sort((a, b) => {
-        if (a.startsAtMs == null && b.startsAtMs == null) return 0;
+        const aFuture = a.startsAtMs != null && a.startsAtMs > now;
+        const bFuture = b.startsAtMs != null && b.startsAtMs > now;
+        if (aFuture !== bFuture) return aFuture ? -1 : 1;
+        if (a.startsAtMs == null && b.startsAtMs == null) {
+          return (a.round_number - b.round_number) || (typeOrder(a.type) - typeOrder(b.type));
+        }
         if (a.startsAtMs == null) return 1;
         if (b.startsAtMs == null) return -1;
-        return a.startsAtMs - b.startsAtMs;
+        if (a.startsAtMs !== b.startsAtMs) return a.startsAtMs - b.startsAtMs;
+        return (a.round_number - b.round_number) || (typeOrder(a.type) - typeOrder(b.type));
       });
 
     const pastEvents = sortedBySchedule
-      .filter((event) => !event.isUpcoming)
+      .filter((event) => event.isScored)
       .sort((a, b) => {
         if (a.startsAtMs == null && b.startsAtMs == null) {
           return (b.round_number - a.round_number) || (typeOrder(a.type) - typeOrder(b.type));
@@ -135,7 +140,7 @@ export default function Events() {
         return (b.round_number - a.round_number) || (typeOrder(a.type) - typeOrder(b.type));
       });
 
-    const nextUpcomingEvent = upcomingEvents[0] || null;
+    const nextUpcomingEvent = upcomingEvents.find((event) => event.isUpcomingByClock) || null;
     const mostRecentScoredEvent = [...pastEvents].find((event) => event.isScored) || null;
 
     const selectUpcomingWindow = (

--- a/apps/f1/client/src/pages/Join.jsx
+++ b/apps/f1/client/src/pages/Join.jsx
@@ -1,6 +1,20 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+
+const AUSTRALIAN_GP_START_ISO = '2026-02-22T04:00:00Z';
+
+function formatCountdown(targetMs, nowMs) {
+  const remainingMs = targetMs - nowMs;
+  if (!Number.isFinite(remainingMs) || remainingMs <= 0) return null;
+
+  const totalSeconds = Math.floor(remainingMs / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+
+  return `${days}d ${hours}h ${minutes}m`;
+}
 
 export default function Join() {
   const { join, adminLogin } = useAuth();
@@ -10,6 +24,17 @@ export default function Join() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [nowMs, setNowMs] = useState(Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  const countdownText = useMemo(() => {
+    const targetMs = Date.parse(AUSTRALIAN_GP_START_ISO);
+    return formatCountdown(targetMs, nowMs);
+  }, [nowMs]);
 
   const handleJoin = async (event) => {
     event.preventDefault();
@@ -45,7 +70,12 @@ export default function Join() {
         </div>
 
         <section className="join-hero">
-          <div className="join-live-pill">2026 Season Live</div>
+          {countdownText ? (
+            <div className="join-live-pill">
+              <span className="join-live-pill-label">Australian GP Countdown</span>
+              <strong className="join-live-pill-value">{countdownText}</strong>
+            </div>
+          ) : null}
           <h1>
             F1 Season
             <br />

--- a/apps/f1/client/src/pages/admin/ResultsPage.jsx
+++ b/apps/f1/client/src/pages/admin/ResultsPage.jsx
@@ -6,9 +6,17 @@ import {
 import AdminLoadingState from './AdminLoadingState';
 import useAdminOutletContext from './useAdminOutletContext';
 
+function stateLabel(state) {
+  if (!state?.status) return 'Not run';
+  return String(state.status).replace(/_/g, ' ');
+}
+
 export default function ResultsPage() {
   const {
     events,
+    providerStatus,
+    refreshDrivers,
+    refreshSchedule,
     syncNext,
     syncEvent,
     refresh,
@@ -32,6 +40,18 @@ export default function ResultsPage() {
           <h2>Results Sync</h2>
           <div className="row wrap gap-sm">
             <button
+              className="btn btn-outline"
+              onClick={() => runAndReload(() => refreshDrivers())}
+            >
+              Refresh Drivers
+            </button>
+            <button
+              className="btn btn-outline"
+              onClick={() => runAndReload(() => refreshSchedule())}
+            >
+              Refresh Schedule
+            </button>
+            <button
               className="btn"
               onClick={() => runAndReload(() => syncNext())}
             >
@@ -43,6 +63,39 @@ export default function ResultsPage() {
             >
               Advance Next (Force)
             </button>
+          </div>
+        </div>
+        <div className="grid-3 results-provider-grid">
+          <div className="strip-item">
+            <span className="label">Active Provider</span>
+            <strong>{providerStatus?.provider || 'unknown'}</strong>
+            <span className="muted small">
+              {providerStatus?.provider_info?.error || providerStatus?.provider_info?.baseUrl || providerStatus?.mode || '—'}
+            </span>
+          </div>
+          <div className="strip-item">
+            <span className="label">Driver Refresh</span>
+            <strong>{stateLabel(providerStatus?.last_driver_refresh)}</strong>
+            <span className="muted small">
+              {providerStatus?.last_driver_refresh?.message || 'No driver refresh recorded yet.'}
+            </span>
+          </div>
+          <div className="strip-item">
+            <span className="label">Schedule Refresh</span>
+            <strong>{stateLabel(providerStatus?.last_schedule_refresh)}</strong>
+            <span className="muted small">
+              {providerStatus?.last_schedule_refresh?.message || 'No schedule refresh recorded yet.'}
+            </span>
+          </div>
+          <div className="strip-item">
+            <span className="label">Auto Poll</span>
+            <strong>{providerStatus?.auto_poll?.enabled ? 'Enabled' : 'Disabled'}</strong>
+            <span className="muted small">
+              {providerStatus?.auto_poll?.message
+                || (providerStatus?.auto_poll?.enabled
+                  ? `Running every ${providerStatus?.auto_poll?.intervalSeconds || 0}s.`
+                  : 'Auto-poll is off.')}
+            </span>
           </div>
         </div>
         <ul className="list">

--- a/apps/f1/client/src/pages/admin/TestDataPage.jsx
+++ b/apps/f1/client/src/pages/admin/TestDataPage.jsx
@@ -34,6 +34,8 @@ export default function TestDataPage() {
   const {
     events,
     recalcSeasonBonuses,
+    clearAllTestData,
+    loadHistoricalSeasonData,
     refresh,
     setMessage,
     loading,
@@ -169,12 +171,78 @@ export default function TestDataPage() {
     }
   }, [selectedEventId, manualRows, setMessage, refresh, loadSeasonBonusBreakdown, loadManualEvent]);
 
+  const onClearAllTestData = useCallback(async () => {
+    const confirmed = window.confirm(
+      'Clear all F1 test data for the active season? This removes auction activity, non-admin participants, results, and payouts.'
+    );
+    if (!confirmed) return;
+
+    await clearAllTestData();
+    setSelectedEventId('');
+    setManualRows([]);
+    setManualMeta(null);
+    setBonusRows([]);
+    setBonusTotals([]);
+    await refresh();
+    await loadSeasonBonusBreakdown();
+  }, [clearAllTestData, refresh, loadSeasonBonusBreakdown]);
+
+  const onLoad2025Data = useCallback(async () => {
+    const confirmed = window.confirm(
+      'Load 2025 OpenF1 drivers and events into the active season for testing? This clears current auction data, results, payouts, and replaces the current season metadata.'
+    );
+    if (!confirmed) return;
+
+    await loadHistoricalSeasonData(2025);
+    setSelectedEventId('');
+    setManualRows([]);
+    setManualMeta(null);
+    setBonusRows([]);
+    setBonusTotals([]);
+    await refresh();
+    await loadSeasonBonusBreakdown();
+  }, [loadHistoricalSeasonData, refresh, loadSeasonBonusBreakdown]);
+
   if (loading && !hasLoaded) {
     return <AdminLoadingState />;
   }
 
   return (
     <div className="stack-lg">
+      <section className="panel note-panel stack">
+        <div className="row between wrap gap-sm">
+          <div className="stack-xs">
+            <h2>Load Historical Test Data</h2>
+            <p className="muted small">
+              Replaces the active season drivers and events with a 2025 OpenF1 dataset so you can test auction and payout flows before 2026 real data is complete.
+            </p>
+          </div>
+          <button
+            className="btn btn-outline"
+            onClick={onLoad2025Data}
+          >
+            Load 2025 Drivers + Events
+          </button>
+        </div>
+      </section>
+
+      <section className="panel note-panel stack">
+        <div className="row between wrap gap-sm">
+          <div className="stack-xs">
+            <h2>Reset Test Data</h2>
+            <p className="muted small">
+              Clears auction activity, non-admin participants, manual results, event payouts, season bonus payouts, and provider sync state for the active F1 season.
+            </p>
+          </div>
+          <button
+            className="btn btn-danger"
+            onClick={onClearAllTestData}
+          >
+            Clear All Test Data
+          </button>
+        </div>
+      </section>
+
       <section className="panel stack">
         <div className="row between wrap gap-sm">
           <h2>Manual Results Editor</h2>

--- a/apps/f1/client/src/pages/admin/adminApi.js
+++ b/apps/f1/client/src/pages/admin/adminApi.js
@@ -51,6 +51,42 @@ export async function syncNext({ force = false } = {}) {
   return parseApiResponse(response, 'Sync failed');
 }
 
+export async function readProviderStatus() {
+  return readApi('/admin/results/provider-status');
+}
+
+export async function refreshDrivers() {
+  const response = await api('/admin/results/refresh-drivers', {
+    method: 'POST',
+    body: '{}',
+  });
+  return parseApiResponse(response, 'Driver refresh failed');
+}
+
+export async function refreshSchedule() {
+  const response = await api('/admin/results/refresh-schedule', {
+    method: 'POST',
+    body: '{}',
+  });
+  return parseApiResponse(response, 'Schedule refresh failed');
+}
+
+export async function clearAllTestData() {
+  const response = await api('/admin/test-data/clear-all', {
+    method: 'POST',
+    body: '{}',
+  });
+  return parseApiResponse(response, 'Failed to clear test data');
+}
+
+export async function loadHistoricalSeasonData(year) {
+  const response = await api('/admin/test-data/load-openf1-year', {
+    method: 'POST',
+    body: JSON.stringify({ year }),
+  });
+  return parseApiResponse(response, 'Failed to load historical season data');
+}
+
 export async function syncEvent(eventId, { force = false } = {}) {
   const response = await api(`/admin/results/sync-event/${eventId}`, {
     method: 'POST',

--- a/apps/f1/client/src/pages/admin/useAdminData.js
+++ b/apps/f1/client/src/pages/admin/useAdminData.js
@@ -1,10 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  clearAllTestData as clearAllTestDataApi,
+  loadHistoricalSeasonData as loadHistoricalSeasonDataApi,
   normalizeRulesPayload,
   normalizeSettingsPayload,
   patchSettings,
   readApi,
+  readProviderStatus,
   recalcSeasonBonuses as recalcSeasonBonusesApi,
+  refreshDrivers as refreshDriversApi,
+  refreshSchedule as refreshScheduleApi,
   runAuctionAction as runAuctionActionApi,
   savePayoutRules,
   syncEvent as syncEventApi,
@@ -16,6 +21,7 @@ export default function useAdminData() {
   const [participants, setParticipants] = useState([]);
   const [events, setEvents] = useState([]);
   const [rules, setRules] = useState(null);
+  const [providerStatus, setProviderStatus] = useState(null);
   const [message, setMessage] = useState('');
   const [loading, setLoading] = useState(true);
   const [hasLoaded, setHasLoaded] = useState(false);
@@ -23,16 +29,18 @@ export default function useAdminData() {
   const loadAll = useCallback(async ({ silent = false } = {}) => {
     if (!silent) setLoading(true);
     try {
-      const [settingsData, participantsData, eventsData, rulesData] = await Promise.all([
+      const [settingsData, participantsData, eventsData, rulesData, providerStatusData] = await Promise.all([
         readApi('/admin/settings'),
         readApi('/admin/participants'),
         readApi('/events'),
         readApi('/admin/payout-rules'),
+        readProviderStatus(),
       ]);
       setSettings(settingsData);
       setParticipants(Array.isArray(participantsData) ? participantsData : []);
       setEvents(Array.isArray(eventsData) ? eventsData : []);
       setRules(rulesData);
+      setProviderStatus(providerStatusData);
       setHasLoaded(true);
     } catch (error) {
       setMessage(error.message || 'Failed to load admin data.');
@@ -90,6 +98,26 @@ export default function useAdminData() {
     }
   }, [loadAll]);
 
+  const refreshDrivers = useCallback(async () => {
+    try {
+      const result = await refreshDriversApi();
+      setMessage(result.message || 'Drivers refreshed.');
+      await loadAll({ silent: true });
+    } catch (error) {
+      setMessage(error.message || 'Driver refresh failed.');
+    }
+  }, [loadAll]);
+
+  const refreshSchedule = useCallback(async () => {
+    try {
+      const result = await refreshScheduleApi();
+      setMessage(result.message || 'Schedule refreshed.');
+      await loadAll({ silent: true });
+    } catch (error) {
+      setMessage(error.message || 'Schedule refresh failed.');
+    }
+  }, [loadAll]);
+
   const recalcSeasonBonuses = useCallback(async () => {
     try {
       await recalcSeasonBonusesApi();
@@ -97,6 +125,26 @@ export default function useAdminData() {
       await loadAll({ silent: true });
     } catch (error) {
       setMessage(error.message || 'Recalculation failed.');
+    }
+  }, [loadAll]);
+
+  const clearAllTestData = useCallback(async () => {
+    try {
+      const result = await clearAllTestDataApi();
+      setMessage(result.message || 'Test data cleared.');
+      await loadAll({ silent: true });
+    } catch (error) {
+      setMessage(error.message || 'Failed to clear test data.');
+    }
+  }, [loadAll]);
+
+  const loadHistoricalSeasonData = useCallback(async (year) => {
+    try {
+      const result = await loadHistoricalSeasonDataApi(year);
+      setMessage(result.message || `Loaded ${year} historical season data.`);
+      await loadAll({ silent: true });
+    } catch (error) {
+      setMessage(error.message || 'Failed to load historical season data.');
     }
   }, [loadAll]);
 
@@ -126,6 +174,7 @@ export default function useAdminData() {
     participants,
     events,
     rules,
+    providerStatus,
     message,
     loading,
     hasLoaded,
@@ -134,6 +183,10 @@ export default function useAdminData() {
     setMessage,
     saveSettings,
     runAuctionAction,
+    refreshDrivers,
+    refreshSchedule,
+    clearAllTestData,
+    loadHistoricalSeasonData,
     syncNext,
     syncEvent,
     recalcSeasonBonuses,
@@ -144,6 +197,7 @@ export default function useAdminData() {
     participants,
     events,
     rules,
+    providerStatus,
     message,
     loading,
     hasLoaded,
@@ -151,6 +205,10 @@ export default function useAdminData() {
     setField,
     saveSettings,
     runAuctionAction,
+    refreshDrivers,
+    refreshSchedule,
+    clearAllTestData,
+    loadHistoricalSeasonData,
     syncNext,
     syncEvent,
     recalcSeasonBonuses,

--- a/apps/f1/client/src/pages/admin/useAdminOutletContext.js
+++ b/apps/f1/client/src/pages/admin/useAdminOutletContext.js
@@ -6,6 +6,7 @@ import { useOutletContext } from 'react-router-dom';
  * @property {Array<Object>} participants
  * @property {Array<Object>} events
  * @property {Object|null} rules
+ * @property {Object|null} providerStatus
  * @property {string} message
  * @property {boolean} loading
  * @property {boolean} hasLoaded
@@ -14,6 +15,10 @@ import { useOutletContext } from 'react-router-dom';
  * @property {(value: string) => void} setMessage
  * @property {() => Promise<void>} saveSettings
  * @property {(endpoint: string) => Promise<void>} runAuctionAction
+ * @property {() => Promise<void>} refreshDrivers
+ * @property {() => Promise<void>} refreshSchedule
+ * @property {() => Promise<void>} clearAllTestData
+ * @property {(year: number) => Promise<void>} loadHistoricalSeasonData
  * @property {(options?: {force?: boolean}) => Promise<void>} syncNext
  * @property {(eventId: number, options?: {force?: boolean}) => Promise<void>} syncEvent
  * @property {() => Promise<void>} recalcSeasonBonuses

--- a/apps/f1/server/db.js
+++ b/apps/f1/server/db.js
@@ -7,6 +7,7 @@ const seasonRepo = require('./persistence/repositories/seasonRepo');
 const auctionRepo = require('./persistence/repositories/auctionRepo');
 const eventRepo = require('./persistence/repositories/eventRepo');
 const standingsRepo = require('./persistence/repositories/standingsRepo');
+const providerSyncRepo = require('./persistence/repositories/providerSyncRepo');
 
 function init() {
   ensureSchema(db);
@@ -118,6 +119,14 @@ function getEventPayouts(seasonId, eventId) {
   return eventRepo.getEventPayouts(db, seasonId, eventId);
 }
 
+function getProviderSyncStates(seasonId) {
+  return providerSyncRepo.getProviderSyncStates(db, seasonId);
+}
+
+function upsertProviderSyncState(seasonId, scope, payload) {
+  return providerSyncRepo.upsertProviderSyncState(db, seasonId, scope, payload);
+}
+
 module.exports = {
   db,
   init,
@@ -145,4 +154,6 @@ module.exports = {
   getEventPayoutRules,
   getSeasonBonusRules,
   getEventPayouts,
+  getProviderSyncStates,
+  upsertProviderSyncState,
 };

--- a/apps/f1/server/index.js
+++ b/apps/f1/server/index.js
@@ -15,6 +15,7 @@ const cors = require('cors');
 const { init } = require('./db');
 const { setupSocket } = require('./socket');
 const { createAuctionService } = require('./services/auctionService');
+const { createResultsAutoPollService } = require('./services/resultsAutoPollService');
 const { createResultsProvider } = require('./providers');
 const { rescoreSeasonEvents } = require('./services/scoringService');
 
@@ -62,7 +63,11 @@ const initResult = init();
 const auctionService = createAuctionService(io);
 auctionService.restoreTimerOnStartup();
 app.set('auctionService', auctionService);
-app.set('resultsProvider', createResultsProvider());
+const resultsProvider = createResultsProvider();
+app.set('resultsProvider', resultsProvider);
+const resultsAutoPollService = createResultsAutoPollService({ provider: resultsProvider, io });
+resultsAutoPollService.start();
+app.set('resultsAutoPollService', resultsAutoPollService);
 setupSocket(io, auctionService);
 
 if (initResult?.payoutModelMigrated || initResult?.payoutRandomAdjusted) {
@@ -89,6 +94,7 @@ let forceExitTimer = null;
 function shutdown(signal) {
   if (isShuttingDown) return;
   isShuttingDown = true;
+  resultsAutoPollService.stop();
 
   console.log(`[shutdown] Received ${signal}, closing server...`);
 

--- a/apps/f1/server/persistence/repositories/providerSyncRepo.js
+++ b/apps/f1/server/persistence/repositories/providerSyncRepo.js
@@ -1,0 +1,36 @@
+function getProviderSyncStates(db, seasonId) {
+  return db.prepare(`
+    SELECT season_id, scope, provider, status, message, meta_json, updated_at
+    FROM provider_sync_state
+    WHERE season_id = ?
+    ORDER BY scope ASC
+  `).all(seasonId);
+}
+
+function upsertProviderSyncState(db, seasonId, scope, payload) {
+  const metaJson = payload?.meta ? JSON.stringify(payload.meta) : null;
+  db.prepare(`
+    INSERT INTO provider_sync_state
+      (season_id, scope, provider, status, message, meta_json, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(season_id, scope) DO UPDATE SET
+      provider = excluded.provider,
+      status = excluded.status,
+      message = excluded.message,
+      meta_json = excluded.meta_json,
+      updated_at = excluded.updated_at
+  `).run(
+    seasonId,
+    scope,
+    String(payload?.provider || 'unknown'),
+    String(payload?.status || 'unknown'),
+    payload?.message || null,
+    metaJson,
+    Number(payload?.updated_at) || Date.now(),
+  );
+}
+
+module.exports = {
+  getProviderSyncStates,
+  upsertProviderSyncState,
+};

--- a/apps/f1/server/persistence/schema.js
+++ b/apps/f1/server/persistence/schema.js
@@ -159,6 +159,17 @@ function ensureSchema(db) {
       tie_count INTEGER NOT NULL DEFAULT 1,
       created_at INTEGER NOT NULL DEFAULT (unixepoch())
     );
+
+    CREATE TABLE IF NOT EXISTS provider_sync_state (
+      season_id INTEGER NOT NULL REFERENCES seasons(id),
+      scope TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      status TEXT NOT NULL,
+      message TEXT,
+      meta_json TEXT,
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      PRIMARY KEY (season_id, scope)
+    );
   `);
 
   if (!columnExists(db, 'seasons', 'payout_model_version')) {

--- a/apps/f1/server/providers/index.js
+++ b/apps/f1/server/providers/index.js
@@ -1,11 +1,31 @@
 const { MockResultsProvider } = require('./mockResultsProvider');
+const { OpenF1ResultsProvider } = require('./openF1ResultsProvider');
+const { UnsupportedResultsProvider } = require('./unsupportedResultsProvider');
 
 function createResultsProvider() {
-  const provider = process.env.F1_RESULTS_PROVIDER || 'mock';
-  if (provider !== 'mock') {
-    console.warn(`[results provider] Unsupported provider "${provider}" configured. Falling back to mock.`);
+  const provider = process.env.F1_RESULTS_PROVIDER
+    || (process.env.NODE_ENV === 'production' ? 'openf1' : 'mock');
+
+  if (provider === 'mock') {
+    if (process.env.NODE_ENV === 'production') {
+      return new UnsupportedResultsProvider({
+        providerName: provider,
+        reason: 'Mock provider is disabled in production. Configure F1_RESULTS_PROVIDER=openf1.',
+      });
+    }
+    return new MockResultsProvider();
   }
-  return new MockResultsProvider();
+
+  if (provider === 'openf1') {
+    return new OpenF1ResultsProvider({
+      baseUrl: process.env.OPENF1_BASE_URL,
+    });
+  }
+
+  return new UnsupportedResultsProvider({
+    providerName: provider,
+    reason: `Unsupported results provider "${provider}" configured.`,
+  });
 }
 
 module.exports = { createResultsProvider };

--- a/apps/f1/server/providers/mockResultsProvider.js
+++ b/apps/f1/server/providers/mockResultsProvider.js
@@ -7,6 +7,10 @@ function seededHash(input) {
 }
 
 class MockResultsProvider {
+  constructor() {
+    this.name = 'mock';
+  }
+
   async fetchDrivers() {
     return DRIVERS_2026;
   }
@@ -40,6 +44,13 @@ class MockResultsProvider {
       finish_position: idx + 1,
       start_position: startPos.get(driver.external_id),
     }));
+  }
+
+  getStatus() {
+    return {
+      provider: this.name,
+      mode: 'mock',
+    };
   }
 }
 

--- a/apps/f1/server/providers/openF1ResultsProvider.js
+++ b/apps/f1/server/providers/openF1ResultsProvider.js
@@ -1,0 +1,240 @@
+const DEFAULT_BASE_URL = 'https://api.openf1.org/v1';
+const EVENT_NAME_OVERRIDES = {
+  melbourne: 'Australian Grand Prix',
+  shanghai: 'Chinese Grand Prix',
+  suzuka: 'Japanese Grand Prix',
+  sakhir: 'Bahrain Grand Prix',
+  jeddah: 'Saudi Arabian Grand Prix',
+  'miami gardens': 'Miami Grand Prix',
+  'monte carlo': 'Monaco Grand Prix',
+  barcelona: 'Spanish Grand Prix',
+  spielberg: 'Austrian Grand Prix',
+  silverstone: 'British Grand Prix',
+  spa: 'Belgian Grand Prix',
+  'spa-francorchamps': 'Belgian Grand Prix',
+  budapest: 'Hungarian Grand Prix',
+  zandvoort: 'Dutch Grand Prix',
+  monza: 'Italian Grand Prix',
+  madrid: 'Spanish Grand Prix',
+  baku: 'Azerbaijan Grand Prix',
+  'marina bay': 'Singapore Grand Prix',
+  austin: 'United States Grand Prix',
+  'mexico city': 'Mexico City Grand Prix',
+  'sao paulo': 'Sao Paulo Grand Prix',
+  'são paulo': 'Sao Paulo Grand Prix',
+  'las vegas': 'Las Vegas Grand Prix',
+  lusail: 'Qatar Grand Prix',
+  'yas marina': 'Abu Dhabi Grand Prix',
+  'yas marina circuit': 'Abu Dhabi Grand Prix',
+  montreal: 'Canadian Grand Prix',
+  'montréal': 'Canadian Grand Prix',
+};
+
+function normalizeBaseUrl(baseUrl) {
+  return String(baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '');
+}
+
+function parseIsoDate(value) {
+  const iso = String(value || '');
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+}
+
+function subtractMinutes(iso, minutes) {
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms - (minutes * 60 * 1000)).toISOString();
+}
+
+function normalizeSessionType(sessionName) {
+  if (sessionName === 'Race') return 'grand_prix';
+  if (sessionName === 'Sprint') return 'sprint';
+  return null;
+}
+
+function canonicalGrandPrixName(session) {
+  const candidates = [
+    session?.meeting_name,
+    session?.location,
+    session?.circuit_short_name,
+  ];
+
+  for (const candidate of candidates) {
+    const key = String(candidate || '').trim().toLowerCase();
+    if (key && EVENT_NAME_OVERRIDES[key]) {
+      return EVENT_NAME_OVERRIDES[key];
+    }
+  }
+
+  const country = String(session?.country_name || '').trim();
+  if (country === 'United States') return 'United States Grand Prix';
+  if (country === 'Saudi Arabia') return 'Saudi Arabian Grand Prix';
+  if (country) return `${country} Grand Prix`;
+  return 'Grand Prix';
+}
+
+function buildEventName(session, eventType) {
+  const base = canonicalGrandPrixName(session);
+  if (!base) return eventType === 'sprint' ? 'Sprint' : 'Grand Prix';
+  return eventType === 'sprint' ? `${base} (Sprint)` : base;
+}
+
+class OpenF1ResultsProvider {
+  constructor({ baseUrl = DEFAULT_BASE_URL, fetchImpl = global.fetch } = {}) {
+    this.name = 'openf1';
+    this.baseUrl = normalizeBaseUrl(baseUrl);
+    this.fetchImpl = fetchImpl;
+  }
+
+  async request(path, params = {}) {
+    if (typeof this.fetchImpl !== 'function') {
+      throw new Error('Fetch is unavailable in this runtime');
+    }
+
+    const url = new URL(`${this.baseUrl}${path}`);
+    Object.entries(params).forEach(([key, value]) => {
+      if (value === undefined || value === null || value === '') return;
+      url.searchParams.set(key, String(value));
+    });
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+    try {
+      const response = await this.fetchImpl(url, {
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`OpenF1 request failed (${response.status})`);
+      }
+
+      const data = await response.json();
+      return Array.isArray(data) ? data : [];
+    } catch (error) {
+      if (error?.name === 'AbortError') {
+        throw new Error('OpenF1 request timed out');
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  async fetchSeasonSessions({ year }) {
+    const sessions = await this.request('/sessions', { year });
+    return sessions
+      .map((session) => ({
+        ...session,
+        starts_at: parseIsoDate(session.date_start),
+        event_type: normalizeSessionType(session.session_name),
+      }))
+      .filter((session) => session.event_type && session.starts_at)
+      .sort((a, b) => Date.parse(a.starts_at) - Date.parse(b.starts_at));
+  }
+
+  async fetchDrivers({ year }) {
+    const allSessions = await this.request('/sessions', { year });
+    const startedSessions = allSessions
+      .map((session) => ({
+        ...session,
+        starts_at: parseIsoDate(session.date_start),
+      }))
+      .filter((session) => session.starts_at && Date.parse(session.starts_at) <= Date.now())
+      .sort((a, b) => Date.parse(a.starts_at) - Date.parse(b.starts_at));
+
+    const sourceSession = startedSessions[startedSessions.length - 1];
+    if (!sourceSession?.session_key) {
+      throw new Error(`OpenF1 has no started sessions yet for ${year}`);
+    }
+
+    const drivers = await this.request('/drivers', { session_key: sourceSession.session_key });
+    const deduped = new Map();
+
+    drivers.forEach((driver) => {
+      const externalId = Number(driver.driver_number);
+      if (!Number.isFinite(externalId)) return;
+      deduped.set(externalId, {
+        external_id: externalId,
+        code: String(driver.name_acronym || '').trim(),
+        name: String(driver.full_name || '').trim(),
+        team_name: String(driver.team_name || '').trim(),
+      });
+    });
+
+    return [...deduped.values()].sort((a, b) => a.external_id - b.external_id);
+  }
+
+  async fetchSeasonSchedule({ year }) {
+    const sessions = await this.fetchSeasonSessions({ year });
+    const meetingRoundMap = new Map();
+    let nextRound = 1;
+
+    return sessions.map((session) => {
+      const meetingKey = String(session.meeting_key || '');
+      if (!meetingRoundMap.has(meetingKey)) {
+        meetingRoundMap.set(meetingKey, nextRound);
+        nextRound += 1;
+      }
+
+      return ({
+      external_event_id: String(session.session_key),
+      round_number: meetingRoundMap.get(meetingKey),
+      name: buildEventName(session, session.event_type),
+      type: session.event_type,
+      starts_at: session.starts_at,
+      lock_at: subtractMinutes(session.starts_at, 10),
+      meeting_key: session.meeting_key,
+      location: session.location || null,
+      country_name: session.country_name || null,
+      meeting_name: session.meeting_name || null,
+      });
+    });
+  }
+
+  async fetchEventResults({ event }) {
+    const sessionKey = Number(event?.external_event_id);
+    if (!Number.isFinite(sessionKey)) {
+      throw new Error(`Event ${event?.id || ''} is missing an OpenF1 session key`);
+    }
+
+    const [sessionResults, startingGrid] = await Promise.all([
+      this.request('/session_result', { session_key: sessionKey }),
+      this.request('/starting_grid', { session_key: sessionKey }),
+    ]);
+
+    const gridByDriver = new Map(
+      startingGrid.map((row) => [Number(row.driver_number), Number(row.position) || null])
+    );
+
+    const rows = sessionResults
+      .map((row) => ({
+        external_driver_id: Number(row.driver_number),
+        finish_position: Number(row.position),
+        start_position: gridByDriver.get(Number(row.driver_number)) ?? null,
+      }))
+      .filter((row) => Number.isFinite(row.external_driver_id) && Number.isFinite(row.finish_position) && row.finish_position > 0)
+      .sort((a, b) => a.finish_position - b.finish_position);
+
+    if (!rows.length) {
+      throw new Error(`OpenF1 returned no classified results for session ${sessionKey}`);
+    }
+
+    return rows;
+  }
+
+  getStatus() {
+    return {
+      provider: this.name,
+      baseUrl: this.baseUrl,
+    };
+  }
+}
+
+module.exports = {
+  OpenF1ResultsProvider,
+  buildEventName,
+  normalizeSessionType,
+  canonicalGrandPrixName,
+};

--- a/apps/f1/server/providers/unsupportedResultsProvider.js
+++ b/apps/f1/server/providers/unsupportedResultsProvider.js
@@ -1,0 +1,27 @@
+class UnsupportedResultsProvider {
+  constructor({ providerName, reason }) {
+    this.name = providerName || 'unsupported';
+    this.reason = reason || `Unsupported provider "${providerName}"`;
+  }
+
+  async fetchDrivers() {
+    throw new Error(this.reason);
+  }
+
+  async fetchSeasonSchedule() {
+    throw new Error(this.reason);
+  }
+
+  async fetchEventResults() {
+    throw new Error(this.reason);
+  }
+
+  getStatus() {
+    return {
+      provider: this.name,
+      error: this.reason,
+    };
+  }
+}
+
+module.exports = { UnsupportedResultsProvider };

--- a/apps/f1/server/routes/admin.js
+++ b/apps/f1/server/routes/admin.js
@@ -6,6 +6,7 @@ const { requireAuth, requireAdmin } = require('./middleware');
 const auctionAdminService = require('../services/admin/auctionAdminService');
 const payoutRulesAdminService = require('../services/admin/payoutRulesAdminService');
 const resultsAdminService = require('../services/admin/resultsAdminService');
+const { OpenF1ResultsProvider } = require('../providers/openF1ResultsProvider');
 const {
   parseForceFlag,
   parseIntegerParam,
@@ -125,6 +126,54 @@ router.post('/results/sync-next', withAdmin, async (req, res) => {
     io: req.app.get('io'),
     force: parseForceFlag(req),
   });
+  return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
+});
+
+router.get('/results/provider-status', withAdmin, (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const provider = req.app.get('resultsProvider');
+  const autoPollService = req.app.get('resultsAutoPollService');
+  return res.json(resultsAdminService.getProviderStatus({
+    seasonId,
+    provider,
+    autoPollService,
+  }));
+});
+
+router.post('/test-data/clear-all', withAdmin, (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const result = resultsAdminService.clearTestDataForSeason({
+    seasonId,
+    io: req.app.get('io'),
+    auctionService: req.app.get('auctionService'),
+  });
+  return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
+});
+
+router.post('/test-data/load-openf1-year', withAdmin, async (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const provider = new OpenF1ResultsProvider({ baseUrl: process.env.OPENF1_BASE_URL });
+  const result = await resultsAdminService.loadHistoricalSeasonMetadata({
+    seasonId,
+    provider,
+    year: req.body?.year,
+    io: req.app.get('io'),
+    auctionService: req.app.get('auctionService'),
+  });
+  return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
+});
+
+router.post('/results/refresh-drivers', withAdmin, async (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const provider = req.app.get('resultsProvider');
+  const result = await resultsAdminService.refreshDriversFromProvider({ seasonId, provider });
+  return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
+});
+
+router.post('/results/refresh-schedule', withAdmin, async (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const provider = req.app.get('resultsProvider');
+  const result = await resultsAdminService.refreshScheduleFromProvider({ seasonId, provider });
   return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
 });
 

--- a/apps/f1/server/services/admin/resultsAdminService.js
+++ b/apps/f1/server/services/admin/resultsAdminService.js
@@ -1,8 +1,12 @@
 const {
   db,
+  getSeason,
   getDrivers,
+  getEvents,
   getEventById,
   getEventResults,
+  getProviderSyncStates,
+  upsertProviderSyncState,
 } = require('../../db');
 const {
   scoreEvent,
@@ -11,6 +15,51 @@ const {
   syncEventFromProvider,
   syncNextEventFromProvider,
 } = require('../scoringService');
+
+function normalizeText(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function normalizeEventBaseName(value) {
+  return normalizeText(value).replace(/\s*\(sprint\)\s*/g, '');
+}
+
+function providerEventMatchKey(event) {
+  return `${Number(event.round_number) || 0}::${event.type}`;
+}
+
+function parseStateRow(row) {
+  let meta = {};
+  if (row?.meta_json) {
+    try {
+      meta = JSON.parse(row.meta_json);
+    } catch {
+      meta = {};
+    }
+  }
+
+  return {
+    scope: row.scope,
+    provider: row.provider,
+    status: row.status,
+    message: row.message,
+    updated_at: row.updated_at,
+    ...meta,
+  };
+}
+
+function saveProviderState(seasonId, scope, providerName, status, message, meta) {
+  upsertProviderSyncState(seasonId, scope, {
+    provider: providerName,
+    status,
+    message,
+    meta,
+  });
+}
+
+function getProviderName(provider) {
+  return provider?.name || 'unknown';
+}
 
 function syncNextResults({ seasonId, provider, io, force = false }) {
   return syncNextEventFromProvider({
@@ -30,6 +79,445 @@ function syncEventResults({ seasonId, eventId, provider, io, force = false }) {
     io,
     ignoreLock: force,
   });
+}
+
+async function refreshDriversFromProvider({ seasonId, provider }) {
+  const providerName = getProviderName(provider);
+  const season = getSeason(seasonId);
+  if (!season) return { ok: false, status: 404, error: 'Season not found' };
+
+  try {
+    const providerDrivers = await provider.fetchDrivers({ year: season.year });
+    if (!providerDrivers.length) {
+      saveProviderState(seasonId, 'drivers', providerName, 'error', 'Provider returned no drivers.');
+      return { ok: false, status: 502, error: 'Provider returned no drivers' };
+    }
+
+    const seasonDrivers = getDrivers(seasonId);
+    const byCode = new Map(seasonDrivers.map((driver) => [normalizeText(driver.code), driver]));
+    const byName = new Map(seasonDrivers.map((driver) => [normalizeText(driver.name), driver]));
+    const matched = [];
+    const matchedIds = new Set();
+    const targetExternalIds = new Set();
+    const unmappedProvider = [];
+
+    providerDrivers.forEach((providerDriver) => {
+      const codeKey = normalizeText(providerDriver.code);
+      const nameKey = normalizeText(providerDriver.name);
+      const match = (
+        (codeKey && byCode.get(codeKey) && !matchedIds.has(byCode.get(codeKey).id) && byCode.get(codeKey))
+        || (nameKey && byName.get(nameKey) && !matchedIds.has(byName.get(nameKey).id) && byName.get(nameKey))
+      );
+
+      if (!match) {
+        unmappedProvider.push(providerDriver.name || providerDriver.code || 'Unknown driver');
+        return;
+      }
+
+      if (targetExternalIds.has(providerDriver.external_id)) {
+        unmappedProvider.push(providerDriver.name || providerDriver.code || 'Duplicate external id');
+        return;
+      }
+
+      targetExternalIds.add(providerDriver.external_id);
+      matchedIds.add(match.id);
+      matched.push({ existing: match, provider: providerDriver });
+    });
+
+    const unmatchedSeason = seasonDrivers
+      .filter((driver) => !matchedIds.has(driver.id))
+      .map((driver) => driver.name);
+
+    if (unmappedProvider.length || unmatchedSeason.length) {
+      const message = `Driver mapping failed. Provider unmatched: ${unmappedProvider.length}. Season unmatched: ${unmatchedSeason.length}.`;
+      saveProviderState(seasonId, 'drivers', providerName, 'error', message, {
+        unmappedProvider,
+        unmatchedSeason,
+      });
+      return { ok: false, status: 400, error: message };
+    }
+
+    const update = db.prepare(`
+      UPDATE drivers
+      SET external_id = ?, code = ?, name = ?, team_name = ?
+      WHERE id = ?
+    `);
+    const clearExternalId = db.prepare(`
+      UPDATE drivers
+      SET external_id = NULL
+      WHERE id = ?
+    `);
+
+    db.transaction(() => {
+      matched.forEach(({ existing }) => {
+        clearExternalId.run(existing.id);
+      });
+      matched.forEach(({ existing, provider: providerDriver }) => {
+        update.run(
+          providerDriver.external_id,
+          providerDriver.code,
+          providerDriver.name,
+          providerDriver.team_name,
+          existing.id,
+        );
+      });
+    })();
+
+    const message = `Refreshed ${matched.length} drivers from ${providerName}.`;
+    saveProviderState(seasonId, 'drivers', providerName, 'success', message, {
+      count: matched.length,
+    });
+    return { ok: true, count: matched.length, message };
+  } catch (error) {
+    saveProviderState(seasonId, 'drivers', providerName, 'error', error.message || 'Driver refresh failed');
+    return { ok: false, status: 502, error: error.message || 'Driver refresh failed' };
+  }
+}
+
+async function refreshScheduleFromProvider({ seasonId, provider }) {
+  const providerName = getProviderName(provider);
+  const season = getSeason(seasonId);
+  if (!season) return { ok: false, status: 404, error: 'Season not found' };
+
+  try {
+    const providerEvents = await provider.fetchSeasonSchedule({ year: season.year });
+    if (!providerEvents.length) {
+      saveProviderState(seasonId, 'schedule', providerName, 'error', 'Provider returned no schedule events.');
+      return { ok: false, status: 502, error: 'Provider returned no schedule events' };
+    }
+
+    const existingEvents = getEvents(seasonId);
+    const eventMapByRound = new Map(
+      existingEvents.map((event) => [providerEventMatchKey(event), event])
+    );
+    const eventMapByName = new Map(
+      existingEvents.map((event) => [`${normalizeEventBaseName(event.name)}::${event.type}`, event])
+    );
+
+    const updateEvent = db.prepare(`
+      UPDATE events
+      SET external_event_id = ?,
+          name = ?,
+          starts_at = ?,
+          lock_at = ?
+      WHERE id = ?
+    `);
+    const insertEvent = db.prepare(`
+      INSERT INTO events
+        (season_id, external_event_id, round_number, name, type, starts_at, lock_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+    const deleteEvent = db.prepare('DELETE FROM events WHERE id = ?');
+
+    const updates = [];
+    const inserts = [];
+    const unmatchedProvider = [];
+    const matchedExistingIds = new Set();
+
+    providerEvents.forEach((providerEvent) => {
+      const roundKey = providerEventMatchKey(providerEvent);
+      const nameKey = `${normalizeEventBaseName(providerEvent.name)}::${providerEvent.type}`;
+      const existing = eventMapByRound.get(roundKey) || eventMapByName.get(nameKey);
+      if (!existing) {
+        if (Number.isFinite(Number(providerEvent.round_number)) && providerEvent.type) {
+          inserts.push(providerEvent);
+        } else {
+          unmatchedProvider.push(providerEvent.name);
+        }
+        return;
+      }
+      matchedExistingIds.add(existing.id);
+      updates.push({ existing, provider: providerEvent });
+    });
+
+    const removableExisting = existingEvents.filter((event) => (
+      !matchedExistingIds.has(event.id)
+      && event.status !== 'scored'
+      && Number(event.result_count || 0) === 0
+      && Number(event.total_payout_cents || 0) === 0
+    ));
+    const retainedExisting = existingEvents.filter((event) => (
+      !matchedExistingIds.has(event.id)
+      && !removableExisting.some((candidate) => candidate.id === event.id)
+    ));
+
+    db.transaction(() => {
+      updates.forEach(({ existing, provider: providerEvent }) => {
+        updateEvent.run(
+          providerEvent.external_event_id,
+          providerEvent.name,
+          providerEvent.starts_at,
+          providerEvent.lock_at,
+          existing.id,
+        );
+      });
+      inserts.forEach((providerEvent) => {
+        insertEvent.run(
+          seasonId,
+          providerEvent.external_event_id,
+          providerEvent.round_number,
+          providerEvent.name,
+          providerEvent.type,
+          providerEvent.starts_at,
+          providerEvent.lock_at,
+        );
+      });
+      removableExisting.forEach((event) => {
+        deleteEvent.run(event.id);
+      });
+    })();
+
+    const warningParts = [];
+    if (unmatchedProvider.length) {
+      warningParts.push(`${unmatchedProvider.length} provider events were not matched`);
+    }
+    if (retainedExisting.length) {
+      warningParts.push(`${retainedExisting.length} existing events were retained because they already contain results or payouts`);
+    }
+    const status = warningParts.length ? 'warning' : 'success';
+    const message = warningParts.length
+      ? `Refreshed ${updates.length + inserts.length} schedule events from ${providerName}; removed ${removableExisting.length} stale events. ${warningParts.join('. ')}.`
+      : `Refreshed ${updates.length + inserts.length} schedule events from ${providerName}.`;
+
+    saveProviderState(seasonId, 'schedule', providerName, status, message, {
+      count: updates.length + inserts.length,
+      insertedCount: inserts.length,
+      removedCount: removableExisting.length,
+      retainedExisting: retainedExisting.map((event) => event.name),
+      unmatchedProvider,
+    });
+
+    return {
+      ok: true,
+      count: updates.length + inserts.length,
+      insertedCount: inserts.length,
+      removedCount: removableExisting.length,
+      unmatchedCount: unmatchedProvider.length,
+      message,
+    };
+  } catch (error) {
+    saveProviderState(seasonId, 'schedule', providerName, 'error', error.message || 'Schedule refresh failed');
+    return { ok: false, status: 502, error: error.message || 'Schedule refresh failed' };
+  }
+}
+
+function getProviderStatus({ seasonId, provider, autoPollService }) {
+  const stateRows = getProviderSyncStates(seasonId).map(parseStateRow);
+  const states = Object.fromEntries(stateRows.map((row) => [row.scope, row]));
+  const providerInfo = typeof provider?.getStatus === 'function' ? provider.getStatus() : {};
+  const autoPollInfo = typeof autoPollService?.getStatus === 'function' ? autoPollService.getStatus() : null;
+
+  return {
+    provider: getProviderName(provider),
+    mode: process.env.NODE_ENV || 'development',
+    provider_info: providerInfo,
+    last_driver_refresh: states.drivers || null,
+    last_schedule_refresh: states.schedule || null,
+    auto_poll: {
+      ...(states.auto_poll || {}),
+      ...(autoPollInfo || {}),
+    },
+  };
+}
+
+function clearTestDataForSeason({ seasonId, io, auctionService }) {
+  const season = getSeason(seasonId);
+  if (!season) return { ok: false, status: 404, error: 'Season not found' };
+
+  if (typeof auctionService?.clearActiveTimer === 'function') {
+    auctionService.clearActiveTimer();
+  }
+
+  const participantIds = db.prepare(`
+    SELECT id
+    FROM participants
+    WHERE is_admin = 0
+      AND id IN (
+        SELECT participant_id
+        FROM season_participants
+        WHERE season_id = ?
+      )
+  `).all(seasonId).map((row) => row.id);
+
+  const eventIds = getEvents(seasonId).map((event) => event.id);
+
+  db.transaction(() => {
+    db.prepare(`
+      UPDATE seasons
+      SET auction_status = 'waiting',
+          season_random_bonus_position = NULL,
+          season_random_bonus_drawn_at = NULL
+      WHERE id = ?
+    `).run(seasonId);
+
+    db.prepare(`
+      UPDATE auction_items
+      SET status = 'pending',
+          current_price_cents = 0,
+          current_leader_id = NULL,
+          bid_end_time = NULL,
+          final_price_cents = NULL,
+          winner_id = NULL
+      WHERE season_id = ?
+    `).run(seasonId);
+
+    db.prepare(`
+      UPDATE events
+      SET status = 'pending',
+          random_bonus_position = NULL,
+          random_bonus_drawn_at = NULL,
+          synced_at = NULL
+      WHERE season_id = ?
+    `).run(seasonId);
+
+    if (eventIds.length) {
+      const placeholders = eventIds.map(() => '?').join(', ');
+      db.prepare(`DELETE FROM event_results WHERE event_id IN (${placeholders})`).run(...eventIds);
+    }
+
+    db.prepare('DELETE FROM event_payouts WHERE season_id = ?').run(seasonId);
+    db.prepare('DELETE FROM season_bonus_payouts WHERE season_id = ?').run(seasonId);
+    db.prepare('DELETE FROM ownership WHERE season_id = ?').run(seasonId);
+    db.prepare('DELETE FROM bids WHERE season_id = ?').run(seasonId);
+    db.prepare('DELETE FROM provider_sync_state WHERE season_id = ?').run(seasonId);
+
+    if (participantIds.length) {
+      const placeholders = participantIds.map(() => '?').join(', ');
+      db.prepare(`
+        DELETE FROM season_participants
+        WHERE season_id = ?
+          AND participant_id IN (${placeholders})
+      `).run(seasonId, ...participantIds);
+
+      db.prepare(`
+        DELETE FROM participants
+        WHERE is_admin = 0
+          AND id IN (${placeholders})
+      `).run(...participantIds);
+    }
+  })();
+
+  io?.emit('auction:status', { status: 'waiting' });
+  io?.emit('standings:update');
+  if (auctionService?.emitAuctionState && io) {
+    auctionService.emitAuctionState(io, seasonId);
+  }
+
+  return {
+    ok: true,
+    message: 'Cleared auction, results, payouts, and non-admin participants for the active season.',
+  };
+}
+
+async function loadHistoricalSeasonMetadata({ seasonId, provider, year, io, auctionService }) {
+  const season = getSeason(seasonId);
+  const parsedYear = Number(year);
+  const providerName = getProviderName(provider);
+
+  if (!season) return { ok: false, status: 404, error: 'Season not found' };
+  if (!Number.isFinite(parsedYear)) {
+    return { ok: false, status: 400, error: 'A numeric year is required.' };
+  }
+  if (parsedYear !== 2025) {
+    return { ok: false, status: 400, error: 'Only 2025 historical metadata is supported right now.' };
+  }
+
+  try {
+    const [drivers, events] = await Promise.all([
+      provider.fetchDrivers({ year: parsedYear }),
+      provider.fetchSeasonSchedule({ year: parsedYear }),
+    ]);
+
+    if (!drivers.length) {
+      return { ok: false, status: 502, error: `Provider returned no drivers for ${parsedYear}.` };
+    }
+    if (!events.length) {
+      return { ok: false, status: 502, error: `Provider returned no events for ${parsedYear}.` };
+    }
+
+    clearTestDataForSeason({ seasonId, io: null, auctionService });
+
+    const deleteAuctionItems = db.prepare('DELETE FROM auction_items WHERE season_id = ?');
+    const deleteDrivers = db.prepare('DELETE FROM drivers WHERE season_id = ?');
+    const deleteEvents = db.prepare('DELETE FROM events WHERE season_id = ?');
+    const insertDriver = db.prepare(`
+      INSERT INTO drivers (season_id, external_id, code, name, team_name, active)
+      VALUES (?, ?, ?, ?, ?, 1)
+    `);
+    const insertAuctionItem = db.prepare(`
+      INSERT INTO auction_items (season_id, driver_id, queue_order)
+      VALUES (?, ?, ?)
+    `);
+    const insertEvent = db.prepare(`
+      INSERT INTO events
+        (season_id, external_event_id, round_number, name, type, starts_at, lock_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    db.transaction(() => {
+      deleteAuctionItems.run(seasonId);
+      deleteDrivers.run(seasonId);
+      deleteEvents.run(seasonId);
+
+      drivers.forEach((driver, idx) => {
+        const insert = insertDriver.run(
+          seasonId,
+          driver.external_id,
+          driver.code,
+          driver.name,
+          driver.team_name,
+        );
+        insertAuctionItem.run(seasonId, insert.lastInsertRowid, idx);
+      });
+
+      events.forEach((event) => {
+        insertEvent.run(
+          seasonId,
+          event.external_event_id || `historical-${parsedYear}-${event.round_number}-${event.type}`,
+          event.round_number,
+          event.name,
+          event.type,
+          event.starts_at,
+          event.lock_at,
+        );
+      });
+    })();
+
+    saveProviderState(seasonId, 'drivers', providerName, 'success', `Loaded ${drivers.length} drivers from ${parsedYear}.`, {
+      count: drivers.length,
+      year: parsedYear,
+      source: 'historical-load',
+    });
+    saveProviderState(seasonId, 'schedule', providerName, 'success', `Loaded ${events.length} events from ${parsedYear}.`, {
+      count: events.length,
+      year: parsedYear,
+      source: 'historical-load',
+    });
+
+    io?.emit('auction:status', { status: 'waiting' });
+    io?.emit('standings:update');
+    if (auctionService?.emitAuctionState && io) {
+      auctionService.emitAuctionState(io, seasonId);
+    }
+
+    return {
+      ok: true,
+      year: parsedYear,
+      driverCount: drivers.length,
+      eventCount: events.length,
+      message: `Loaded ${parsedYear} OpenF1 drivers and events for testing.`,
+    };
+  } catch (error) {
+    saveProviderState(seasonId, 'drivers', providerName, 'error', error.message || 'Historical driver load failed', {
+      year: parsedYear,
+      source: 'historical-load',
+    });
+    saveProviderState(seasonId, 'schedule', providerName, 'error', error.message || 'Historical schedule load failed', {
+      year: parsedYear,
+      source: 'historical-load',
+    });
+    return { ok: false, status: 502, error: error.message || 'Historical metadata load failed' };
+  }
 }
 
 function getEventEditorData({ seasonId, eventId }) {
@@ -101,6 +589,11 @@ function getSeasonBonusPayouts({ seasonId }) {
 module.exports = {
   syncNextResults,
   syncEventResults,
+  refreshDriversFromProvider,
+  refreshScheduleFromProvider,
+  getProviderStatus,
+  clearTestDataForSeason,
+  loadHistoricalSeasonMetadata,
   getEventEditorData,
   saveManualResultsAndScore,
   recalcSeasonBonusesForSeason,

--- a/apps/f1/server/services/auctionService.js
+++ b/apps/f1/server/services/auctionService.js
@@ -269,6 +269,7 @@ function createAuctionService(io, options = {}) {
     startAuction,
     closeAuction,
     closeActiveAuction,
+    clearActiveTimer,
     placeBid,
     emitAuctionState,
     restoreTimerOnStartup,

--- a/apps/f1/server/services/resultsAutoPollService.js
+++ b/apps/f1/server/services/resultsAutoPollService.js
@@ -1,0 +1,108 @@
+const { getActiveSeasonId, upsertProviderSyncState } = require('../db');
+const resultsAdminService = require('./admin/resultsAdminService');
+
+function createResultsAutoPollService({ provider, io }) {
+  const enabled = String(process.env.F1_AUTO_POLL_ENABLED || '0') === '1';
+  const intervalSeconds = Math.max(30, Number(process.env.F1_AUTO_POLL_INTERVAL_SECONDS) || 120);
+  let timer = null;
+  let running = false;
+  let lastRunAt = null;
+
+  async function tick() {
+    if (!enabled || running) return;
+    running = true;
+    lastRunAt = Date.now();
+
+    const seasonId = getActiveSeasonId();
+    const providerName = provider?.name || 'unknown';
+
+    try {
+      if (providerName !== 'openf1') {
+        upsertProviderSyncState(seasonId, 'auto_poll', {
+          provider: providerName,
+          status: 'disabled',
+          message: `Auto-poll requires openf1; current provider is ${providerName}.`,
+          meta: { enabled, intervalSeconds, lastRunAt },
+        });
+        return;
+      }
+
+      const result = await resultsAdminService.syncNextResults({
+        seasonId,
+        provider,
+        io,
+        force: false,
+      });
+
+      if (result.ok) {
+        upsertProviderSyncState(seasonId, 'auto_poll', {
+          provider: providerName,
+          status: 'success',
+          message: 'Auto-poll synced the next available event.',
+          meta: { enabled, intervalSeconds, lastRunAt, rowCount: result.rowCount || 0 },
+        });
+        return;
+      }
+
+      if (result.status === 404) {
+        upsertProviderSyncState(seasonId, 'auto_poll', {
+          provider: providerName,
+          status: 'idle',
+          message: 'No due events are pending sync.',
+          meta: { enabled, intervalSeconds, lastRunAt },
+        });
+        return;
+      }
+
+      upsertProviderSyncState(seasonId, 'auto_poll', {
+        provider: providerName,
+        status: 'error',
+        message: result.error || 'Auto-poll failed.',
+        meta: { enabled, intervalSeconds, lastRunAt },
+      });
+    } catch (error) {
+      upsertProviderSyncState(seasonId, 'auto_poll', {
+        provider: providerName,
+        status: 'error',
+        message: error.message || 'Auto-poll failed.',
+        meta: { enabled, intervalSeconds, lastRunAt },
+      });
+    } finally {
+      running = false;
+    }
+  }
+
+  function start() {
+    if (!enabled || timer) return;
+    timer = setInterval(() => {
+      tick().catch(() => {});
+    }, intervalSeconds * 1000);
+    timer.unref?.();
+    tick().catch(() => {});
+  }
+
+  function stop() {
+    if (!timer) return;
+    clearInterval(timer);
+    timer = null;
+  }
+
+  function getStatus() {
+    return {
+      enabled,
+      intervalSeconds,
+      running,
+      lastRunAt,
+    };
+  }
+
+  return {
+    start,
+    stop,
+    getStatus,
+  };
+}
+
+module.exports = {
+  createResultsAutoPollService,
+};

--- a/apps/f1/server/tests/adminServices.test.js
+++ b/apps/f1/server/tests/adminServices.test.js
@@ -101,6 +101,490 @@ test('results admin manual save forces scoring path and persists results', () =>
   assert.equal(rowCount, 1);
 });
 
+test('results admin refreshDrivers updates seeded drivers without changing identities', async () => {
+  const {
+    db,
+    getActiveSeasonId,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const before = db.prepare(`
+    SELECT id, name, code, external_id, team_name
+    FROM drivers
+    WHERE season_id = ? AND code = 'PER'
+  `).get(seasonId);
+
+  const provider = {
+    name: 'openf1',
+    async fetchDrivers() {
+      return [
+        { external_id: 1, code: 'VER', name: 'Max Verstappen', team_name: 'Oracle Red Bull Racing' },
+        { external_id: 11, code: 'PER', name: 'Sergio Perez', team_name: 'Oracle Red Bull Racing' },
+        { external_id: 16, code: 'LEC', name: 'Charles Leclerc', team_name: 'Scuderia Ferrari' },
+        { external_id: 44, code: 'HAM', name: 'Lewis Hamilton', team_name: 'Scuderia Ferrari' },
+        { external_id: 4, code: 'NOR', name: 'Lando Norris', team_name: 'McLaren Formula 1 Team' },
+        { external_id: 81, code: 'PIA', name: 'Oscar Piastri', team_name: 'McLaren Formula 1 Team' },
+        { external_id: 63, code: 'RUS', name: 'George Russell', team_name: 'Mercedes-AMG PETRONAS' },
+        { external_id: 12, code: 'ANT', name: 'Andrea Kimi Antonelli', team_name: 'Mercedes-AMG PETRONAS' },
+        { external_id: 14, code: 'ALO', name: 'Fernando Alonso', team_name: 'Aston Martin Aramco' },
+        { external_id: 18, code: 'STR', name: 'Lance Stroll', team_name: 'Aston Martin Aramco' },
+        { external_id: 10, code: 'GAS', name: 'Pierre Gasly', team_name: 'BWT Alpine F1 Team' },
+        { external_id: 7, code: 'DOO', name: 'Jack Doohan', team_name: 'BWT Alpine F1 Team' },
+        { external_id: 23, code: 'ALB', name: 'Alex Albon', team_name: 'Williams Racing' },
+        { external_id: 55, code: 'SAI', name: 'Carlos Sainz', team_name: 'Williams Racing' },
+        { external_id: 27, code: 'HUL', name: 'Nico Hulkenberg', team_name: 'Stake F1 Team Kick Sauber' },
+        { external_id: 5, code: 'BOR', name: 'Gabriel Bortoleto', team_name: 'Stake F1 Team Kick Sauber' },
+        { external_id: 22, code: 'TSU', name: 'Yuki Tsunoda', team_name: 'Visa Cash App Racing Bulls' },
+        { external_id: 30, code: 'LAW', name: 'Liam Lawson', team_name: 'Visa Cash App Racing Bulls' },
+        { external_id: 31, code: 'OCO', name: 'Esteban Ocon', team_name: 'MoneyGram Haas F1 Team' },
+        { external_id: 87, code: 'BEA', name: 'Oliver Bearman', team_name: 'MoneyGram Haas F1 Team' },
+      ];
+    },
+  };
+
+  const result = await resultsAdminService.refreshDriversFromProvider({
+    seasonId,
+    provider,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.count, 20);
+
+  const after = db.prepare(`
+    SELECT id, name, code, external_id, team_name
+    FROM drivers
+    WHERE season_id = ? AND code = 'PER'
+  `).get(seasonId);
+
+  assert.equal(after.id, before.id);
+  assert.notEqual(after.external_id, before.external_id);
+  assert.equal(after.external_id, 11);
+  assert.equal(after.team_name, 'Oracle Red Bull Racing');
+});
+
+test('results admin refreshSchedule updates matching seeded events with provider keys', async () => {
+  const {
+    db,
+    getActiveSeasonId,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const provider = {
+    name: 'openf1',
+    async fetchSeasonSchedule() {
+      return [
+        {
+          external_event_id: '9001',
+          round_number: 1,
+          name: 'Australian Grand Prix',
+          type: 'grand_prix',
+          starts_at: '2026-02-22T04:00:00.000Z',
+          lock_at: '2026-02-22T03:50:00.000Z',
+        },
+        {
+          external_event_id: '9002',
+          round_number: 2,
+          name: 'Chinese Grand Prix (Sprint)',
+          type: 'sprint',
+          starts_at: '2026-03-01T03:00:00.000Z',
+          lock_at: '2026-03-01T02:50:00.000Z',
+        },
+      ];
+    },
+  };
+
+  const result = await resultsAdminService.refreshScheduleFromProvider({
+    seasonId,
+    provider,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.count, 2);
+
+  const australianGp = db.prepare(`
+    SELECT external_event_id
+    FROM events
+    WHERE season_id = ? AND round_number = 1 AND type = 'grand_prix'
+  `).get(seasonId);
+
+  const chineseSprint = db.prepare(`
+    SELECT external_event_id
+    FROM events
+    WHERE season_id = ? AND round_number = 2 AND type = 'sprint'
+  `).get(seasonId);
+
+  assert.equal(australianGp.external_event_id, '9001');
+  assert.equal(chineseSprint.external_event_id, '9002');
+});
+
+test('results admin refreshSchedule matches by round and type when provider names differ', async () => {
+  const {
+    db,
+    getActiveSeasonId,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const provider = {
+    name: 'openf1',
+    async fetchSeasonSchedule() {
+      return [
+        {
+          external_event_id: '9901',
+          round_number: 1,
+          name: 'FORMULA 1 LOUIS VUITTON AUSTRALIAN GRAND PRIX 2026',
+          type: 'grand_prix',
+          starts_at: '2026-02-22T04:00:00.000Z',
+          lock_at: '2026-02-22T03:50:00.000Z',
+        },
+      ];
+    },
+  };
+
+  const result = await resultsAdminService.refreshScheduleFromProvider({
+    seasonId,
+    provider,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.count, 1);
+
+  const australianGp = db.prepare(`
+    SELECT external_event_id, name
+    FROM events
+    WHERE season_id = ? AND round_number = 1 AND type = 'grand_prix'
+  `).get(seasonId);
+
+  assert.equal(australianGp.external_event_id, '9901');
+  assert.equal(australianGp.name, 'FORMULA 1 LOUIS VUITTON AUSTRALIAN GRAND PRIX 2026');
+});
+
+test('results admin refreshSchedule inserts missing sprint-weekend grand prix rows', async () => {
+  const {
+    db,
+    getActiveSeasonId,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+
+  const provider = {
+    name: 'openf1',
+    async fetchSeasonSchedule() {
+      return [
+        {
+          external_event_id: '9002',
+          round_number: 2,
+          name: 'Chinese Grand Prix (Sprint)',
+          type: 'sprint',
+          starts_at: '2026-03-01T03:00:00.000Z',
+          lock_at: '2026-03-01T02:50:00.000Z',
+        },
+        {
+          external_event_id: '9003',
+          round_number: 2,
+          name: 'Chinese Grand Prix',
+          type: 'grand_prix',
+          starts_at: '2026-03-01T07:00:00.000Z',
+          lock_at: '2026-03-01T06:50:00.000Z',
+        },
+      ];
+    },
+  };
+
+  const result = await resultsAdminService.refreshScheduleFromProvider({
+    seasonId,
+    provider,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.insertedCount, 1);
+
+  const chineseGp = db.prepare(`
+    SELECT external_event_id, round_number, type, name
+    FROM events
+    WHERE season_id = ? AND round_number = 2 AND type = 'grand_prix'
+  `).get(seasonId);
+
+  assert.equal(chineseGp.external_event_id, '9003');
+  assert.equal(chineseGp.name, 'Chinese Grand Prix');
+});
+
+test('results admin refreshSchedule removes stale unmatched pending events', async () => {
+  const {
+    db,
+    getActiveSeasonId,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+
+  const provider = {
+    name: 'openf1',
+    async fetchSeasonSchedule() {
+      return [
+        {
+          external_event_id: '9201',
+          round_number: 1,
+          name: 'Australian Grand Prix',
+          type: 'grand_prix',
+          starts_at: '2026-03-08T04:00:00.000Z',
+          lock_at: '2026-03-08T03:50:00.000Z',
+        },
+      ];
+    },
+  };
+
+  const before = db.prepare(`
+    SELECT COUNT(*) as c
+    FROM events
+    WHERE season_id = ? AND round_number = 12 AND type = 'sprint'
+  `).get(seasonId).c;
+
+  const result = await resultsAdminService.refreshScheduleFromProvider({
+    seasonId,
+    provider,
+  });
+
+  assert.equal(result.ok, true);
+  assert.ok(result.removedCount >= 1);
+
+  const after = db.prepare(`
+    SELECT COUNT(*) as c
+    FROM events
+    WHERE season_id = ? AND round_number = 12 AND type = 'sprint'
+  `).get(seasonId).c;
+
+  assert.equal(before, 1);
+  assert.equal(after, 0);
+});
+
+test('results admin clearTestData resets season activity but preserves seeded setup', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const adminResult = db.prepare(`
+    INSERT INTO participants (name, color, is_admin, session_token)
+    VALUES ('Admin Tester', '#000000', 1, 'admin-token-1')
+  `).run();
+  const adminId = adminResult.lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, adminId);
+  const driver = db.prepare('SELECT id FROM drivers WHERE season_id = ? ORDER BY id ASC LIMIT 1').get(seasonId);
+  const event = db.prepare('SELECT id FROM events WHERE season_id = ? ORDER BY id ASC LIMIT 1').get(seasonId);
+
+  const participantResult = db.prepare(`
+    INSERT INTO participants (name, color, is_admin, session_token)
+    VALUES ('Tester', '#ffffff', 0, 'token-1')
+  `).run();
+  const participantId = participantResult.lastInsertRowid;
+
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, driver.id, participantId, 500);
+  db.prepare(`
+    INSERT INTO bids (season_id, driver_id, participant_id, amount_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, driver.id, participantId, 500);
+  db.prepare(`
+    INSERT INTO event_results (event_id, driver_id, finish_position, start_position, positions_gained, is_manual_override)
+    VALUES (?, ?, 5, 10, 5, 1)
+  `).run(event.id, driver.id);
+  db.prepare(`
+    INSERT INTO event_payouts (season_id, event_id, participant_id, driver_id, category, amount_cents, tie_count)
+    VALUES (?, ?, ?, ?, 'race_winner', 100, 1)
+  `).run(seasonId, event.id, participantId, driver.id);
+  db.prepare(`
+    INSERT INTO season_bonus_payouts (season_id, participant_id, driver_id, category, amount_cents, tie_count)
+    VALUES (?, ?, ?, 'drivers_champion', 200, 1)
+  `).run(seasonId, participantId, driver.id);
+  db.prepare(`
+    INSERT INTO provider_sync_state (season_id, scope, provider, status, message)
+    VALUES (?, 'drivers', 'openf1', 'success', 'ok')
+  `).run(seasonId);
+  db.prepare(`
+    UPDATE auction_items
+    SET status = 'sold',
+        current_price_cents = 500,
+        current_leader_id = ?,
+        bid_end_time = 123,
+        final_price_cents = 500,
+        winner_id = ?
+    WHERE season_id = ? AND driver_id = ?
+  `).run(participantId, participantId, seasonId, driver.id);
+  db.prepare(`
+    UPDATE events
+    SET status = 'scored',
+        random_bonus_position = 9,
+        random_bonus_drawn_at = 123,
+        synced_at = 123
+    WHERE id = ?
+  `).run(event.id);
+  db.prepare(`
+    UPDATE seasons
+    SET auction_status = 'complete',
+        season_random_bonus_position = 7,
+        season_random_bonus_drawn_at = 123
+    WHERE id = ?
+  `).run(seasonId);
+
+  const clearStateCalls = [];
+  const result = resultsAdminService.clearTestDataForSeason({
+    seasonId,
+    io: null,
+    auctionService: {
+      clearActiveTimer() {
+        clearStateCalls.push('cleared');
+      },
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(clearStateCalls.length, 1);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM ownership WHERE season_id = ?').get(seasonId).c, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM bids WHERE season_id = ?').get(seasonId).c, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM event_results WHERE event_id = ?').get(event.id).c, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM event_payouts WHERE season_id = ?').get(seasonId).c, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM season_bonus_payouts WHERE season_id = ?').get(seasonId).c, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM provider_sync_state WHERE season_id = ?').get(seasonId).c, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM season_participants WHERE season_id = ? AND participant_id = ?').get(seasonId, participantId).c, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM participants WHERE id = ?').get(participantId).c, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM participants WHERE id = ?').get(adminId).c, 1);
+
+  const auctionItem = db.prepare(`
+    SELECT status, current_price_cents, current_leader_id, bid_end_time, final_price_cents, winner_id
+    FROM auction_items
+    WHERE season_id = ? AND driver_id = ?
+  `).get(seasonId, driver.id);
+  assert.equal(auctionItem.status, 'pending');
+  assert.equal(auctionItem.current_price_cents, 0);
+  assert.equal(auctionItem.current_leader_id, null);
+  assert.equal(auctionItem.bid_end_time, null);
+  assert.equal(auctionItem.final_price_cents, null);
+  assert.equal(auctionItem.winner_id, null);
+
+  const eventAfter = db.prepare(`
+    SELECT status, random_bonus_position, random_bonus_drawn_at, synced_at
+    FROM events
+    WHERE id = ?
+  `).get(event.id);
+  assert.equal(eventAfter.status, 'pending');
+  assert.equal(eventAfter.random_bonus_position, null);
+  assert.equal(eventAfter.random_bonus_drawn_at, null);
+  assert.equal(eventAfter.synced_at, null);
+
+  const seasonAfter = db.prepare(`
+    SELECT auction_status, season_random_bonus_position, season_random_bonus_drawn_at
+    FROM seasons
+    WHERE id = ?
+  `).get(seasonId);
+  assert.equal(seasonAfter.auction_status, 'waiting');
+  assert.equal(seasonAfter.season_random_bonus_position, null);
+  assert.equal(seasonAfter.season_random_bonus_drawn_at, null);
+
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM drivers WHERE season_id = ?').get(seasonId).c, 20);
+  assert.ok(db.prepare('SELECT COUNT(*) as c FROM events WHERE season_id = ?').get(seasonId).c > 0);
+});
+
+test('results admin loadHistoricalSeasonMetadata replaces drivers and events with a historical dataset', async () => {
+  const {
+    db,
+    getActiveSeasonId,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const participantResult = db.prepare(`
+    INSERT INTO participants (name, color, is_admin, session_token)
+    VALUES ('Tester', '#ffffff', 0, 'token-historical')
+  `).run();
+  const participantId = participantResult.lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+
+  const provider = {
+    name: 'openf1',
+    async fetchDrivers({ year }) {
+      assert.equal(year, 2025);
+      return [
+        { external_id: 81, code: 'PIA', name: 'Oscar Piastri', team_name: 'McLaren' },
+        { external_id: 4, code: 'NOR', name: 'Lando Norris', team_name: 'McLaren' },
+      ];
+    },
+    async fetchSeasonSchedule({ year }) {
+      assert.equal(year, 2025);
+      return [
+        {
+          external_event_id: '2025-1-gp',
+          round_number: 1,
+          name: 'Australian Grand Prix',
+          type: 'grand_prix',
+          starts_at: '2025-03-16T04:00:00.000Z',
+          lock_at: '2025-03-16T03:50:00.000Z',
+        },
+        {
+          external_event_id: '2025-2-sprint',
+          round_number: 2,
+          name: 'Chinese Grand Prix (Sprint)',
+          type: 'sprint',
+          starts_at: '2025-03-22T03:00:00.000Z',
+          lock_at: '2025-03-22T02:50:00.000Z',
+        },
+        {
+          external_event_id: '2025-2-gp',
+          round_number: 2,
+          name: 'Chinese Grand Prix',
+          type: 'grand_prix',
+          starts_at: '2025-03-23T07:00:00.000Z',
+          lock_at: '2025-03-23T06:50:00.000Z',
+        },
+      ];
+    },
+  };
+
+  const result = await resultsAdminService.loadHistoricalSeasonMetadata({
+    seasonId,
+    provider,
+    year: 2025,
+    io: null,
+    auctionService: {
+      clearActiveTimer() {},
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.driverCount, 2);
+  assert.equal(result.eventCount, 3);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM drivers WHERE season_id = ?').get(seasonId).c, 2);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM auction_items WHERE season_id = ?').get(seasonId).c, 2);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM events WHERE season_id = ?').get(seasonId).c, 3);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM season_participants WHERE season_id = ? AND participant_id = ?').get(seasonId, participantId).c, 0);
+
+  const firstDriver = db.prepare(`
+    SELECT code, name, team_name
+    FROM drivers
+    WHERE season_id = ?
+    ORDER BY id ASC
+    LIMIT 1
+  `).get(seasonId);
+  assert.equal(firstDriver.code, 'PIA');
+  assert.equal(firstDriver.name, 'Oscar Piastri');
+
+  const loadedSprint = db.prepare(`
+    SELECT external_event_id, name, type
+    FROM events
+    WHERE season_id = ? AND round_number = 2 AND type = 'sprint'
+  `).get(seasonId);
+  assert.equal(loadedSprint.external_event_id, '2025-2-sprint');
+  assert.equal(loadedSprint.name, 'Chinese Grand Prix (Sprint)');
+});
+
 test('payout rules admin save triggers bonus recalc path and standings update emit', () => {
   const {
     db,

--- a/apps/f1/server/tests/openF1ResultsProvider.test.js
+++ b/apps/f1/server/tests/openF1ResultsProvider.test.js
@@ -1,0 +1,138 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  OpenF1ResultsProvider,
+  canonicalGrandPrixName,
+} = require('../providers/openF1ResultsProvider');
+const {
+  createResultsProvider,
+} = require('../providers');
+
+test('createResultsProvider blocks mock in production and selects openf1 when configured', () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousProvider = process.env.F1_RESULTS_PROVIDER;
+
+  process.env.NODE_ENV = 'production';
+  process.env.F1_RESULTS_PROVIDER = 'mock';
+  let provider = createResultsProvider();
+  assert.equal(provider.name, 'mock');
+  assert.match(provider.getStatus().error, /disabled in production/i);
+
+  process.env.F1_RESULTS_PROVIDER = 'openf1';
+  provider = createResultsProvider();
+  assert.equal(provider.name, 'openf1');
+
+  process.env.NODE_ENV = previousNodeEnv;
+  process.env.F1_RESULTS_PROVIDER = previousProvider;
+});
+
+test('MockResultsProvider reports its provider identity', () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousProvider = process.env.F1_RESULTS_PROVIDER;
+
+  process.env.NODE_ENV = 'development';
+  process.env.F1_RESULTS_PROVIDER = 'mock';
+
+  const provider = createResultsProvider();
+  assert.equal(provider.name, 'mock');
+  assert.equal(provider.getStatus().provider, 'mock');
+
+  process.env.NODE_ENV = previousNodeEnv;
+  process.env.F1_RESULTS_PROVIDER = previousProvider;
+});
+
+test('OpenF1ResultsProvider normalizes season schedule and event results', async () => {
+  const responses = {
+    '/v1/sessions?year=2026': [
+      {
+        session_key: 8999,
+        meeting_key: 100,
+        meeting_name: '',
+        circuit_short_name: 'Sakhir',
+        session_name: 'Practice 3',
+        date_start: '2026-02-20T07:00:00Z',
+        country_name: 'Bahrain',
+        location: 'Bahrain',
+      },
+      {
+        session_key: 9001,
+        meeting_key: 101,
+        meeting_name: '',
+        circuit_short_name: 'Melbourne',
+        session_name: 'Race',
+        date_start: '2026-02-22T04:00:00Z',
+        country_name: 'Australia',
+        location: 'Melbourne',
+      },
+      {
+        session_key: 9002,
+        meeting_key: 102,
+        meeting_name: '',
+        circuit_short_name: 'Shanghai',
+        session_name: 'Sprint',
+        date_start: '2026-03-01T03:00:00Z',
+        country_name: 'China',
+        location: 'Shanghai',
+      },
+    ],
+    '/v1/drivers?session_key=9002': [
+      {
+        driver_number: 1,
+        name_acronym: 'VER',
+        full_name: 'Max Verstappen',
+        team_name: 'Oracle Red Bull Racing',
+      },
+    ],
+    '/v1/session_result?session_key=9001': [
+      { driver_number: 1, position: 2 },
+      { driver_number: 16, position: 1 },
+    ],
+    '/v1/starting_grid?session_key=9001': [
+      { driver_number: 1, position: 4 },
+      { driver_number: 16, position: 2 },
+    ],
+  };
+
+  const provider = new OpenF1ResultsProvider({
+    fetchImpl: async (url) => {
+      const key = `${url.pathname}${url.search}`;
+      return {
+        ok: true,
+        async json() {
+          return responses[key] || [];
+        },
+      };
+    },
+  });
+
+  const drivers = await provider.fetchDrivers({ year: 2026 });
+  assert.deepEqual(drivers[0], {
+    external_id: 1,
+    code: 'VER',
+    name: 'Max Verstappen',
+    team_name: 'Oracle Red Bull Racing',
+  });
+
+  const schedule = await provider.fetchSeasonSchedule({ year: 2026 });
+  assert.equal(schedule[0].type, 'grand_prix');
+  assert.equal(schedule[0].round_number, 1);
+  assert.equal(schedule[0].name, 'Australian Grand Prix');
+  assert.equal(schedule[1].name, 'Chinese Grand Prix (Sprint)');
+  assert.equal(schedule[1].round_number, 2);
+
+  const results = await provider.fetchEventResults({
+    event: { external_event_id: '9001' },
+  });
+  assert.deepEqual(results, [
+    { external_driver_id: 16, finish_position: 1, start_position: 2 },
+    { external_driver_id: 1, finish_position: 2, start_position: 4 },
+  ]);
+});
+
+test('canonicalGrandPrixName derives expected names from OpenF1 location data', () => {
+  assert.equal(canonicalGrandPrixName({ location: 'Austin', country_name: 'United States' }), 'United States Grand Prix');
+  assert.equal(canonicalGrandPrixName({ location: 'Miami Gardens', country_name: 'United States' }), 'Miami Grand Prix');
+  assert.equal(canonicalGrandPrixName({ location: 'São Paulo', country_name: 'Brazil' }), 'Sao Paulo Grand Prix');
+  assert.equal(canonicalGrandPrixName({ circuit_short_name: 'Melbourne', country_name: 'Australia' }), 'Australian Grand Prix');
+});

--- a/docs/adr/0002-f1-openf1-provider-runtime.md
+++ b/docs/adr/0002-f1-openf1-provider-runtime.md
@@ -1,0 +1,69 @@
+# 0002 F1 OpenF1 Provider Runtime
+
+## Status
+
+Accepted
+
+## Context
+
+The F1 app previously relied on a mock-only results provider. That was sufficient for UI and scoring development, but not for running the pool against real race data. The app needed a production-capable ingestion path for:
+
+- season driver metadata
+- season schedule/session metadata
+- classified event results with starting-grid context
+
+The existing admin result sync flow and scoring engine were already structured around a provider abstraction. The missing pieces were a real provider implementation, operational controls for refreshing metadata, and safe production behavior when provider calls fail.
+
+## Decision
+
+The F1 app now supports a real `openf1` results provider behind the existing provider adapter boundary.
+
+The runtime model is:
+
+1. Production uses `F1_RESULTS_PROVIDER=openf1`.
+2. `mock` remains available for local/dev/test only.
+3. Driver and schedule metadata refresh are explicit admin actions.
+4. Event result sync remains admin-triggered by default.
+5. Optional server-side auto-poll may call the same sync path when enabled by env var.
+6. Provider failures fail closed and surface in admin status rather than silently scoring mock or partial data.
+7. Provider refresh and auto-poll state are persisted in `provider_sync_state`.
+
+## Consequences
+
+Positive:
+
+- Real F1 data can be ingested without changing the core scoring engine.
+- Admins can refresh drivers and schedule independently of event scoring.
+- Production behavior is explicit and safer than silent fallback.
+- Auto-poll can be enabled later without changing the scoring contract.
+
+Tradeoffs:
+
+- Event and driver mapping now depend on OpenF1 field stability.
+- Metadata refresh is an operational step that must happen before live syncing if mappings drift.
+- Auto-poll adds a long-lived server loop, so it remains opt-in.
+
+## Rollback / Alternatives
+
+Rollback:
+
+1. Disable `F1_AUTO_POLL_ENABLED`.
+2. Continue using manual results entry if provider incidents occur.
+3. Use `mock` only in local/dev/test, not production.
+
+Rejected alternatives:
+
+1. Silent production fallback from `openf1` to `mock`
+   - Rejected because it can create incorrect payouts with false confidence.
+2. Automatic metadata refresh on startup
+   - Rejected because it introduces hidden startup side effects and deploy-time drift.
+3. Provider-specific scoring path
+   - Rejected because it would duplicate winner resolution and payout behavior.
+
+## References
+
+- `/apps/f1/server/providers/openF1ResultsProvider.js`
+- `/apps/f1/server/services/admin/resultsAdminService.js`
+- `/apps/f1/server/services/resultsAutoPollService.js`
+- `/apps/f1/server/routes/admin.js`
+- `/apps/f1/client/src/pages/admin/ResultsPage.jsx`


### PR DESCRIPTION
Summary
- sync global and F1-specific docs (AGENTS, README, RUNBOOK, HEARTBEAT, ARCHITECTURE, SOUL, DESIGN, handoff, docs/adr and guide content) with the latest operational expectations
- refresh F1 client/admin pages (App, pages, styles, guide content) and assets to match the updated narrative, including test data controls
- update F1 server routes/services/tests to support the new admin flows and payout audit/payout rule logic while keeping NCAA scope untouched
- record the new doc control plane addressables and templates for team reference

Testing
- Not run (not requested)