### PR TITLE
Add F1 auction participant budget cap enforcement

### DIFF
--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -5,9 +5,12 @@ A dedicated Formula 1 Calcutta app for a full season pool.
 ## Features
 
 - Live driver auction (real-time via Socket.io)
+- Auction queue shuffled randomly once per season, with admin reshuffle for pending drivers
+- Admin-configurable per-participant auction budget cap (default $200)
 - Event-by-event payouts using percentage-of-pool rules
 - Grand Prix and Sprint scoring categories
 - Auto-drawn random finishing position bonus per event
+- Grand Prix novelty rule for slowest recorded pit stop via OpenF1 `stop_duration`
 - Season bonus payouts from remaining pool
 - Results sync via provider adapter (`openf1` for real data, `mock` for local/dev/test)
 - Admin controls for auction, sync, payout rules, and settings
@@ -42,6 +45,7 @@ Server: `http://localhost:3002`
   - `F1_AUTO_POLL_INTERVAL_SECONDS=<seconds>`
 - Local/dev/test may continue using `mock`
 - Admin Test Data page can load a 2025 OpenF1 driver/event dataset for pre-2026 flow testing
+- Admin Test Data page can rescore all scored events after payout-rule changes
 
 ## Engineering Docs
 

--- a/apps/f1/client/src/content/guideContent.js
+++ b/apps/f1/client/src/content/guideContent.js
@@ -10,7 +10,7 @@ export const GUIDE_EVENT_PAYOUTS = {
       { category: 'Best P6+', bps: 50 },
       { category: 'Best P11+', bps: 50 },
       { category: 'Most Positions Gained', bps: 50 },
-      { category: '2nd Most Positions Gained', bps: 25 },
+      { category: 'Slowest Pit Stop', bps: 25 },
       { category: 'Random Position Bonus (P4+)', bps: 75 },
     ],
   },

--- a/apps/f1/client/src/pages/Auction.jsx
+++ b/apps/f1/client/src/pages/Auction.jsx
@@ -109,6 +109,10 @@ export default function Auction() {
   const [bidInput, setBidInput] = useState('');
   const [bidError, setBidError] = useState('');
   const [soldNotice, setSoldNotice] = useState(null);
+  const [auctionBudgetCapCents, setAuctionBudgetCapCents] = useState(0);
+  const [participantSpentCents, setParticipantSpentCents] = useState(0);
+  const [participantReservedBidCents, setParticipantReservedBidCents] = useState(0);
+  const [participantRemainingCents, setParticipantRemainingCents] = useState(0);
 
   const refresh = useCallback(async () => {
     const response = await api('/auction');
@@ -117,6 +121,10 @@ export default function Auction() {
     setActive(data.active);
     setItems(data.items || []);
     setRecentBids(data.recentBids || []);
+    setAuctionBudgetCapCents(data.auctionBudgetCapCents || 0);
+    setParticipantSpentCents(data.participantSpentCents || 0);
+    setParticipantReservedBidCents(data.participantReservedBidCents || 0);
+    setParticipantRemainingCents(data.participantRemainingCents || 0);
   }, []);
 
   useEffect(() => {
@@ -144,6 +152,10 @@ export default function Auction() {
     setActive(payload.active || null);
     setItems(payload.items || []);
     setRecentBids(payload.recentBids || []);
+    setAuctionBudgetCapCents(payload.auctionBudgetCapCents || 0);
+    setParticipantSpentCents(payload.participantSpentCents || 0);
+    setParticipantReservedBidCents(payload.participantReservedBidCents || 0);
+    setParticipantRemainingCents(payload.participantRemainingCents || 0);
   }, []));
 
   useSocketEvent('auction:started', useCallback(() => {
@@ -163,7 +175,8 @@ export default function Auction() {
     setRecentBids(payload.recentBids || []);
     setBidError('');
     setBidInput('');
-  }, []));
+    refresh().catch(() => {});
+  }, [refresh]));
 
   useSocketEvent('auction:sold', useCallback((payload) => {
     setSoldNotice({
@@ -273,6 +286,9 @@ export default function Auction() {
     [soldByOwner]
   );
   const auctionComplete = auctionStatus === 'complete';
+  const quickBidCents = (active?.current_price_cents || 0) + 100;
+  const maxAvailableBidCents = Math.max(0, auctionBudgetCapCents - participantSpentCents);
+  const quickBidWouldExceedBudget = canPlaceBid && quickBidCents > maxAvailableBidCents;
 
   const submitBid = (event) => {
     event.preventDefault();
@@ -286,10 +302,12 @@ export default function Auction() {
       setBidError('Enter a valid bid amount.');
       return;
     }
+    if (value > maxAvailableBidCents) {
+      setBidError(`Bid exceeds your remaining cap. Maximum available bid is ${fmtCents(maxAvailableBidCents)}.`);
+      return;
+    }
     socket?.emit('auction:bid', { amountCents: value });
   };
-
-  const quickBidCents = (active?.current_price_cents || 0) + 100;
 
   const submitQuickBid = () => {
     setBidError('');
@@ -298,6 +316,10 @@ export default function Auction() {
       return;
     }
     if (!active) return;
+    if (quickBidCents > maxAvailableBidCents) {
+      setBidError(`Quick bid exceeds your remaining cap. Maximum available bid is ${fmtCents(maxAvailableBidCents)}.`);
+      return;
+    }
     socket?.emit('auction:bid', { amountCents: quickBidCents });
   };
 
@@ -313,8 +335,10 @@ export default function Auction() {
           <strong>{pendingCount}</strong>
         </div>
         <div className="strip-item">
-          <span className="label">Auction Purse</span>
-          <strong>{fmtCents(auctionPurseCents)}</strong>
+          <span className="label">{canPlaceBid ? 'Remaining Budget' : 'Auction Purse'}</span>
+          <strong className={canPlaceBid && participantRemainingCents < 0 ? 'text-neg' : ''}>
+            {canPlaceBid ? fmtCents(participantRemainingCents) : fmtCents(auctionPurseCents)}
+          </strong>
         </div>
       </section>
 
@@ -350,6 +374,7 @@ export default function Auction() {
                 className="btn btn-outline quick-bid-btn"
                 type="button"
                 onClick={submitQuickBid}
+                disabled={!active || quickBidWouldExceedBudget}
               >
                 Quick +$1
               </button>
@@ -358,6 +383,11 @@ export default function Auction() {
           ) : (
             <p className="muted">Admin view only. Bidding is disabled for admin accounts.</p>
           )}
+          {canPlaceBid ? (
+            <p className="muted small">
+              Cap {fmtCents(auctionBudgetCapCents)} • Spent {fmtCents(participantSpentCents)} • Reserved {fmtCents(participantReservedBidCents)}
+            </p>
+          ) : null}
           {bidError ? <p className="error-text">{bidError}</p> : null}
         </section>
       ) : null}

--- a/apps/f1/client/src/pages/Events.jsx
+++ b/apps/f1/client/src/pages/Events.jsx
@@ -55,7 +55,9 @@ function winnerResultSummary(winner) {
   const start = winner?.start_position ?? 'N/A';
   const gain = winner?.positions_gained;
   const gainText = gain == null || gain === '' ? 'N/A' : String(gain);
-  return `Finished ${finish}, started ${start}, gained ${gainText}.`;
+  const pitStop = Number(winner?.slowest_pit_stop_seconds);
+  const pitText = Number.isFinite(pitStop) && pitStop > 0 ? ` Slowest stop ${pitStop.toFixed(3)}s.` : '';
+  return `Finished ${finish}, started ${start}, gained ${gainText}.${pitText}`;
 }
 
 export default function Events() {

--- a/apps/f1/client/src/pages/admin/AuctionPage.jsx
+++ b/apps/f1/client/src/pages/admin/AuctionPage.jsx
@@ -4,6 +4,9 @@ import useAdminOutletContext from './useAdminOutletContext';
 
 export default function AuctionPage() {
   const { settings, setField, saveSettings, runAuctionAction, loading, hasLoaded } = useAdminOutletContext();
+  const budgetCapValue = typeof settings?.auction_budget_cap_cents === 'string'
+    ? settings.auction_budget_cap_cents
+    : String(settings?.auction_budget_cap_cents == null ? 200 : (Number(settings.auction_budget_cap_cents) / 100));
 
   if (loading && !hasLoaded) {
     return <AdminLoadingState />;
@@ -17,6 +20,7 @@ export default function AuctionPage() {
           <button className="btn" onClick={() => runAuctionAction('/admin/auction/start')}>Open</button>
           <button className="btn btn-outline" onClick={() => runAuctionAction('/admin/auction/pause')}>Pause</button>
           <button className="btn btn-outline" onClick={() => runAuctionAction('/admin/auction/next')}>Start Next Driver</button>
+          <button className="btn btn-outline" onClick={() => runAuctionAction('/admin/auction/shuffle')}>Shuffle Pending Order</button>
           <button className="btn btn-outline" onClick={() => runAuctionAction('/admin/auction/close')}>Close Active</button>
         </div>
       </section>
@@ -36,6 +40,16 @@ export default function AuctionPage() {
             <input
               value={settings?.auction_grace_seconds ?? ''}
               onChange={(e) => setField('auction_grace_seconds', e.target.value)}
+            />
+          </label>
+          <label>
+            Budget Cap ($)
+            <input
+              type="number"
+              min="0"
+              step="1"
+              value={budgetCapValue}
+              onChange={(e) => setField('auction_budget_cap_cents', e.target.value)}
             />
           </label>
           <label className="checkbox-row">

--- a/apps/f1/client/src/pages/admin/PayoutAuditPage.jsx
+++ b/apps/f1/client/src/pages/admin/PayoutAuditPage.jsx
@@ -25,7 +25,9 @@ function winnerResultSummary(winner) {
   const start = winner?.start_position ?? 'N/A';
   const gain = winner?.positions_gained;
   const gainText = gain == null || gain === '' ? 'N/A' : String(gain);
-  return `Finished ${finish}, started ${start}, gained ${gainText}.`;
+  const pitStop = Number(winner?.slowest_pit_stop_seconds);
+  const pitText = Number.isFinite(pitStop) && pitStop > 0 ? ` Slowest stop ${pitStop.toFixed(3)}s.` : '';
+  return `Finished ${finish}, started ${start}, gained ${gainText}.${pitText}`;
 }
 
 export default function PayoutAuditPage() {
@@ -186,6 +188,9 @@ export default function PayoutAuditPage() {
                                   Start {winner.start_position ?? 'N/A'}
                                   {' • '}
                                   Gain {winner.positions_gained ?? 'N/A'}
+                                  {Number.isFinite(Number(winner.slowest_pit_stop_seconds)) && Number(winner.slowest_pit_stop_seconds) > 0
+                                    ? ` • Slowest stop ${Number(winner.slowest_pit_stop_seconds).toFixed(3)}s`
+                                    : ''}
                                 </div>
                                 <div className="muted small">
                                   Owner: {winner.owner_participant_name || 'Unowned'}

--- a/apps/f1/client/src/pages/admin/TestDataPage.jsx
+++ b/apps/f1/client/src/pages/admin/TestDataPage.jsx
@@ -15,6 +15,12 @@ function parsePositiveInt(value) {
   return Math.floor(n);
 }
 
+function parsePositiveSeconds(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+}
+
 function buildManualRows(drivers, results) {
   const byDriver = new Map((results || []).map((row) => [row.driver_id, row]));
   return (drivers || []).map((driver) => {
@@ -26,6 +32,7 @@ function buildManualRows(drivers, results) {
       team_name: driver.team_name,
       finish_position: existing?.finish_position ?? '',
       start_position: existing?.start_position ?? '',
+      slowest_pit_stop_seconds: existing?.slowest_pit_stop_seconds ?? '',
     };
   });
 }
@@ -34,6 +41,7 @@ export default function TestDataPage() {
   const {
     events,
     recalcSeasonBonuses,
+    rescoreSeasonEvents,
     clearAllTestData,
     loadHistoricalSeasonData,
     refresh,
@@ -136,6 +144,7 @@ export default function TestDataPage() {
           driver_id: row.driver_id,
           finish_position,
           start_position,
+          slowest_pit_stop_seconds: parsePositiveSeconds(row.slowest_pit_stop_seconds),
         };
       })
       .filter(Boolean);
@@ -203,6 +212,20 @@ export default function TestDataPage() {
     await loadSeasonBonusBreakdown();
   }, [loadHistoricalSeasonData, refresh, loadSeasonBonusBreakdown]);
 
+  const onRescoreSeasonEvents = useCallback(async () => {
+    const confirmed = window.confirm(
+      'Rescore all currently scored F1 events under the active payout rules? This rewrites event payouts and recalculates season bonuses for the active season.'
+    );
+    if (!confirmed) return;
+
+    await rescoreSeasonEvents();
+    await refresh();
+    await loadSeasonBonusBreakdown();
+    if (selectedEventId) {
+      await loadManualEvent(selectedEventId);
+    }
+  }, [rescoreSeasonEvents, refresh, loadSeasonBonusBreakdown, selectedEventId, loadManualEvent]);
+
   if (loading && !hasLoaded) {
     return <AdminLoadingState />;
   }
@@ -239,6 +262,23 @@ export default function TestDataPage() {
             onClick={onClearAllTestData}
           >
             Clear All Test Data
+          </button>
+        </div>
+      </section>
+
+      <section className="panel note-panel stack">
+        <div className="row between wrap gap-sm">
+          <div className="stack-xs">
+            <h2>Rescore Scored Events</h2>
+            <p className="muted small">
+              Rebuilds event payouts and season bonus payouts for every currently scored event using the active payout rules.
+            </p>
+          </div>
+          <button
+            className="btn btn-outline"
+            onClick={onRescoreSeasonEvents}
+          >
+            Rescore All Scored Events
           </button>
         </div>
       </section>
@@ -287,6 +327,7 @@ export default function TestDataPage() {
                   <th>Finish</th>
                   <th>Start</th>
                   <th>Gain</th>
+                  <th>Slowest Stop (s)</th>
                 </tr>
               </thead>
               <tbody>
@@ -321,6 +362,15 @@ export default function TestDataPage() {
                         />
                       </td>
                       <td>{gain == null ? '—' : gain}</td>
+                      <td>
+                        <input
+                          type="number"
+                          min="0"
+                          step="0.001"
+                          value={row.slowest_pit_stop_seconds}
+                          onChange={(e) => onManualCellChange(row.driver_id, 'slowest_pit_stop_seconds', e.target.value)}
+                        />
+                      </td>
                     </tr>
                   );
                 })}

--- a/apps/f1/client/src/pages/admin/adminApi.js
+++ b/apps/f1/client/src/pages/admin/adminApi.js
@@ -9,10 +9,16 @@ async function parseApiResponse(response, fallbackMessage) {
 }
 
 export function normalizeSettingsPayload(settings) {
+  const rawBudgetCap = settings?.auction_budget_cap_cents;
+  const budgetCapDollars = typeof rawBudgetCap === 'string'
+    ? Number(rawBudgetCap)
+    : Number(rawBudgetCap || 0) / 100;
+
   return {
     auction_timer_seconds: Number(settings?.auction_timer_seconds) || 30,
     auction_grace_seconds: Number(settings?.auction_grace_seconds) || 15,
     auction_auto_advance: settings?.auction_auto_advance ? 1 : 0,
+    auction_budget_cap_cents: Math.max(0, Math.round((Number.isFinite(budgetCapDollars) ? budgetCapDollars : 200) * 100)),
   };
 }
 
@@ -101,6 +107,14 @@ export async function recalcSeasonBonuses() {
     body: '{}',
   });
   return parseApiResponse(response, 'Recalculation failed');
+}
+
+export async function rescoreSeasonEvents() {
+  const response = await api('/admin/results/rescore-season-events', {
+    method: 'POST',
+    body: '{}',
+  });
+  return parseApiResponse(response, 'Season rescore failed');
 }
 
 export async function savePayoutRules(payload) {

--- a/apps/f1/client/src/pages/admin/useAdminData.js
+++ b/apps/f1/client/src/pages/admin/useAdminData.js
@@ -8,6 +8,7 @@ import {
   readApi,
   readProviderStatus,
   recalcSeasonBonuses as recalcSeasonBonusesApi,
+  rescoreSeasonEvents as rescoreSeasonEventsApi,
   refreshDrivers as refreshDriversApi,
   refreshSchedule as refreshScheduleApi,
   runAuctionAction as runAuctionActionApi,
@@ -128,6 +129,16 @@ export default function useAdminData() {
     }
   }, [loadAll]);
 
+  const rescoreSeasonEvents = useCallback(async () => {
+    try {
+      const result = await rescoreSeasonEventsApi();
+      setMessage(result.message || 'Scored events rescored.');
+      await loadAll({ silent: true });
+    } catch (error) {
+      setMessage(error.message || 'Season rescore failed.');
+    }
+  }, [loadAll]);
+
   const clearAllTestData = useCallback(async () => {
     try {
       const result = await clearAllTestDataApi();
@@ -190,6 +201,7 @@ export default function useAdminData() {
     syncNext,
     syncEvent,
     recalcSeasonBonuses,
+    rescoreSeasonEvents,
     updateRules,
     saveRules,
   }), [
@@ -212,6 +224,7 @@ export default function useAdminData() {
     syncNext,
     syncEvent,
     recalcSeasonBonuses,
+    rescoreSeasonEvents,
     updateRules,
     saveRules,
   ]);

--- a/apps/f1/client/src/pages/admin/useAdminOutletContext.js
+++ b/apps/f1/client/src/pages/admin/useAdminOutletContext.js
@@ -22,6 +22,7 @@ import { useOutletContext } from 'react-router-dom';
  * @property {(options?: {force?: boolean}) => Promise<void>} syncNext
  * @property {(eventId: number, options?: {force?: boolean}) => Promise<void>} syncEvent
  * @property {() => Promise<void>} recalcSeasonBonuses
+ * @property {() => Promise<void>} rescoreSeasonEvents
  * @property {(group: string, id: number, field: string, value: unknown) => void} updateRules
  * @property {() => Promise<void>} saveRules
  */

--- a/apps/f1/client/src/utils.js
+++ b/apps/f1/client/src/utils.js
@@ -48,6 +48,7 @@ export const categoryLabel = (category) => {
     best_p6_or_lower: 'Best P6+',
     best_p11_or_lower: 'Best P11+',
     most_positions_gained: 'Most Positions Gained',
+    slowest_pit_stop: 'Slowest Pit Stop',
     second_most_positions_gained: '2nd Most Positions Gained',
     random_finish_bonus: 'Random Position Bonus',
     drivers_champion: 'Drivers Champion',
@@ -70,6 +71,7 @@ export const auditRuleSummary = (category, { randomBonusPosition } = {}) => {
     best_p6_or_lower: 'Pays the best finisher from positions 6 through 20.',
     best_p11_or_lower: 'Pays the best finisher from positions 11 through 20.',
     most_positions_gained: 'Pays the driver with the most positions gained.',
+    slowest_pit_stop: 'Pays the driver with the slowest recorded pit stop duration from OpenF1 pit data.',
     second_most_positions_gained: 'Pays the driver with the second-most positions gained.',
     random_finish_bonus: randomBonusPosition
       ? `Pays the driver who finished in random position ${randomBonusPosition}.`

--- a/apps/f1/server/data/payoutRules.js
+++ b/apps/f1/server/data/payoutRules.js
@@ -8,7 +8,7 @@ const EVENT_RULES = {
     { category: 'best_p6_or_lower', label: 'Best Finisher P6 or Lower', bps: 50, rank_order: 1 },
     { category: 'best_p11_or_lower', label: 'Best Finisher P11 or Lower', bps: 50, rank_order: 1 },
     { category: 'most_positions_gained', label: 'Most Positions Gained', bps: 50, rank_order: 1 },
-    { category: 'second_most_positions_gained', label: '2nd Most Positions Gained', bps: 25, rank_order: 2 },
+    { category: 'slowest_pit_stop', label: 'Slowest Pit Stop', bps: 25, rank_order: 1 },
     { category: 'random_finish_bonus', label: 'Random Finishing Position Bonus (P4+)', bps: 75, rank_order: 1 },
   ],
   sprint: [

--- a/apps/f1/server/db.js
+++ b/apps/f1/server/db.js
@@ -83,6 +83,18 @@ function getResolvedAuctionStatus(seasonId) {
   return auctionRepo.getResolvedAuctionStatus(db, seasonId);
 }
 
+function getParticipantSpendCents(seasonId, participantId) {
+  return auctionRepo.getParticipantSpendCents(db, seasonId, participantId);
+}
+
+function getParticipantReservedBidCents(seasonId, participantId) {
+  return auctionRepo.getParticipantReservedBidCents(db, seasonId, participantId);
+}
+
+function getParticipantAuctionBudgetSummary(seasonId, participantId, budgetCapCents) {
+  return auctionRepo.getParticipantAuctionBudgetSummary(db, seasonId, participantId, budgetCapCents);
+}
+
 function getStandings(seasonId) {
   return standingsRepo.getStandings(db, seasonId);
 }
@@ -145,6 +157,9 @@ module.exports = {
   getTotalPotCents,
   getAuctionCounts,
   getResolvedAuctionStatus,
+  getParticipantSpendCents,
+  getParticipantReservedBidCents,
+  getParticipantAuctionBudgetSummary,
   getStandings,
   getParticipantPortfolio,
   getEvents,

--- a/apps/f1/server/lib/shuffle.js
+++ b/apps/f1/server/lib/shuffle.js
@@ -1,0 +1,14 @@
+const { randomInt } = require('node:crypto');
+
+function shuffleArray(values) {
+  const array = [...values];
+  for (let idx = array.length - 1; idx > 0; idx -= 1) {
+    const swapIdx = randomInt(idx + 1);
+    [array[idx], array[swapIdx]] = [array[swapIdx], array[idx]];
+  }
+  return array;
+}
+
+module.exports = {
+  shuffleArray,
+};

--- a/apps/f1/server/persistence/repositories/auctionRepo.js
+++ b/apps/f1/server/persistence/repositories/auctionRepo.js
@@ -91,6 +91,34 @@ function getResolvedAuctionStatus(db, seasonId) {
   return configured;
 }
 
+function getParticipantSpendCents(db, seasonId, participantId) {
+  return Number(db.prepare(`
+    SELECT COALESCE(SUM(purchase_price_cents), 0) as total
+    FROM ownership
+    WHERE season_id = ? AND participant_id = ?
+  `).get(seasonId, participantId)?.total || 0);
+}
+
+function getParticipantReservedBidCents(db, seasonId, participantId) {
+  return Number(db.prepare(`
+    SELECT COALESCE(current_price_cents, 0) as reserved
+    FROM auction_items
+    WHERE season_id = ? AND status = 'active' AND current_leader_id = ?
+    LIMIT 1
+  `).get(seasonId, participantId)?.reserved || 0);
+}
+
+function getParticipantAuctionBudgetSummary(db, seasonId, participantId, budgetCapCents) {
+  const spentCents = getParticipantSpendCents(db, seasonId, participantId);
+  const reservedBidCents = getParticipantReservedBidCents(db, seasonId, participantId);
+  return {
+    auctionBudgetCapCents: Number(budgetCapCents || 0),
+    participantSpentCents: spentCents,
+    participantReservedBidCents: reservedBidCents,
+    participantRemainingCents: Number(budgetCapCents || 0) - spentCents - reservedBidCents,
+  };
+}
+
 module.exports = {
   getAuctionItems,
   getActiveAuctionItem,
@@ -100,4 +128,7 @@ module.exports = {
   getTotalPotCents,
   getAuctionCounts,
   getResolvedAuctionStatus,
+  getParticipantSpendCents,
+  getParticipantReservedBidCents,
+  getParticipantAuctionBudgetSummary,
 };

--- a/apps/f1/server/persistence/repositories/eventRepo.js
+++ b/apps/f1/server/persistence/repositories/eventRepo.js
@@ -6,7 +6,7 @@ const EVENT_CATEGORY_ORDER = {
     'best_p6_or_lower',
     'best_p11_or_lower',
     'most_positions_gained',
-    'second_most_positions_gained',
+    'slowest_pit_stop',
     'random_finish_bonus',
   ],
   sprint: [

--- a/apps/f1/server/persistence/repositories/seasonRepo.js
+++ b/apps/f1/server/persistence/repositories/seasonRepo.js
@@ -32,6 +32,7 @@ function getSeasonSettings(db, seasonId) {
     SELECT id, year, name, invite_code, status,
            auction_timer_seconds, auction_grace_seconds,
            auction_status, auction_auto_advance,
+           auction_budget_cap_cents,
            payout_model_version,
            season_random_bonus_position,
            season_random_bonus_drawn_at
@@ -48,6 +49,7 @@ function updateSeasonSettings(db, seasonId, patch) {
     'auction_grace_seconds',
     'auction_status',
     'auction_auto_advance',
+    'auction_budget_cap_cents',
     'status',
   ];
 

--- a/apps/f1/server/persistence/schema.js
+++ b/apps/f1/server/persistence/schema.js
@@ -20,6 +20,7 @@ function ensureSchema(db) {
       auction_grace_seconds INTEGER NOT NULL DEFAULT 15,
       auction_status TEXT NOT NULL DEFAULT 'waiting',
       auction_auto_advance INTEGER NOT NULL DEFAULT 0,
+      auction_budget_cap_cents INTEGER NOT NULL DEFAULT 20000,
       payout_model_version INTEGER NOT NULL DEFAULT 1,
       season_random_bonus_position INTEGER,
       season_random_bonus_drawn_at INTEGER,
@@ -109,6 +110,7 @@ function ensureSchema(db) {
       finish_position INTEGER NOT NULL,
       start_position INTEGER,
       positions_gained INTEGER,
+      slowest_pit_stop_seconds REAL,
       is_manual_override INTEGER NOT NULL DEFAULT 0,
       updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
       UNIQUE(event_id, driver_id)
@@ -180,6 +182,12 @@ function ensureSchema(db) {
   }
   if (!columnExists(db, 'seasons', 'season_random_bonus_drawn_at')) {
     db.exec('ALTER TABLE seasons ADD COLUMN season_random_bonus_drawn_at INTEGER');
+  }
+  if (!columnExists(db, 'seasons', 'auction_budget_cap_cents')) {
+    db.exec('ALTER TABLE seasons ADD COLUMN auction_budget_cap_cents INTEGER NOT NULL DEFAULT 20000');
+  }
+  if (!columnExists(db, 'event_results', 'slowest_pit_stop_seconds')) {
+    db.exec('ALTER TABLE event_results ADD COLUMN slowest_pit_stop_seconds REAL');
   }
 }
 

--- a/apps/f1/server/persistence/seed.js
+++ b/apps/f1/server/persistence/seed.js
@@ -1,4 +1,5 @@
 const { generateInviteCode } = require('../lib/core');
+const { shuffleArray } = require('../lib/shuffle');
 const { DRIVERS_2026 } = require('../data/drivers2026');
 const { EVENTS_2026 } = require('../data/events2026');
 const { EVENT_RULES, DEFAULT_SEASON_BONUS_RULES } = require('../data/payoutRules');
@@ -63,7 +64,7 @@ function seedSeasonData(db, seasonId) {
       ORDER BY external_id ASC
     `).all(seasonId);
 
-    seededDrivers.forEach((driver, idx) => {
+    shuffleArray(seededDrivers).forEach((driver, idx) => {
       insertAuctionItem.run(seasonId, driver.id, idx);
     });
 

--- a/apps/f1/server/providers/openF1ResultsProvider.js
+++ b/apps/f1/server/providers/openF1ResultsProvider.js
@@ -199,20 +199,34 @@ class OpenF1ResultsProvider {
       throw new Error(`Event ${event?.id || ''} is missing an OpenF1 session key`);
     }
 
-    const [sessionResults, startingGrid] = await Promise.all([
+    const [sessionResults, startingGrid, pitStops] = await Promise.all([
       this.request('/session_result', { session_key: sessionKey }),
       this.request('/starting_grid', { session_key: sessionKey }),
+      this.request('/pit', { session_key: sessionKey }),
     ]);
 
     const gridByDriver = new Map(
       startingGrid.map((row) => [Number(row.driver_number), Number(row.position) || null])
     );
+    const slowestPitByDriver = new Map();
+
+    pitStops.forEach((row) => {
+      const driverNumber = Number(row.driver_number);
+      const stopDuration = Number(row.stop_duration);
+      if (!Number.isFinite(driverNumber) || !Number.isFinite(stopDuration) || stopDuration <= 0) return;
+
+      const current = slowestPitByDriver.get(driverNumber);
+      if (current == null || stopDuration > current) {
+        slowestPitByDriver.set(driverNumber, stopDuration);
+      }
+    });
 
     const rows = sessionResults
       .map((row) => ({
         external_driver_id: Number(row.driver_number),
         finish_position: Number(row.position),
         start_position: gridByDriver.get(Number(row.driver_number)) ?? null,
+        slowest_pit_stop_seconds: slowestPitByDriver.get(Number(row.driver_number)) ?? null,
       }))
       .filter((row) => Number.isFinite(row.external_driver_id) && Number.isFinite(row.finish_position) && row.finish_position > 0)
       .sort((a, b) => a.finish_position - b.finish_position);

--- a/apps/f1/server/routes/admin.js
+++ b/apps/f1/server/routes/admin.js
@@ -101,6 +101,12 @@ router.post('/auction/close', withAdmin, (req, res) => {
   return runAndRespond(res, result, () => ({ ok: true }));
 });
 
+router.post('/auction/shuffle', withAdmin, (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const result = auctionAdminService.shufflePendingAuctionQueue({ seasonId });
+  return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
+});
+
 router.get('/payout-rules', withAdmin, (req, res) => {
   const seasonId = getActiveSeasonId();
   return res.json(payoutRulesAdminService.getPayoutRulesForSeason({ seasonId }));
@@ -243,6 +249,15 @@ router.patch('/results/event/:id', withAdmin, (req, res) => {
 router.post('/results/recalc-season-bonuses', withAdmin, (req, res) => {
   const seasonId = getActiveSeasonId();
   const result = resultsAdminService.recalcSeasonBonusesForSeason({
+    seasonId,
+    io: req.app.get('io'),
+  });
+  return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
+});
+
+router.post('/results/rescore-season-events', withAdmin, (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const result = resultsAdminService.rescoreSeasonEventsForSeason({
     seasonId,
     io: req.app.get('io'),
   });

--- a/apps/f1/server/routes/auction.js
+++ b/apps/f1/server/routes/auction.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const {
   getActiveSeasonId,
+  getSeasonSettings,
   getAuctionItems,
   getActiveAuctionItem,
   getRecentBids,
   getResolvedAuctionStatus,
+  getParticipantAuctionBudgetSummary,
 } = require('../db');
 const { requireAuth } = require('./middleware');
 
@@ -13,11 +15,21 @@ const router = express.Router();
 router.get('/', requireAuth, (req, res) => {
   const seasonId = getActiveSeasonId();
   const active = getActiveAuctionItem(seasonId);
+  const settings = getSeasonSettings(seasonId);
+  const budgetSummary = req.participant && !req.participant.is_admin
+    ? getParticipantAuctionBudgetSummary(seasonId, req.participant.id, settings.auction_budget_cap_cents)
+    : {
+      auctionBudgetCapCents: Number(settings?.auction_budget_cap_cents || 0),
+      participantSpentCents: 0,
+      participantReservedBidCents: 0,
+      participantRemainingCents: Number(settings?.auction_budget_cap_cents || 0),
+    };
   res.json({
     auctionStatus: getResolvedAuctionStatus(seasonId),
     active,
     recentBids: active ? getRecentBids(active.driver_id, seasonId) : [],
     items: getAuctionItems(seasonId),
+    ...budgetSummary,
   });
 });
 

--- a/apps/f1/server/services/admin/auctionAdminService.js
+++ b/apps/f1/server/services/admin/auctionAdminService.js
@@ -6,6 +6,7 @@ const {
   getSeasonParticipants,
   getAuctionItems,
 } = require('../../db');
+const { shuffleArray } = require('../../lib/shuffle');
 
 function getSettings({ seasonId }) {
   return getSeasonSettings(seasonId);
@@ -58,6 +59,34 @@ function updateAuctionQueue({ seasonId, order }) {
   return { ok: true };
 }
 
+function shufflePendingAuctionQueue({ seasonId, shuffle = shuffleArray }) {
+  const pendingItems = db.prepare(`
+    SELECT id
+    FROM auction_items
+    WHERE season_id = ? AND status = 'pending'
+    ORDER BY queue_order ASC, id ASC
+  `).all(seasonId);
+
+  const update = db.prepare(`
+    UPDATE auction_items
+    SET queue_order = ?
+    WHERE id = ? AND season_id = ? AND status = 'pending'
+  `);
+
+  const shuffled = shuffle(pendingItems);
+  db.transaction(() => {
+    shuffled.forEach((item, idx) => update.run(idx, item.id, seasonId));
+  })();
+
+  return {
+    ok: true,
+    shuffledCount: shuffled.length,
+    message: shuffled.length
+      ? `Shuffled ${shuffled.length} pending drivers.`
+      : 'No pending drivers to shuffle.',
+  };
+}
+
 function setAuctionStatus({ seasonId, status, io }) {
   updateSeasonSettings(seasonId, { auction_status: status });
   io?.emit('auction:status', { status });
@@ -80,6 +109,7 @@ module.exports = {
   removeParticipant,
   listAuctionQueue,
   updateAuctionQueue,
+  shufflePendingAuctionQueue,
   setAuctionStatus,
   startNextAuction,
   closeActiveAuction,

--- a/apps/f1/server/services/admin/resultsAdminService.js
+++ b/apps/f1/server/services/admin/resultsAdminService.js
@@ -11,10 +11,12 @@ const {
 const {
   scoreEvent,
   recalcSeasonBonuses,
+  rescoreSeasonEvents,
   upsertEventResults,
   syncEventFromProvider,
   syncNextEventFromProvider,
 } = require('../scoringService');
+const { shuffleArray } = require('../../lib/shuffle');
 
 function normalizeText(value) {
   return String(value || '').replace(/\s+/g, ' ').trim().toLowerCase();
@@ -454,12 +456,14 @@ async function loadHistoricalSeasonMetadata({ seasonId, provider, year, io, auct
       VALUES (?, ?, ?, ?, ?, ?, ?)
     `);
 
+    const insertedDriverIds = [];
+
     db.transaction(() => {
       deleteAuctionItems.run(seasonId);
       deleteDrivers.run(seasonId);
       deleteEvents.run(seasonId);
 
-      drivers.forEach((driver, idx) => {
+      drivers.forEach((driver) => {
         const insert = insertDriver.run(
           seasonId,
           driver.external_id,
@@ -467,7 +471,11 @@ async function loadHistoricalSeasonMetadata({ seasonId, provider, year, io, auct
           driver.name,
           driver.team_name,
         );
-        insertAuctionItem.run(seasonId, insert.lastInsertRowid, idx);
+        insertedDriverIds.push(insert.lastInsertRowid);
+      });
+
+      shuffleArray(insertedDriverIds).forEach((driverId, idx) => {
+        insertAuctionItem.run(seasonId, driverId, idx);
       });
 
       events.forEach((event) => {
@@ -562,6 +570,13 @@ function recalcSeasonBonusesForSeason({ seasonId, io }) {
   return { ok: true, ...result };
 }
 
+function rescoreSeasonEventsForSeason({ seasonId, io }) {
+  const result = rescoreSeasonEvents({ seasonId });
+  if (!result.ok) return result;
+  io?.emit('standings:update');
+  return { ok: true, ...result, message: `Rescored ${result.rescoredEvents} scored events under the current rule set.` };
+}
+
 function getSeasonBonusPayouts({ seasonId }) {
   const rows = db.prepare(`
     SELECT sbp.id, sbp.category, sbp.amount_cents, sbp.tie_count,
@@ -597,5 +612,6 @@ module.exports = {
   getEventEditorData,
   saveManualResultsAndScore,
   recalcSeasonBonusesForSeason,
+  rescoreSeasonEventsForSeason,
   getSeasonBonusPayouts,
 };

--- a/apps/f1/server/services/auctionService.js
+++ b/apps/f1/server/services/auctionService.js
@@ -12,7 +12,19 @@ const {
   getRecentBids,
   getAuctionCounts,
   getResolvedAuctionStatus,
+  getParticipantSpendCents,
+  getParticipantReservedBidCents,
+  getParticipantAuctionBudgetSummary,
 } = require('../db');
+
+function formatCurrencyCents(cents) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format((Number(cents) || 0) / 100);
+}
 
 function createAuctionService(io, options = {}) {
   const autoAdvanceDelayMs = options.autoAdvanceDelayMs ?? 2500;
@@ -207,6 +219,22 @@ function createAuctionService(io, options = {}) {
       return { ok: false, status: 400, error: 'Bid must be higher than current price' };
     }
 
+    const budgetCapCents = Number(settings.auction_budget_cap_cents || 0);
+    const spentCents = getParticipantSpendCents(sid, participant.id);
+    const currentReservedBidCents = getParticipantReservedBidCents(sid, participant.id);
+    const nextReservedBidCents = active.current_leader_id === participant.id ? currentReservedBidCents : bidAmount;
+    const committedCents = spentCents + nextReservedBidCents;
+
+    if (committedCents > budgetCapCents) {
+      const budgetSummary = getParticipantAuctionBudgetSummary(sid, participant.id, budgetCapCents);
+      const availableBidCents = Math.max(0, budgetCapCents - spentCents);
+      return {
+        ok: false,
+        status: 400,
+        error: `Bid exceeds your ${formatCurrencyCents(budgetCapCents)} cap. Remaining budget: ${formatCurrencyCents(budgetSummary.participantRemainingCents)}. Maximum available bid: ${formatCurrencyCents(availableBidCents)}.`,
+      };
+    }
+
     const newEndTime = extendBidEndTime({
       nowMs: Date.now(),
       existingEndTime: active.bid_end_time,
@@ -246,11 +274,22 @@ function createAuctionService(io, options = {}) {
     const sid = seasonId ?? getActiveSeasonId();
     const active = getActiveAuctionItem(sid);
     const auctionStatus = getResolvedAuctionStatus(sid);
+    const settings = getSeasonSettings(sid);
+    const participant = socket?.data?.participant || null;
+    const budgetSummary = participant && !participant.is_admin
+      ? getParticipantAuctionBudgetSummary(sid, participant.id, settings.auction_budget_cap_cents)
+      : {
+        auctionBudgetCapCents: Number(settings.auction_budget_cap_cents || 0),
+        participantSpentCents: 0,
+        participantReservedBidCents: 0,
+        participantRemainingCents: Number(settings.auction_budget_cap_cents || 0),
+      };
     socket.emit('auction:state', {
       auctionStatus,
       active,
       recentBids: active ? getRecentBids(active.driver_id, sid) : [],
       items: getAuctionItems(sid),
+      ...budgetSummary,
     });
   }
 

--- a/apps/f1/server/services/payoutAuditService.js
+++ b/apps/f1/server/services/payoutAuditService.js
@@ -113,6 +113,7 @@ function buildEventPayoutAudit({ seasonId, eventId }) {
         finish_position: row?.finish_position ?? null,
         start_position: row?.start_position ?? null,
         positions_gained: row?.positions_gained ?? null,
+        slowest_pit_stop_seconds: row?.slowest_pit_stop_seconds ?? null,
         owner_participant_id: ownerParticipantId,
         owner_participant_name: ownerParticipant?.name || null,
         split_share_cents: splitShareCents,

--- a/apps/f1/server/services/payoutRuleResolvers.js
+++ b/apps/f1/server/services/payoutRuleResolvers.js
@@ -35,6 +35,20 @@ function mostPositionsGained(rows, denseRank) {
   };
 }
 
+function slowestPitStop(rows) {
+  const eligible = rows.filter((row) => Number.isFinite(Number(row.slowest_pit_stop_seconds)) && Number(row.slowest_pit_stop_seconds) > 0);
+  if (!eligible.length) {
+    return { winnerDriverIds: [], targetDuration: null };
+  }
+  const targetDuration = Math.max(...eligible.map((row) => Number(row.slowest_pit_stop_seconds)));
+  return {
+    winnerDriverIds: eligible
+      .filter((row) => Number(row.slowest_pit_stop_seconds) === targetDuration)
+      .map((row) => row.driver_id),
+    targetDuration,
+  };
+}
+
 function randomPositionWinners(rows, randomPosition) {
   if (!randomPosition) return [];
   return rows
@@ -111,6 +125,18 @@ function evaluateCategoryRule({ category, rows, event, rankOrder = 1 }) {
         },
       };
     }
+    case 'slowest_pit_stop': {
+      const slowestPit = slowestPitStop(rows);
+      return {
+        winnerDriverIds: slowestPit.winnerDriverIds,
+        criteriaText: 'Slowest recorded pit stop',
+        resolution: {
+          metric: 'slowest_pit_stop_seconds',
+          target_value: slowestPit.targetDuration,
+          note: 'Highest OpenF1 stop_duration recorded for a driver in this event',
+        },
+      };
+    }
     case 'second_most_positions_gained': {
       const secondMostGain = mostPositionsGained(rows, rankOrder || 2);
       return {
@@ -154,6 +180,7 @@ module.exports = {
   winnersByFinish,
   bestFinisherAtOrBelow,
   mostPositionsGained,
+  slowestPitStop,
   randomPositionWinners,
   resolveCategoryWinners,
   evaluateCategoryRule,

--- a/apps/f1/server/services/scoringService.js
+++ b/apps/f1/server/services/scoringService.js
@@ -292,14 +292,17 @@ function upsertEventResults({ seasonId, eventId, rows, manualOverride = false })
     if (!driverId) return null;
     const finish = Number(row.finish_position);
     const start = Number(row.start_position);
+    const slowestPitStop = Number(row.slowest_pit_stop_seconds);
     if (!Number.isFinite(finish) || finish < 1) return null;
     const startPos = Number.isFinite(start) && start >= 1 ? start : null;
+    const pitStopSeconds = Number.isFinite(slowestPitStop) && slowestPitStop > 0 ? slowestPitStop : null;
 
     return {
       driver_id: driverId,
       finish_position: Math.floor(finish),
       start_position: startPos,
       positions_gained: startPos ? (startPos - Math.floor(finish)) : 0,
+      slowest_pit_stop_seconds: pitStopSeconds,
       is_manual_override: manualOverride ? 1 : 0,
     };
   }).filter(Boolean);
@@ -310,8 +313,8 @@ function upsertEventResults({ seasonId, eventId, rows, manualOverride = false })
 
   const insert = db.prepare(`
     INSERT INTO event_results
-      (event_id, driver_id, finish_position, start_position, positions_gained, is_manual_override, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+      (event_id, driver_id, finish_position, start_position, positions_gained, slowest_pit_stop_seconds, is_manual_override, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   db.transaction(() => {
@@ -324,6 +327,7 @@ function upsertEventResults({ seasonId, eventId, rows, manualOverride = false })
         row.finish_position,
         row.start_position,
         row.positions_gained,
+        row.slowest_pit_stop_seconds,
         row.is_manual_override,
         Date.now()
       );

--- a/apps/f1/server/tests/adminApiHelpers.test.js
+++ b/apps/f1/server/tests/adminApiHelpers.test.js
@@ -20,11 +20,13 @@ test('admin api helper normalizes settings and rules payloads', async () => {
     auction_timer_seconds: '45',
     auction_grace_seconds: '15',
     auction_auto_advance: true,
+    auction_budget_cap_cents: '250',
   });
   assert.deepEqual(settings, {
     auction_timer_seconds: 45,
     auction_grace_seconds: 15,
     auction_auto_advance: 1,
+    auction_budget_cap_cents: 25000,
   });
 
   const rules = normalizeRulesPayload({

--- a/apps/f1/server/tests/adminServices.test.js
+++ b/apps/f1/server/tests/adminServices.test.js
@@ -13,7 +13,8 @@ function freshModules() {
   const dbModule = require('../db');
   const resultsAdminService = require('../services/admin/resultsAdminService');
   const payoutRulesAdminService = require('../services/admin/payoutRulesAdminService');
-  return { ...dbModule, resultsAdminService, payoutRulesAdminService };
+  const auctionAdminService = require('../services/admin/auctionAdminService');
+  return { ...dbModule, resultsAdminService, payoutRulesAdminService, auctionAdminService };
 }
 
 function setupDb() {
@@ -259,6 +260,54 @@ test('results admin refreshSchedule matches by round and type when provider name
 
   assert.equal(australianGp.external_event_id, '9901');
   assert.equal(australianGp.name, 'FORMULA 1 LOUIS VUITTON AUSTRALIAN GRAND PRIX 2026');
+});
+
+test('auction admin shufflePendingAuctionQueue reorders pending drivers only', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    auctionAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const before = db.prepare(`
+    SELECT id, queue_order, status
+    FROM auction_items
+    WHERE season_id = ?
+    ORDER BY queue_order ASC, id ASC
+    LIMIT 5
+  `).all(seasonId);
+
+  db.prepare(`
+    UPDATE auction_items
+    SET status = 'sold'
+    WHERE id = ?
+  `).run(before[0].id);
+
+  const result = auctionAdminService.shufflePendingAuctionQueue({
+    seasonId,
+    shuffle: (items) => [...items].reverse(),
+  });
+  assert.equal(result.ok, true);
+  assert.ok(result.shuffledCount > 0);
+
+  const sold = db.prepare('SELECT queue_order, status FROM auction_items WHERE id = ?').get(before[0].id);
+  assert.equal(sold.status, 'sold');
+  assert.equal(sold.queue_order, before[0].queue_order);
+
+  const pending = db.prepare(`
+    SELECT id, queue_order
+    FROM auction_items
+    WHERE season_id = ? AND status = 'pending'
+    ORDER BY queue_order ASC
+    LIMIT 5
+  `).all(seasonId);
+
+  assert.deepEqual(pending.map((item) => item.queue_order), [0, 1, 2, 3, 4]);
+  assert.notDeepEqual(
+    pending.map((item) => item.id),
+    before.slice(1).map((item) => item.id),
+  );
 });
 
 test('results admin refreshSchedule inserts missing sprint-weekend grand prix rows', async () => {
@@ -583,6 +632,87 @@ test('results admin loadHistoricalSeasonMetadata replaces drivers and events wit
   `).get(seasonId);
   assert.equal(loadedSprint.external_event_id, '2025-2-sprint');
   assert.equal(loadedSprint.name, 'Chinese Grand Prix (Sprint)');
+});
+
+test('results admin rescoreSeasonEventsForSeason rewrites scored event payouts under current rules', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const event = db.prepare(`
+    SELECT id
+    FROM events
+    WHERE season_id = ? AND type = 'grand_prix'
+    ORDER BY round_number ASC
+    LIMIT 1
+  `).get(seasonId);
+  const [d1, d2] = db.prepare(`
+    SELECT id, external_id
+    FROM drivers
+    WHERE season_id = ?
+    ORDER BY external_id ASC
+    LIMIT 2
+  `).all(seasonId);
+
+  const participantId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('Rescore Tester', '#ffaa00', 'rescore-token')
+  `).run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, d2.id, participantId, 1000);
+
+  db.prepare(`
+    INSERT INTO event_results
+      (event_id, driver_id, finish_position, start_position, positions_gained, slowest_pit_stop_seconds, is_manual_override)
+    VALUES (?, ?, ?, ?, ?, ?, 1)
+  `).run(event.id, d1.id, 3, 2, -1, 2.111);
+  db.prepare(`
+    INSERT INTO event_results
+      (event_id, driver_id, finish_position, start_position, positions_gained, slowest_pit_stop_seconds, is_manual_override)
+    VALUES (?, ?, ?, ?, ?, ?, 1)
+  `).run(event.id, d2.id, 8, 7, -1, 7.456);
+  db.prepare(`
+    UPDATE events
+    SET status = 'scored', lock_at = '2000-01-01T00:00:00Z'
+    WHERE id = ?
+  `).run(event.id);
+
+  db.prepare(`
+    INSERT INTO event_payouts (season_id, event_id, participant_id, driver_id, category, amount_cents, tie_count)
+    VALUES (?, ?, ?, ?, 'second_most_positions_gained', 999, 1)
+  `).run(seasonId, event.id, participantId, d2.id);
+
+  const emitted = [];
+  const result = resultsAdminService.rescoreSeasonEventsForSeason({
+    seasonId,
+    io: { emit: (eventName) => emitted.push(eventName) },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.rescoredEvents, 1);
+  assert.ok(emitted.includes('standings:update'));
+
+  const stalePayoutCount = db.prepare(`
+    SELECT COUNT(*) as c
+    FROM event_payouts
+    WHERE season_id = ? AND event_id = ? AND category = 'second_most_positions_gained'
+  `).get(seasonId, event.id).c;
+  assert.equal(stalePayoutCount, 0);
+
+  const newPayout = db.prepare(`
+    SELECT participant_id, driver_id, category, amount_cents
+    FROM event_payouts
+    WHERE season_id = ? AND event_id = ? AND category = 'slowest_pit_stop'
+  `).get(seasonId, event.id);
+  assert.equal(newPayout.participant_id, participantId);
+  assert.equal(newPayout.driver_id, d2.id);
+  assert.equal(newPayout.amount_cents, 3);
 });
 
 test('payout rules admin save triggers bonus recalc path and standings update emit', () => {

--- a/apps/f1/server/tests/openF1ResultsProvider.test.js
+++ b/apps/f1/server/tests/openF1ResultsProvider.test.js
@@ -92,6 +92,11 @@ test('OpenF1ResultsProvider normalizes season schedule and event results', async
       { driver_number: 1, position: 4 },
       { driver_number: 16, position: 2 },
     ],
+    '/v1/pit?session_key=9001': [
+      { driver_number: 1, stop_duration: 2.455 },
+      { driver_number: 1, stop_duration: 3.102 },
+      { driver_number: 16, stop_duration: 2.201 },
+    ],
   };
 
   const provider = new OpenF1ResultsProvider({
@@ -125,8 +130,8 @@ test('OpenF1ResultsProvider normalizes season schedule and event results', async
     event: { external_event_id: '9001' },
   });
   assert.deepEqual(results, [
-    { external_driver_id: 16, finish_position: 1, start_position: 2 },
-    { external_driver_id: 1, finish_position: 2, start_position: 4 },
+    { external_driver_id: 16, finish_position: 1, start_position: 2, slowest_pit_stop_seconds: 2.201 },
+    { external_driver_id: 1, finish_position: 2, start_position: 4, slowest_pit_stop_seconds: 3.102 },
   ]);
 });
 

--- a/apps/f1/server/tests/scoringService.test.js
+++ b/apps/f1/server/tests/scoringService.test.js
@@ -115,6 +115,73 @@ test('random bonus position is immutable after first scoring', () => {
   assert.equal(secondDraw, firstDraw);
 });
 
+test('season settings default auction budget cap is $200', () => {
+  const { getActiveSeasonId, getSeasonSettings } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const settings = getSeasonSettings(seasonId);
+  assert.equal(settings.auction_budget_cap_cents, 20000);
+});
+
+test('slowest pit stop payout uses highest recorded stop duration', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    upsertEventResults,
+    scoreEvent,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const event = db.prepare(`
+    SELECT id
+    FROM events
+    WHERE season_id = ? AND type = 'grand_prix'
+    ORDER BY round_number ASC
+    LIMIT 1
+  `).get(seasonId);
+  db.prepare('UPDATE events SET lock_at = ? WHERE id = ?').run('2000-01-01T00:00:00Z', event.id);
+
+  const participantId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('Pit-Tester', '#ff8a65', 'tok-pit')
+  `).run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+
+  const [d1, d2] = db.prepare(`
+    SELECT id, external_id
+    FROM drivers
+    WHERE season_id = ?
+    ORDER BY external_id ASC
+    LIMIT 2
+  `).all(seasonId);
+
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, d2.id, participantId, 1000);
+
+  upsertEventResults({
+    seasonId,
+    eventId: event.id,
+    rows: [
+      { external_driver_id: d1.external_id, finish_position: 5, start_position: 3, slowest_pit_stop_seconds: 2.411 },
+      { external_driver_id: d2.external_id, finish_position: 9, start_position: 8, slowest_pit_stop_seconds: 6.834 },
+    ],
+  });
+
+  const score = scoreEvent({ seasonId, eventId: event.id });
+  assert.equal(score.ok, true);
+
+  const payout = db.prepare(`
+    SELECT participant_id, driver_id, amount_cents
+    FROM event_payouts
+    WHERE season_id = ? AND event_id = ? AND category = 'slowest_pit_stop'
+  `).get(seasonId, event.id);
+
+  assert.equal(payout.participant_id, participantId);
+  assert.equal(payout.driver_id, d2.id);
+  assert.equal(payout.amount_cents, 3);
+});
+
 test('auction lifecycle sells driver and records ownership', () => {
   const {
     db,
@@ -147,6 +214,109 @@ test('auction lifecycle sells driver and records ownership', () => {
 
   const ownershipCount = db.prepare('SELECT COUNT(*) as c FROM ownership WHERE season_id = ?').get(seasonId).c;
   assert.equal(ownershipCount, 1);
+});
+
+test('auction rejects bids that exceed participant budget cap', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    createAuctionService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const participantId = db.prepare("INSERT INTO participants (name, color, session_token) VALUES ('Budget Bob', '#22aaee', 'tok-budget')").run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+
+  const driver = db.prepare('SELECT id FROM drivers WHERE season_id = ? ORDER BY external_id ASC LIMIT 1').get(seasonId);
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, driver.id, participantId, 19900);
+
+  const io = { emit: () => {} };
+  const auction = createAuctionService(io, {
+    setTimeoutFn: () => 0,
+    clearTimeoutFn: () => {},
+  });
+
+  assert.equal(auction.startAuction({ seasonId }).ok, true);
+  const participant = db.prepare('SELECT * FROM participants WHERE id = ?').get(participantId);
+  const bid = auction.placeBid({ participant, amountCents: 200 });
+  assert.equal(bid.ok, false);
+  assert.match(bid.error, /exceeds your \$200 cap/i);
+});
+
+test('auction budget summary counts current live high bid as reserved commitment', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    getSeasonSettings,
+    getParticipantAuctionBudgetSummary,
+    createAuctionService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const participantId = db.prepare("INSERT INTO participants (name, color, session_token) VALUES ('Reserve Rita', '#33aa55', 'tok-reserve')").run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+
+  const io = { emit: () => {} };
+  const auction = createAuctionService(io, {
+    setTimeoutFn: () => 0,
+    clearTimeoutFn: () => {},
+  });
+
+  assert.equal(auction.startAuction({ seasonId }).ok, true);
+  const participant = db.prepare('SELECT * FROM participants WHERE id = ?').get(participantId);
+  assert.equal(auction.placeBid({ participant, amountCents: 4500 }).ok, true);
+
+  const settings = getSeasonSettings(seasonId);
+  const budget = getParticipantAuctionBudgetSummary(seasonId, participantId, settings.auction_budget_cap_cents);
+  assert.equal(budget.participantSpentCents, 0);
+  assert.equal(budget.participantReservedBidCents, 4500);
+  assert.equal(budget.participantRemainingCents, 15500);
+});
+
+test('existing over-cap ownership blocks future bids without rewriting prior data', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    createAuctionService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const participantId = db.prepare("INSERT INTO participants (name, color, session_token) VALUES ('Over Cap Owen', '#cc6622', 'tok-overcap')").run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+
+  const [driverA, driverB] = db.prepare('SELECT id FROM drivers WHERE season_id = ? ORDER BY external_id ASC LIMIT 2').all(seasonId);
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, driverA.id, participantId, 21000);
+
+  const io = { emit: () => {} };
+  const auction = createAuctionService(io, {
+    setTimeoutFn: () => 0,
+    clearTimeoutFn: () => {},
+  });
+
+  db.prepare(`
+    UPDATE auction_items
+    SET queue_order = CASE WHEN driver_id = ? THEN 0 ELSE queue_order + 1 END
+    WHERE season_id = ?
+  `).run(driverB.id, seasonId);
+
+  assert.equal(auction.startAuction({ seasonId, driverId: driverB.id }).ok, true);
+  const participant = db.prepare('SELECT * FROM participants WHERE id = ?').get(participantId);
+  const bid = auction.placeBid({ participant, amountCents: 100 });
+  assert.equal(bid.ok, false);
+  assert.match(bid.error, /remaining budget/i);
+
+  const ownershipAmount = db.prepare(`
+    SELECT purchase_price_cents
+    FROM ownership
+    WHERE season_id = ? AND driver_id = ? AND participant_id = ?
+  `).get(seasonId, driverA.id, participantId).purchase_price_cents;
+  assert.equal(ownershipAmount, 21000);
 });
 
 test('random bonus draw ranges follow payout model v2 bounds by event type', () => {

--- a/docs/adr/0003-f1-pit-stop-novelty-rule.md
+++ b/docs/adr/0003-f1-pit-stop-novelty-rule.md
@@ -1,0 +1,43 @@
+## Status
+
+Accepted - 2026-03-05
+
+## Context
+
+The F1 event payout model originally used `second_most_positions_gained` as a Grand Prix rule.
+That category overlapped too heavily with `most_positions_gained` and did not create a meaningfully different payout experience.
+
+For the first season, the product direction is to allow one deliberate novelty/chaos category as long as:
+
+1. the data source is explicit,
+2. the scoring is deterministic,
+3. the payout audit can explain the outcome.
+
+OpenF1 documents pit-stop `stop_duration` under its pit endpoint. The metric is imperfect as a pure racing-performance signal, but it is well-defined enough for a novelty rule when surfaced transparently.
+
+## Decision
+
+Replace the F1 Grand Prix payout rule `second_most_positions_gained` with `slowest_pit_stop`.
+
+Implementation semantics:
+
+1. Source: OpenF1 `pit` endpoint `stop_duration`
+2. Stored per driver per event as `event_results.slowest_pit_stop_seconds`
+3. Winner: driver with the highest recorded pit-stop duration in that event
+4. Drivers without a recorded pit stop are excluded
+5. Ties split using the existing even-cent split logic
+6. Manual test-data entry may provide this value directly
+
+## Consequences
+
+Positive:
+
+1. The GP rule set becomes more distinct and intentionally chaotic.
+2. The rule remains auditable because the stored per-driver value is explicit.
+3. The app can still score historical/manual events without live provider calls.
+
+Negative:
+
+1. The rule rewards an operational mishap rather than a performance outcome.
+2. OpenF1 pit-stop coverage may be absent for some sessions, which means the category can resolve to no winner.
+3. Existing scored events that used the removed category may need rescore/reset if strict consistency is required.

--- a/docs/adr/0004-f1-auction-budget-cap.md
+++ b/docs/adr/0004-f1-auction-budget-cap.md
@@ -1,0 +1,49 @@
+## Status
+
+Accepted - 2026-03-05
+
+## Context
+
+The F1 auction previously had no server-enforced participant spending limit.
+That made test auctions easy to run, but it also allowed unrealistic ownership concentration and accidental overspending that could not be distinguished from intentional stress testing.
+
+The product requirement is to introduce a per-participant cap that:
+
+1. is configurable by admins,
+2. defaults to a realistic friend-group budget,
+3. is enforced deterministically on the server,
+4. accounts for a participant's current live leading bid as committed budget,
+5. does not rewrite or invalidate existing over-cap test data.
+
+Because this changes season-level auction semantics, the policy needs to be explicit in the decision log.
+
+## Decision
+
+Add an F1 season setting `auction_budget_cap_cents` with a default value of `20000` ($200).
+
+Implementation semantics:
+
+1. The cap applies per participant per season.
+2. The cap is enforced in server-side bid placement.
+3. A participant's committed auction spend is:
+   - sold ownership spend, plus
+   - the participant's current leading live bid, if any.
+4. Bids that would push committed spend above the cap are rejected.
+5. Existing ownership that already exceeds the cap is preserved, but future bids are blocked until the participant is back under the limit.
+6. Admin users remain non-bidding users and are not subject to auction participation budget calculations in the client UI.
+7. The auction API exposes cap, spent, reserved, and remaining budget values for the authenticated participant so the client can show remaining budget directly.
+
+## Consequences
+
+Positive:
+
+1. Auction behavior is closer to the intended real-money-style constraint model.
+2. Overspend prevention is deterministic and does not depend on client behavior.
+3. Participants can see remaining budget clearly during live bidding.
+4. Existing test setups are not destructively rewritten.
+
+Negative:
+
+1. The server now depends on additional per-bid budget queries and budget-summary bookkeeping.
+2. Existing over-cap test data can produce negative remaining budget displays until the season is reset or the cap is raised.
+3. Mid-auction cap reductions can immediately block additional bids for already-committed participants, which is intentional but operationally significant.


### PR DESCRIPTION
Summary
- add a season-level `auction_budget_cap_cents` setting with admin UI input and persistence in the F1 admin settings flow
- enforce the per-participant cap inside `auctionService.placeBid`, counting live high bids as reserved and blocking future bids when over cap without mutating historical ownership
- extend the auction API response with budget fields, show remaining budget to participants, guard quick/inline bids on the client, and document the new cap behavior

Testing
- Not run (not requested)