### PR TITLE
Fix driver roster sync to use live OpenF1 data

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,6 +65,7 @@ Both have:
 - F1 results ingestion uses a provider adapter:
   - `mock` for local/dev/test
   - `openf1` for real driver, schedule, and event-result data
+- F1 OpenF1 runtime can exchange backend credentials for a cached bearer token when the upstream provider restricts live-session access.
 - F1 provider sync state is persisted in `provider_sync_state`.
 - F1 event scoring remains admin-triggered by default; optional auto-poll calls the same sync path and does not override manual edits.
 

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -23,10 +23,15 @@ Owner: On-call engineer / active implementer
 - Scoring/payout engine tests passing.
 - Service shutdown path updated to avoid false-failure exits during orchestrator stop.
 - Results provider layer now supports OpenF1, admin-triggered driver/schedule refresh, and optional result auto-poll.
+- OpenF1 live-session windows now require backend auth support with cached token refresh via `OPENF1_USERNAME` / `OPENF1_PASSWORD`.
+- F1 driver refresh now supports an authoritative pre-auction roster rebuild from OpenF1 when the seeded 2026 lineup drifts from live provider data and the season has no auction/scoring activity yet.
+- F1 driver refresh now pulls the latest started non-testing session roster and falls back from `session_key` to `meeting_key` roster lookups when a live session weekend has started but the session-level roster is not populated yet.
+- F1 event sync now preserves unknown substitute/new race drivers as inactive, non-auction season drivers so event scoring can mark their payouts as unowned instead of dropping their result rows.
+- F1 OpenF1 access now rate-limits outbound provider calls against both short-burst and rolling minute windows to reduce `429` failures during admin refresh/sync operations.
 
 ## Active Priorities
 
-1. Confirm Railway deploy health with `F1_RESULTS_PROVIDER=openf1` in production.
+1. Confirm Railway deploy health with `F1_RESULTS_PROVIDER=openf1` plus OpenF1 credentials in production.
 2. Validate F1 driver and schedule refresh against live provider data before relying on event sync.
 3. Keep docs as single source of truth (no drift back into handoff files).
 
@@ -34,19 +39,20 @@ Owner: On-call engineer / active implementer
 
 1. Railway logs can show historical deployment errors; always verify by deployment ID and timestamp.
 2. OpenF1 field stability now affects driver/event mapping; mismatches fail closed and require admin correction.
-3. Auto-poll should remain opt-in until one production verification pass is complete.
-4. Shared package changes can cause silent cross-app impact if not scoped carefully.
+3. OpenF1 can reject unauthenticated requests during live sessions, so missing credentials now presents as provider-side `401` failures.
+4. Auto-poll should remain opt-in until one production verification pass is complete.
+5. Shared package changes can cause silent cross-app impact if not scoped carefully.
 
 ## Recent Completed Work
 
 1. Introduced docs control plane (`AGENTS`, `SOUL`, `HEARTBEAT`, `ARCHITECTURE`, `DESIGN`, `RUNBOOK`, ADRs).
 2. Converted handoff docs to compatibility stubs.
 3. Hardened NCAA/F1 shutdown behavior to avoid false deployment-failure exits.
-4. Added F1 OpenF1 provider integration with provider diagnostics, metadata refresh controls, and optional auto-poll.
+4. Added F1 OpenF1 provider integration with provider diagnostics, metadata refresh controls, optional auto-poll, and live-session auth support.
 
 ## Next Suggested Actions
 
-1. Run one F1 deploy with `F1_RESULTS_PROVIDER=openf1`, then verify `/api/admin/results/provider-status`.
+1. Run one F1 deploy with `F1_RESULTS_PROVIDER=openf1`, `OPENF1_USERNAME`, and `OPENF1_PASSWORD`, then verify `/api/admin/results/provider-status`.
 2. Refresh F1 drivers and schedule once in admin, then confirm event mappings before syncing results.
 3. Add follow-up ADR if additional Railway-specific behavior is discovered.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -32,14 +32,18 @@ Operational guide for deploying, validating, and recovering NCAA/F1 services.
 - `ADMIN_PASSWORD`
 - `NODE_ENV=production`
 - `DB_PATH=/data/f1-calcutta.db`
-- optional: `F1_CLIENT_ORIGIN`, `F1_RESULTS_PROVIDER`, `F1_AUTO_POLL_ENABLED`, `F1_AUTO_POLL_INTERVAL_SECONDS`, `OPENF1_BASE_URL`
+- `F1_RESULTS_PROVIDER=openf1`
+- `OPENF1_USERNAME`
+- `OPENF1_PASSWORD`
+- optional: `F1_CLIENT_ORIGIN`, `F1_AUTO_POLL_ENABLED`, `F1_AUTO_POLL_INTERVAL_SECONDS`, `OPENF1_BASE_URL`, `OPENF1_TOKEN_URL`
 
 ## F1 Provider Defaults
 
 1. Production should use `F1_RESULTS_PROVIDER=openf1`.
-2. `mock` is intended for local/dev/test only.
-3. Do not set `F1_PORT` in Railway.
-4. Keep `F1_AUTO_POLL_ENABLED=0` until one successful manual OpenF1 verification pass is complete.
+2. OpenF1 live-session windows can require authenticated backend requests even for historical endpoints.
+3. `mock` is intended for local/dev/test only.
+4. Do not set `F1_PORT` in Railway.
+5. Keep `F1_AUTO_POLL_ENABLED=0` until one successful manual OpenF1 verification pass is complete.
 
 ## Deploy Validation
 
@@ -82,8 +86,10 @@ After deploy:
 
 1. Check `GET /api/admin/results/provider-status`.
 2. Verify `F1_RESULTS_PROVIDER=openf1` in production.
-3. Run admin `Refresh Drivers` and `Refresh Schedule` before syncing event results.
-4. If provider responses are incomplete or unmapped, use manual results entry and do not force-score partial provider data.
+3. Verify `OPENF1_USERNAME` and `OPENF1_PASSWORD` are set when OpenF1 returns live-session `401` responses.
+4. Run admin `Refresh Drivers` and `Refresh Schedule` before syncing event results.
+5. If OpenF1 returns `429`, wait briefly and retry; the F1 provider now serializes requests, spaces them, retries boundedly, and enforces a rolling minute budget, but repeated manual clicks can still queue work and extend refresh latency.
+6. If provider responses are incomplete or unmapped, use manual results entry and do not force-score partial provider data.
 
 ## Rollback Procedure
 

--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -14,6 +14,7 @@ A dedicated Formula 1 Calcutta app for a full season pool.
 - Season bonus payouts from remaining pool
 - Results sync via provider adapter (`openf1` for real data, `mock` for local/dev/test)
 - Admin controls for auction, sync, payout rules, and settings
+- Results Sync admin view shows collapsible driver/event lists after provider refreshes
 
 ## Run
 
@@ -40,11 +41,20 @@ Server: `http://localhost:3002`
 ## Runtime Notes
 
 - Production provider: `F1_RESULTS_PROVIDER=openf1`
+- OpenF1 live-session access now requires backend auth:
+  - `OPENF1_USERNAME`
+  - `OPENF1_PASSWORD`
+- optional token override: `OPENF1_TOKEN_URL`
+- Driver refresh now uses the latest started non-testing OpenF1 session roster and falls back from session_key to meeting_key lookups when a live session roster is not yet populated; if 2026 weekend data is still unavailable, admin will see a clear "no populated driver roster yet" message instead of a raw provider 404
+- Event result sync now preserves unknown substitute/new race drivers by inserting them as inactive season drivers with no auction item; their results still score, but any resulting payouts remain unowned/undistributed unless an owner exists
+- If the active season has no bids, ownership, or scored race data yet, driver refresh can now rebuild the season roster directly from OpenF1 when the provider lineup has drifted from the seeded 2026 driver list
+- OpenF1 requests are now serialized, spaced, bounded-retried on `429`, and limited against a rolling per-minute budget to match the provider's published rate limits more closely
 - Optional auto-poll:
   - `F1_AUTO_POLL_ENABLED=1`
   - `F1_AUTO_POLL_INTERVAL_SECONDS=<seconds>`
 - Local/dev/test may continue using `mock`
 - Admin Test Data page can load a 2025 OpenF1 driver/event dataset for pre-2026 flow testing
+- Admin Test Data page can restore the canonical seeded 2026 F1 drivers and events for recovery from polluted local metadata
 - Admin Test Data page can reset only auction state while keeping participants and scored race data
 - Admin Test Data page can rescore all scored events after payout-rule changes
 

--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -1591,6 +1591,73 @@ tbody tr:hover {
   min-height: 112px;
 }
 
+.admin-collapsible {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  background: rgba(10, 14, 20, 0.56);
+  overflow: hidden;
+}
+
+.admin-collapsible + .admin-collapsible {
+  margin-top: var(--space-3);
+}
+
+.admin-collapsible-summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  cursor: pointer;
+  padding: 0.7rem 0.8rem;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.admin-collapsible-summary::-webkit-details-marker {
+  display: none;
+}
+
+.admin-collapsible-summary strong {
+  display: block;
+}
+
+.admin-collapsible-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.admin-collapsible-time {
+  font-size: var(--text-xs);
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.admin-collapsible-count {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.22rem 0.5rem;
+  border-radius: var(--radius-sm);
+}
+
+.admin-collapsible > .muted.small,
+.admin-collapsible > .list {
+  margin: 0;
+}
+
+.admin-collapsible > .muted.small {
+  padding: 0 0.8rem 0.8rem;
+}
+
+.admin-sync-list {
+  padding: 0.8rem;
+}
+
 .bps-summary {
   margin-top: var(--space-2);
   display: flex;
@@ -1677,6 +1744,25 @@ tbody tr:hover {
 .audit-rule-detail {
   border-top: 1px solid rgba(255, 255, 255, 0.1);
   padding-top: var(--space-2);
+}
+
+.status-flag {
+  display: inline-flex;
+  align-items: center;
+  margin-left: var(--space-2);
+  padding: 0.12rem 0.42rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.substitute-flag {
+  color: #d7c39a;
+  border-color: rgba(215, 195, 154, 0.38);
+  background: rgba(215, 195, 154, 0.08);
 }
 
 .audit-winner-list {

--- a/apps/f1/client/src/pages/Events.jsx
+++ b/apps/f1/client/src/pages/Events.jsx
@@ -60,6 +60,10 @@ function winnerResultSummary(winner) {
   return `Finished ${finish}, started ${start}, gained ${gainText}.${pitText}`;
 }
 
+function isInactiveRaceOnlyDriver(driver) {
+  return Number(driver?.driver_active) === 0;
+}
+
 export default function Events() {
   const [events, setEvents] = useState([]);
   const [selectedEventId, setSelectedEventId] = useState(null);
@@ -412,6 +416,9 @@ export default function Events() {
                                         >
                                           <div>
                                             <strong>{winner.driver_name || winner.driver_code || 'Driver'}</strong>
+                                            {isInactiveRaceOnlyDriver(winner) ? (
+                                              <span className="status-flag substitute-flag">Substitute / Unauctioned</span>
+                                            ) : null}
                                             <div className="muted small">
                                               {winner.team_name || 'Team N/A'}
                                               {' • '}
@@ -456,6 +463,9 @@ export default function Events() {
                               showCode={false}
                               showTeam
                             />
+                            {isInactiveRaceOnlyDriver(result) ? (
+                              <span className="status-flag substitute-flag">Substitute / Unauctioned</span>
+                            ) : null}
                           </span>
                           <span className="muted">Started {result.start_position ?? 'N/A'}</span>
                         </li>

--- a/apps/f1/client/src/pages/admin/PayoutAuditPage.jsx
+++ b/apps/f1/client/src/pages/admin/PayoutAuditPage.jsx
@@ -30,6 +30,10 @@ function winnerResultSummary(winner) {
   return `Finished ${finish}, started ${start}, gained ${gainText}.${pitText}`;
 }
 
+function isInactiveRaceOnlyDriver(driver) {
+  return Number(driver?.driver_active) === 0;
+}
+
 export default function PayoutAuditPage() {
   const { events, loading, hasLoaded } = useAdminOutletContext();
   const [selectedEventId, setSelectedEventId] = useState('');
@@ -180,6 +184,9 @@ export default function PayoutAuditPage() {
                             <li key={`${currentRuleKey}:${winner.driver_id}`}>
                               <div>
                                 <strong>{winner.driver_name || winner.driver_code || 'Driver'}</strong>
+                                {isInactiveRaceOnlyDriver(winner) ? (
+                                  <span className="status-flag substitute-flag">Substitute / Unauctioned</span>
+                                ) : null}
                                 <div className="muted small">
                                   {winner.team_name || 'Team N/A'}
                                   {' • '}

--- a/apps/f1/client/src/pages/admin/ResultsPage.jsx
+++ b/apps/f1/client/src/pages/admin/ResultsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   eventTypeLabel,
   fmtCents,
@@ -9,6 +9,33 @@ import useAdminOutletContext from './useAdminOutletContext';
 function stateLabel(state) {
   if (!state?.status) return 'Not run';
   return String(state.status).replace(/_/g, ' ');
+}
+
+function formatEventTime(value) {
+  if (!value) return 'TBD';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'TBD';
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function formatRefreshTime(value) {
+  if (!value) return 'Not refreshed yet';
+  const numeric = Number(value);
+  const date = Number.isFinite(numeric) && String(value).trim() !== ''
+    ? new Date(numeric)
+    : new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Not refreshed yet';
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
 }
 
 export default function ResultsPage() {
@@ -28,6 +55,11 @@ export default function ResultsPage() {
     await runner();
     await refresh();
   }, [refresh]);
+
+  const refreshedDrivers = useMemo(
+    () => Array.isArray(providerStatus?.last_driver_refresh?.drivers) ? providerStatus.last_driver_refresh.drivers : [],
+    [providerStatus]
+  );
 
   if (loading && !hasLoaded) {
     return <AdminLoadingState />;
@@ -98,33 +130,89 @@ export default function ResultsPage() {
             </span>
           </div>
         </div>
-        <ul className="list">
-          {(events || []).map((event) => (
-            <li key={event.id}>
+        <div className="stack">
+          <details className="admin-collapsible" open={refreshedDrivers.length > 0}>
+            <summary className="admin-collapsible-summary">
               <div>
-                <strong>R{event.round_number}</strong> {event.name}
+                <strong>Refreshed Drivers</strong>
                 <div className="muted small">
-                  {eventTypeLabel(event.type)} • {event.status} • payout {fmtCents(event.total_payout_cents || 0)}
+                  {refreshedDrivers.length
+                    ? `${refreshedDrivers.length} drivers from the latest refresh.`
+                    : 'No successful driver refresh recorded yet.'}
                 </div>
               </div>
-              <div className="row wrap gap-sm">
-                <button
-                  className="btn btn-outline"
-                  onClick={() => runAndReload(() => syncEvent(event.id))}
-                >
-                  Sync
-                </button>
-                <button
-                  className="btn btn-outline"
-                  onClick={() => runAndReload(() => syncEvent(event.id, { force: true }))}
-                >
-                  Force Sync
-                </button>
+              <div className="admin-collapsible-meta">
+                <span className="admin-collapsible-time">
+                  {formatRefreshTime(providerStatus?.last_driver_refresh?.updated_at)}
+                </span>
+                <span className="admin-collapsible-count">{refreshedDrivers.length}</span>
               </div>
-            </li>
-          ))}
-        </ul>
-        {(!events || events.length === 0) ? <p className="muted small">No events available to sync.</p> : null}
+            </summary>
+            {refreshedDrivers.length ? (
+              <ul className="list admin-sync-list">
+                {refreshedDrivers.map((driver) => (
+                  <li key={`${driver.external_id}-${driver.code || driver.name}`}>
+                    <div>
+                      <strong>{driver.name}</strong>
+                      <div className="muted small">
+                        {driver.code} • {driver.team_name}
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="muted small">Run `Refresh Drivers` to inspect the provider driver list here.</p>
+            )}
+          </details>
+
+          <details className="admin-collapsible" open={Boolean(events?.length)}>
+            <summary className="admin-collapsible-summary">
+              <div>
+                <strong>Season Events</strong>
+                <div className="muted small">
+                  Current F1 event list for sync, review, and force-sync actions.
+                </div>
+              </div>
+              <div className="admin-collapsible-meta">
+                <span className="admin-collapsible-time">
+                  {formatRefreshTime(providerStatus?.last_schedule_refresh?.updated_at)}
+                </span>
+                <span className="admin-collapsible-count">{events?.length || 0}</span>
+              </div>
+            </summary>
+            {events?.length ? (
+              <ul className="list admin-sync-list">
+                {events.map((event) => (
+                  <li key={event.id}>
+                    <div>
+                      <strong>R{event.round_number}</strong> {event.name}
+                      <div className="muted small">
+                        {eventTypeLabel(event.type)} • {event.status} • {formatEventTime(event.starts_at)} • payout {fmtCents(event.total_payout_cents || 0)}
+                      </div>
+                    </div>
+                    <div className="row wrap gap-sm">
+                      <button
+                        className="btn btn-outline"
+                        onClick={() => runAndReload(() => syncEvent(event.id))}
+                      >
+                        Sync
+                      </button>
+                      <button
+                        className="btn btn-outline"
+                        onClick={() => runAndReload(() => syncEvent(event.id, { force: true }))}
+                      >
+                        Force Sync
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="muted small">No events available to sync.</p>
+            )}
+          </details>
+        </div>
       </section>
     </div>
   );

--- a/apps/f1/client/src/pages/admin/TestDataPage.jsx
+++ b/apps/f1/client/src/pages/admin/TestDataPage.jsx
@@ -45,6 +45,7 @@ export default function TestDataPage() {
     clearAllTestData,
     resetAuctionOnly,
     loadHistoricalSeasonData,
+    restoreSeeded2026Data,
     refresh,
     setMessage,
     loading,
@@ -223,6 +224,22 @@ export default function TestDataPage() {
     await loadSeasonBonusBreakdown();
   }, [loadHistoricalSeasonData, refresh, loadSeasonBonusBreakdown]);
 
+  const onRestore2026Data = useCallback(async () => {
+    const confirmed = window.confirm(
+      'Restore the active F1 season back to the canonical seeded 2026 drivers and events? This clears current auction data, results, payouts, and participants, then rebuilds the season metadata from the app seed data.'
+    );
+    if (!confirmed) return;
+
+    await restoreSeeded2026Data();
+    setSelectedEventId('');
+    setManualRows([]);
+    setManualMeta(null);
+    setBonusRows([]);
+    setBonusTotals([]);
+    await refresh();
+    await loadSeasonBonusBreakdown();
+  }, [restoreSeeded2026Data, refresh, loadSeasonBonusBreakdown]);
+
   const onRescoreSeasonEvents = useCallback(async () => {
     const confirmed = window.confirm(
       'Rescore all currently scored F1 events under the active payout rules? This rewrites event payouts and recalculates season bonuses for the active season.'
@@ -243,6 +260,23 @@ export default function TestDataPage() {
 
   return (
     <div className="stack-lg">
+      <section className="panel note-panel stack">
+        <div className="row between wrap gap-sm">
+          <div className="stack-xs">
+            <h2>Restore Seeded 2026 Data</h2>
+            <p className="muted small">
+              Rebuilds the active season from the canonical seeded 2026 F1 driver roster and 2026 event schedule. Use this to recover from polluted local test metadata before running OpenF1 refreshes.
+            </p>
+          </div>
+          <button
+            className="btn btn-outline"
+            onClick={onRestore2026Data}
+          >
+            Restore 2026 Drivers + Events
+          </button>
+        </div>
+      </section>
+
       <section className="panel note-panel stack">
         <div className="row between wrap gap-sm">
           <div className="stack-xs">

--- a/apps/f1/client/src/pages/admin/adminApi.js
+++ b/apps/f1/client/src/pages/admin/adminApi.js
@@ -101,6 +101,14 @@ export async function loadHistoricalSeasonData(year) {
   return parseApiResponse(response, 'Failed to load historical season data');
 }
 
+export async function restoreSeeded2026Data() {
+  const response = await api('/admin/test-data/restore-seeded-2026', {
+    method: 'POST',
+    body: '{}',
+  });
+  return parseApiResponse(response, 'Failed to restore seeded 2026 data');
+}
+
 export async function syncEvent(eventId, { force = false } = {}) {
   const response = await api(`/admin/results/sync-event/${eventId}`, {
     method: 'POST',

--- a/apps/f1/client/src/pages/admin/useAdminData.js
+++ b/apps/f1/client/src/pages/admin/useAdminData.js
@@ -9,6 +9,7 @@ import {
   readProviderStatus,
   recalcSeasonBonuses as recalcSeasonBonusesApi,
   resetAuctionOnly as resetAuctionOnlyApi,
+  restoreSeeded2026Data as restoreSeeded2026DataApi,
   rescoreSeasonEvents as rescoreSeasonEventsApi,
   refreshDrivers as refreshDriversApi,
   refreshSchedule as refreshScheduleApi,
@@ -170,6 +171,16 @@ export default function useAdminData() {
     }
   }, [loadAll]);
 
+  const restoreSeeded2026Data = useCallback(async () => {
+    try {
+      const result = await restoreSeeded2026DataApi();
+      setMessage(result.message || 'Restored seeded 2026 data.');
+      await loadAll({ silent: true });
+    } catch (error) {
+      setMessage(error.message || 'Failed to restore seeded 2026 data.');
+    }
+  }, [loadAll]);
+
   const updateRules = useCallback((group, id, field, value) => {
     setRules((prev) => {
       if (!prev?.[group]) return prev;
@@ -210,6 +221,7 @@ export default function useAdminData() {
     clearAllTestData,
     resetAuctionOnly,
     loadHistoricalSeasonData,
+    restoreSeeded2026Data,
     syncNext,
     syncEvent,
     recalcSeasonBonuses,
@@ -234,6 +246,7 @@ export default function useAdminData() {
     clearAllTestData,
     resetAuctionOnly,
     loadHistoricalSeasonData,
+    restoreSeeded2026Data,
     syncNext,
     syncEvent,
     recalcSeasonBonuses,

--- a/apps/f1/client/src/pages/admin/useAdminOutletContext.js
+++ b/apps/f1/client/src/pages/admin/useAdminOutletContext.js
@@ -20,6 +20,7 @@ import { useOutletContext } from 'react-router-dom';
  * @property {() => Promise<void>} clearAllTestData
  * @property {() => Promise<void>} resetAuctionOnly
  * @property {(year: number) => Promise<void>} loadHistoricalSeasonData
+ * @property {() => Promise<void>} restoreSeeded2026Data
  * @property {(options?: {force?: boolean}) => Promise<void>} syncNext
  * @property {(eventId: number, options?: {force?: boolean}) => Promise<void>} syncEvent
  * @property {() => Promise<void>} recalcSeasonBonuses

--- a/apps/f1/server/persistence/repositories/eventRepo.js
+++ b/apps/f1/server/persistence/repositories/eventRepo.js
@@ -53,7 +53,7 @@ function getEventById(db, seasonId, eventId) {
 function getEventResults(db, eventId) {
   return db.prepare(`
     SELECT er.*, d.external_id as driver_external_id, d.code as driver_code,
-           d.name as driver_name, d.team_name
+           d.name as driver_name, d.team_name, d.active as driver_active
     FROM event_results er
     JOIN drivers d ON d.id = er.driver_id
     WHERE er.event_id = ?

--- a/apps/f1/server/providers/index.js
+++ b/apps/f1/server/providers/index.js
@@ -19,6 +19,9 @@ function createResultsProvider() {
   if (provider === 'openf1') {
     return new OpenF1ResultsProvider({
       baseUrl: process.env.OPENF1_BASE_URL,
+      tokenUrl: process.env.OPENF1_TOKEN_URL,
+      username: process.env.OPENF1_USERNAME,
+      password: process.env.OPENF1_PASSWORD,
     });
   }
 

--- a/apps/f1/server/providers/openF1ResultsProvider.js
+++ b/apps/f1/server/providers/openF1ResultsProvider.js
@@ -1,4 +1,9 @@
 const DEFAULT_BASE_URL = 'https://api.openf1.org/v1';
+const DEFAULT_TOKEN_PATH = '/token';
+const DEFAULT_MIN_REQUEST_INTERVAL_MS = 200;
+const DEFAULT_MINUTE_WINDOW_MS = 60_000;
+const DEFAULT_MAX_REQUESTS_PER_MINUTE = 60;
+const DEFAULT_MAX_RATE_LIMIT_RETRIES = 3;
 const EVENT_NAME_OVERRIDES = {
   melbourne: 'Australian Grand Prix',
   shanghai: 'Chinese Grand Prix',
@@ -34,10 +39,30 @@ function normalizeBaseUrl(baseUrl) {
   return String(baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '');
 }
 
+function deriveTokenUrl(baseUrl, explicitTokenUrl) {
+  if (explicitTokenUrl) return String(explicitTokenUrl).trim();
+
+  const normalized = normalizeBaseUrl(baseUrl);
+  if (normalized.endsWith('/v1')) {
+    return `${normalized.slice(0, -3)}${DEFAULT_TOKEN_PATH}`;
+  }
+
+  try {
+    const url = new URL(normalized);
+    return `${url.origin}${DEFAULT_TOKEN_PATH}`;
+  } catch {
+    return DEFAULT_TOKEN_PATH;
+  }
+}
+
 function parseIsoDate(value) {
   const iso = String(value || '');
   const ms = Date.parse(iso);
   return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function subtractMinutes(iso, minutes) {
@@ -50,6 +75,41 @@ function normalizeSessionType(sessionName) {
   if (sessionName === 'Race') return 'grand_prix';
   if (sessionName === 'Sprint') return 'sprint';
   return null;
+}
+
+function isTestingSession(session = {}) {
+  const fields = [
+    session.session_name,
+    session.meeting_name,
+    session.meeting_official_name,
+    session.location,
+    session.country_name,
+    session.circuit_short_name,
+  ];
+
+  return fields.some((value) => /test/i.test(String(value || '')));
+}
+
+function isNoResultsFoundError(error) {
+  return /OpenF1 request failed \(404\): No results found\.?/i.test(String(error?.message || ''));
+}
+
+function normalizeProviderDriverRows(drivers) {
+  const deduped = new Map();
+
+  drivers.forEach((driver) => {
+    const externalId = Number(driver.driver_number);
+    if (!Number.isFinite(externalId)) return;
+
+    deduped.set(externalId, {
+      external_id: externalId,
+      code: String(driver.name_acronym || '').trim(),
+      name: String(driver.full_name || '').trim(),
+      team_name: String(driver.team_name || '').trim(),
+    });
+  });
+
+  return [...deduped.values()].sort((a, b) => a.external_id - b.external_id);
 }
 
 function canonicalGrandPrixName(session) {
@@ -79,14 +139,166 @@ function buildEventName(session, eventType) {
   return eventType === 'sprint' ? `${base} (Sprint)` : base;
 }
 
-class OpenF1ResultsProvider {
-  constructor({ baseUrl = DEFAULT_BASE_URL, fetchImpl = global.fetch } = {}) {
-    this.name = 'openf1';
-    this.baseUrl = normalizeBaseUrl(baseUrl);
-    this.fetchImpl = fetchImpl;
+async function parseErrorDetail(response) {
+  const contentType = String(response.headers?.get?.('content-type') || '');
+
+  try {
+    if (contentType.includes('application/json')) {
+      const data = await response.json();
+      return data?.detail || data?.error || data?.message || '';
+    }
+
+    const text = await response.text();
+    return String(text || '').trim();
+  } catch {
+    return '';
+  }
+}
+
+function parseRetryDelayMs(response, attempt, minRequestIntervalMs) {
+  const retryAfter = String(response.headers?.get?.('retry-after') || '').trim();
+  const retrySeconds = Number(retryAfter);
+  if (Number.isFinite(retrySeconds) && retrySeconds >= 0) {
+    return Math.max(retrySeconds * 1000, minRequestIntervalMs);
   }
 
-  async request(path, params = {}) {
+  return Math.max(minRequestIntervalMs * (attempt + 1), 300);
+}
+
+class OpenF1ResultsProvider {
+  constructor({
+    baseUrl = DEFAULT_BASE_URL,
+    tokenUrl,
+    username = process.env.OPENF1_USERNAME,
+    password = process.env.OPENF1_PASSWORD,
+    fetchImpl = global.fetch,
+    sleepImpl = sleep,
+    nowImpl = Date.now,
+    minRequestIntervalMs = DEFAULT_MIN_REQUEST_INTERVAL_MS,
+    minuteWindowMs = DEFAULT_MINUTE_WINDOW_MS,
+    maxRequestsPerMinute = DEFAULT_MAX_REQUESTS_PER_MINUTE,
+    maxRateLimitRetries = DEFAULT_MAX_RATE_LIMIT_RETRIES,
+  } = {}) {
+    this.name = 'openf1';
+    this.baseUrl = normalizeBaseUrl(baseUrl);
+    this.tokenUrl = deriveTokenUrl(baseUrl, tokenUrl || process.env.OPENF1_TOKEN_URL);
+    this.username = username;
+    this.password = password;
+    this.fetchImpl = fetchImpl;
+    this.sleepImpl = sleepImpl;
+    this.nowImpl = nowImpl;
+    this.minRequestIntervalMs = minRequestIntervalMs;
+    this.minuteWindowMs = minuteWindowMs;
+    this.maxRequestsPerMinute = maxRequestsPerMinute;
+    this.maxRateLimitRetries = maxRateLimitRetries;
+    this.accessToken = null;
+    this.accessTokenExpiresAt = 0;
+    this.tokenPromise = null;
+    this.nextRequestAt = 0;
+    this.requestTimestamps = [];
+    this.requestQueue = Promise.resolve();
+  }
+
+  get authConfigured() {
+    return Boolean(this.username && this.password);
+  }
+
+  async getAccessToken({ forceRefresh = false } = {}) {
+    const now = this.nowImpl();
+    if (!forceRefresh && this.accessToken && now < (this.accessTokenExpiresAt - 60_000)) {
+      return this.accessToken;
+    }
+
+    if (!this.authConfigured) {
+      throw new Error('OpenF1 authentication is required. Set OPENF1_USERNAME and OPENF1_PASSWORD.');
+    }
+
+    if (this.tokenPromise && !forceRefresh) {
+      return this.tokenPromise;
+    }
+
+    this.tokenPromise = (async () => {
+      const params = new URLSearchParams();
+      params.set('username', this.username);
+      params.set('password', this.password);
+
+      const response = await this.fetchImpl(this.tokenUrl, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: params,
+      });
+
+      if (!response.ok) {
+        const detail = await parseErrorDetail(response);
+        throw new Error(detail
+          ? `OpenF1 auth failed (${response.status}): ${detail}`
+          : `OpenF1 auth failed (${response.status})`);
+      }
+
+      const data = await response.json();
+      const accessToken = String(data?.access_token || '').trim();
+      const expiresInSeconds = Number(data?.expires_in);
+
+      if (!accessToken) {
+        throw new Error('OpenF1 auth failed: missing access token in response.');
+      }
+
+      this.accessToken = accessToken;
+      this.accessTokenExpiresAt = now + ((Number.isFinite(expiresInSeconds) ? expiresInSeconds : 3600) * 1000);
+      return this.accessToken;
+    })();
+
+    try {
+      return await this.tokenPromise;
+    } finally {
+      this.tokenPromise = null;
+    }
+  }
+
+  enqueueRequest(work) {
+    const run = this.requestQueue.then(work, work);
+    this.requestQueue = run.catch(() => {});
+    return run;
+  }
+
+  pruneRequestTimestamps(now) {
+    this.requestTimestamps = this.requestTimestamps.filter(
+      (timestamp) => (now - timestamp) < this.minuteWindowMs
+    );
+  }
+
+  async waitForRateLimitSlot() {
+    while (true) {
+      const now = this.nowImpl();
+      this.pruneRequestTimestamps(now);
+
+      const delays = [];
+      const intervalDelay = this.nextRequestAt - now;
+      if (intervalDelay > 0) delays.push(intervalDelay);
+
+      if (this.requestTimestamps.length >= this.maxRequestsPerMinute) {
+        const oldest = this.requestTimestamps[0];
+        const minuteDelay = (oldest + this.minuteWindowMs) - now;
+        if (minuteDelay > 0) delays.push(minuteDelay);
+      }
+
+      const waitMs = delays.length ? Math.max(...delays) : 0;
+      if (waitMs <= 0) return;
+      await this.sleepImpl(waitMs);
+    }
+  }
+
+  noteRequestSent() {
+    const now = this.nowImpl();
+    this.requestTimestamps.push(now);
+    this.pruneRequestTimestamps(now);
+    this.nextRequestAt = now + this.minRequestIntervalMs;
+  }
+
+  async performRequest(path, params = {}, { forceAuthRefresh = false } = {}) {
     if (typeof this.fetchImpl !== 'function') {
       throw new Error('Fetch is unavailable in this runtime');
     }
@@ -101,13 +313,44 @@ class OpenF1ResultsProvider {
     const timeoutId = setTimeout(() => controller.abort(), 10000);
 
     try {
-      const response = await this.fetchImpl(url, {
-        headers: { Accept: 'application/json' },
-        signal: controller.signal,
-      });
+      const headers = { Accept: 'application/json' };
+      if (this.authConfigured) {
+        headers.Authorization = `Bearer ${await this.getAccessToken({ forceRefresh: forceAuthRefresh })}`;
+      }
+
+      let response;
+      let attempt = 0;
+
+      while (attempt <= this.maxRateLimitRetries) {
+        await this.waitForRateLimitSlot();
+        response = await this.fetchImpl(url, { headers, signal: controller.signal });
+        this.noteRequestSent();
+
+        if (response.status !== 429 || attempt === this.maxRateLimitRetries) {
+          break;
+        }
+
+        await this.sleepImpl(parseRetryDelayMs(response, attempt, this.minRequestIntervalMs));
+        attempt += 1;
+      }
+
+      if (response.status === 401 && !forceAuthRefresh) {
+        if (!this.authConfigured) {
+          const detail = await parseErrorDetail(response);
+          throw new Error(detail
+            ? `OpenF1 request failed (401): ${detail}. Configure OPENF1_USERNAME and OPENF1_PASSWORD for live-session access.`
+            : 'OpenF1 request failed (401). Configure OPENF1_USERNAME and OPENF1_PASSWORD for live-session access.');
+        }
+        this.accessToken = null;
+        this.accessTokenExpiresAt = 0;
+        return this.performRequest(path, params, { forceAuthRefresh: true });
+      }
 
       if (!response.ok) {
-        throw new Error(`OpenF1 request failed (${response.status})`);
+        const detail = await parseErrorDetail(response);
+        throw new Error(detail
+          ? `OpenF1 request failed (${response.status}): ${detail}`
+          : `OpenF1 request failed (${response.status})`);
       }
 
       const data = await response.json();
@@ -120,6 +363,45 @@ class OpenF1ResultsProvider {
     } finally {
       clearTimeout(timeoutId);
     }
+  }
+
+  async request(path, params = {}, options = {}) {
+    return this.enqueueRequest(() => this.performRequest(path, params, options));
+  }
+
+  async fetchSessionMetadata(sessionKey) {
+    const sessions = await this.request('/sessions', { session_key: sessionKey });
+    const session = Array.isArray(sessions) ? sessions[0] : null;
+    if (!session) return null;
+    return {
+      ...session,
+      starts_at: parseIsoDate(session.date_start),
+    };
+  }
+
+  async fetchNormalizedDriverRoster(session) {
+    if (!session?.session_key) return [];
+
+    const lookups = [() => this.request('/drivers', { session_key: session.session_key })];
+    if (session.meeting_key != null) {
+      lookups.push(() => this.request('/drivers', { meeting_key: session.meeting_key }));
+    }
+
+    for (const lookup of lookups) {
+      try {
+        const drivers = await lookup();
+        const normalized = normalizeProviderDriverRows(drivers);
+        if (normalized.length) {
+          return normalized;
+        }
+      } catch (error) {
+        if (!isNoResultsFoundError(error)) {
+          throw error;
+        }
+      }
+    }
+
+    return [];
   }
 
   async fetchSeasonSessions({ year }) {
@@ -135,35 +417,47 @@ class OpenF1ResultsProvider {
   }
 
   async fetchDrivers({ year }) {
-    const allSessions = await this.request('/sessions', { year });
-    const startedSessions = allSessions
+    const sessions = await this.request('/sessions', { year });
+    const candidateSessions = sessions
       .map((session) => ({
         ...session,
         starts_at: parseIsoDate(session.date_start),
       }))
-      .filter((session) => session.starts_at && Date.parse(session.starts_at) <= Date.now())
-      .sort((a, b) => Date.parse(a.starts_at) - Date.parse(b.starts_at));
+      .filter((session) => (
+        session.session_key
+        && session.starts_at
+        && !isTestingSession(session)
+      ))
+      .sort((a, b) => Date.parse(b.starts_at) - Date.parse(a.starts_at));
 
-    const sourceSession = startedSessions[startedSessions.length - 1];
-    if (!sourceSession?.session_key) {
-      throw new Error(`OpenF1 has no started sessions yet for ${year}`);
+    const startedCandidates = candidateSessions
+      .filter((session) => Date.parse(session.starts_at) <= Date.now());
+
+    const orderedCandidates = startedCandidates.length
+      ? startedCandidates
+      : candidateSessions;
+
+    if (!orderedCandidates.length) {
+      throw new Error(`OpenF1 has no non-testing sessions yet for ${year}`);
     }
 
-    const drivers = await this.request('/drivers', { session_key: sourceSession.session_key });
-    const deduped = new Map();
+    let lastNoResultsSession = null;
 
-    drivers.forEach((driver) => {
-      const externalId = Number(driver.driver_number);
-      if (!Number.isFinite(externalId)) return;
-      deduped.set(externalId, {
-        external_id: externalId,
-        code: String(driver.name_acronym || '').trim(),
-        name: String(driver.full_name || '').trim(),
-        team_name: String(driver.team_name || '').trim(),
-      });
-    });
+    for (const session of orderedCandidates) {
+      try {
+        const normalized = await this.fetchNormalizedDriverRoster(session);
+        if (normalized.length) return normalized;
+        lastNoResultsSession = session;
+      } catch (error) {
+        if (!isNoResultsFoundError(error)) {
+          throw error;
+        }
+        lastNoResultsSession = session;
+      }
+    }
 
-    return [...deduped.values()].sort((a, b) => a.external_id - b.external_id);
+    const sessionLabel = lastNoResultsSession?.session_name || 'eligible session';
+    throw new Error(`OpenF1 has no populated driver roster yet for ${year}. Tried the latest non-testing ${sessionLabel.toLowerCase()} via session and meeting lookups.`);
   }
 
   async fetchSeasonSchedule({ year }) {
@@ -199,14 +493,19 @@ class OpenF1ResultsProvider {
       throw new Error(`Event ${event?.id || ''} is missing an OpenF1 session key`);
     }
 
-    const [sessionResults, startingGrid, pitStops] = await Promise.all([
+    const session = await this.fetchSessionMetadata(sessionKey);
+    const [sessionResults, startingGrid, pitStops, roster] = await Promise.all([
       this.request('/session_result', { session_key: sessionKey }),
       this.request('/starting_grid', { session_key: sessionKey }),
       this.request('/pit', { session_key: sessionKey }),
+      this.fetchNormalizedDriverRoster(session || { session_key: sessionKey }),
     ]);
 
     const gridByDriver = new Map(
       startingGrid.map((row) => [Number(row.driver_number), Number(row.position) || null])
+    );
+    const rosterByDriver = new Map(
+      roster.map((driver) => [Number(driver.external_id), driver])
     );
     const slowestPitByDriver = new Map();
 
@@ -224,6 +523,9 @@ class OpenF1ResultsProvider {
     const rows = sessionResults
       .map((row) => ({
         external_driver_id: Number(row.driver_number),
+        driver_code: rosterByDriver.get(Number(row.driver_number))?.code || null,
+        driver_name: rosterByDriver.get(Number(row.driver_number))?.name || null,
+        team_name: rosterByDriver.get(Number(row.driver_number))?.team_name || null,
         finish_position: Number(row.position),
         start_position: gridByDriver.get(Number(row.driver_number)) ?? null,
         slowest_pit_stop_seconds: slowestPitByDriver.get(Number(row.driver_number)) ?? null,
@@ -239,10 +541,15 @@ class OpenF1ResultsProvider {
   }
 
   getStatus() {
-    return {
-      provider: this.name,
-      baseUrl: this.baseUrl,
-    };
+      return {
+        provider: this.name,
+        baseUrl: this.baseUrl,
+        authConfigured: this.authConfigured,
+        tokenCached: Boolean(this.accessToken),
+        tokenExpiresAt: this.accessTokenExpiresAt || null,
+        rateLimitGuardMs: this.minRequestIntervalMs,
+        maxRequestsPerMinute: this.maxRequestsPerMinute,
+      };
   }
 }
 

--- a/apps/f1/server/routes/admin.js
+++ b/apps/f1/server/routes/admin.js
@@ -179,6 +179,16 @@ router.post('/test-data/load-openf1-year', withAdmin, async (req, res) => {
   return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
 });
 
+router.post('/test-data/restore-seeded-2026', withAdmin, (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const result = resultsAdminService.restoreSeededSeasonMetadata({
+    seasonId,
+    io: req.app.get('io'),
+    auctionService: req.app.get('auctionService'),
+  });
+  return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
+});
+
 router.post('/results/refresh-drivers', withAdmin, async (req, res) => {
   const seasonId = getActiveSeasonId();
   const provider = req.app.get('resultsProvider');

--- a/apps/f1/server/services/admin/resultsAdminService.js
+++ b/apps/f1/server/services/admin/resultsAdminService.js
@@ -17,6 +17,8 @@ const {
   syncNextEventFromProvider,
 } = require('../scoringService');
 const { shuffleArray } = require('../../lib/shuffle');
+const { DRIVERS_2026 } = require('../../data/drivers2026');
+const { EVENTS_2026 } = require('../../data/events2026');
 
 function normalizeText(value) {
   return String(value || '').replace(/\s+/g, ' ').trim().toLowerCase();
@@ -61,6 +63,68 @@ function saveProviderState(seasonId, scope, providerName, status, message, meta)
 
 function getProviderName(provider) {
   return provider?.name || 'unknown';
+}
+
+function getSeasonActivityCounts(seasonId) {
+  return {
+    bids: db.prepare('SELECT COUNT(*) as c FROM bids WHERE season_id = ?').get(seasonId).c,
+    ownership: db.prepare('SELECT COUNT(*) as c FROM ownership WHERE season_id = ?').get(seasonId).c,
+    eventResults: db.prepare(`
+      SELECT COUNT(*) as c
+      FROM event_results
+      WHERE event_id IN (SELECT id FROM events WHERE season_id = ?)
+    `).get(seasonId).c,
+    eventPayouts: db.prepare('SELECT COUNT(*) as c FROM event_payouts WHERE season_id = ?').get(seasonId).c,
+    seasonBonusPayouts: db.prepare('SELECT COUNT(*) as c FROM season_bonus_payouts WHERE season_id = ?').get(seasonId).c,
+  };
+}
+
+function canAuthoritativelyReplaceDrivers(seasonId) {
+  const counts = getSeasonActivityCounts(seasonId);
+  const isClean = Object.values(counts).every((count) => Number(count) === 0);
+  return { isClean, counts };
+}
+
+function rebuildSeasonDriversFromProvider({ seasonId, providerDrivers, shuffle = shuffleArray }) {
+  const deleteAuctionItems = db.prepare('DELETE FROM auction_items WHERE season_id = ?');
+  const deleteDrivers = db.prepare('DELETE FROM drivers WHERE season_id = ?');
+  const insertDriver = db.prepare(`
+    INSERT INTO drivers (season_id, external_id, code, name, team_name, active)
+    VALUES (?, ?, ?, ?, ?, 1)
+  `);
+  const insertAuctionItem = db.prepare(`
+    INSERT INTO auction_items (season_id, driver_id, queue_order)
+    VALUES (?, ?, ?)
+  `);
+  const resetAuctionStatus = db.prepare(`
+    UPDATE seasons
+    SET auction_status = 'waiting'
+    WHERE id = ?
+  `);
+
+  const insertedDriverIds = [];
+
+  db.transaction(() => {
+    deleteAuctionItems.run(seasonId);
+    deleteDrivers.run(seasonId);
+
+    providerDrivers.forEach((driver) => {
+      const insert = insertDriver.run(
+        seasonId,
+        driver.external_id,
+        driver.code,
+        driver.name,
+        driver.team_name,
+      );
+      insertedDriverIds.push(insert.lastInsertRowid);
+    });
+
+    shuffle(insertedDriverIds).forEach((driverId, idx) => {
+      insertAuctionItem.run(seasonId, driverId, idx);
+    });
+
+    resetAuctionStatus.run(seasonId);
+  })();
 }
 
 function syncNextResults({ seasonId, provider, io, force = false }) {
@@ -131,10 +195,28 @@ async function refreshDriversFromProvider({ seasonId, provider }) {
       .map((driver) => driver.name);
 
     if (unmappedProvider.length || unmatchedSeason.length) {
+      const replacementCheck = canAuthoritativelyReplaceDrivers(seasonId);
+      if (replacementCheck.isClean) {
+        rebuildSeasonDriversFromProvider({ seasonId, providerDrivers });
+        const message = `Rebuilt ${providerDrivers.length} season drivers from ${providerName}.`;
+        saveProviderState(seasonId, 'drivers', providerName, 'success', message, {
+          count: providerDrivers.length,
+          source: 'authoritative-rebuild',
+          drivers: providerDrivers.map((providerDriver) => ({
+            external_id: providerDriver.external_id,
+            code: providerDriver.code,
+            name: providerDriver.name,
+            team_name: providerDriver.team_name,
+          })),
+        });
+        return { ok: true, count: providerDrivers.length, message };
+      }
+
       const message = `Driver mapping failed. Provider unmatched: ${unmappedProvider.length}. Season unmatched: ${unmatchedSeason.length}.`;
       saveProviderState(seasonId, 'drivers', providerName, 'error', message, {
         unmappedProvider,
         unmatchedSeason,
+        seasonActivity: replacementCheck.counts,
       });
       return { ok: false, status: 400, error: message };
     }
@@ -168,6 +250,12 @@ async function refreshDriversFromProvider({ seasonId, provider }) {
     const message = `Refreshed ${matched.length} drivers from ${providerName}.`;
     saveProviderState(seasonId, 'drivers', providerName, 'success', message, {
       count: matched.length,
+      drivers: matched.map(({ provider: providerDriver }) => ({
+        external_id: providerDriver.external_id,
+        code: providerDriver.code,
+        name: providerDriver.name,
+        team_name: providerDriver.team_name,
+      })),
     });
     return { ok: true, count: matched.length, message };
   } catch (error) {
@@ -587,6 +675,78 @@ async function loadHistoricalSeasonMetadata({ seasonId, provider, year, io, auct
   }
 }
 
+function restoreSeededSeasonMetadata({ seasonId, io, auctionService }) {
+  const season = getSeason(seasonId);
+  if (!season) return { ok: false, status: 404, error: 'Season not found' };
+
+  clearTestDataForSeason({ seasonId, io: null, auctionService });
+
+  const deleteAuctionItems = db.prepare('DELETE FROM auction_items WHERE season_id = ?');
+  const deleteDrivers = db.prepare('DELETE FROM drivers WHERE season_id = ?');
+  const deleteEvents = db.prepare('DELETE FROM events WHERE season_id = ?');
+  const insertDriver = db.prepare(`
+    INSERT INTO drivers (season_id, external_id, code, name, team_name, active)
+    VALUES (?, ?, ?, ?, ?, 1)
+  `);
+  const insertAuctionItem = db.prepare(`
+    INSERT INTO auction_items (season_id, driver_id, queue_order)
+    VALUES (?, ?, ?)
+  `);
+  const insertEvent = db.prepare(`
+    INSERT INTO events
+      (season_id, external_event_id, round_number, name, type, starts_at, lock_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  const insertedDriverIds = [];
+
+  db.transaction(() => {
+    deleteAuctionItems.run(seasonId);
+    deleteDrivers.run(seasonId);
+    deleteEvents.run(seasonId);
+
+    DRIVERS_2026.forEach((driver) => {
+      const insert = insertDriver.run(
+        seasonId,
+        driver.external_id,
+        driver.code,
+        driver.name,
+        driver.team_name,
+      );
+      insertedDriverIds.push(insert.lastInsertRowid);
+    });
+
+    shuffleArray(insertedDriverIds).forEach((driverId, idx) => {
+      insertAuctionItem.run(seasonId, driverId, idx);
+    });
+
+    EVENTS_2026.forEach((event) => {
+      insertEvent.run(
+        seasonId,
+        `mock-${event.round_number}`,
+        event.round_number,
+        event.name,
+        event.type,
+        event.starts_at,
+        event.lock_at,
+      );
+    });
+  })();
+
+  io?.emit('auction:status', { status: 'waiting' });
+  io?.emit('standings:update');
+  if (auctionService?.emitAuctionState && io) {
+    auctionService.emitAuctionState(io, seasonId);
+  }
+
+  return {
+    ok: true,
+    driverCount: DRIVERS_2026.length,
+    eventCount: EVENTS_2026.length,
+    message: 'Restored canonical 2026 F1 drivers and events for the active season.',
+  };
+}
+
 function getEventEditorData({ seasonId, eventId }) {
   const event = getEventById(seasonId, eventId);
   if (!event) return { ok: false, status: 404, error: 'Event not found' };
@@ -669,6 +829,7 @@ module.exports = {
   clearTestDataForSeason,
   resetAuctionOnlyForSeason,
   loadHistoricalSeasonMetadata,
+  restoreSeededSeasonMetadata,
   getEventEditorData,
   saveManualResultsAndScore,
   recalcSeasonBonusesForSeason,

--- a/apps/f1/server/services/payoutAuditService.js
+++ b/apps/f1/server/services/payoutAuditService.js
@@ -110,6 +110,7 @@ function buildEventPayoutAudit({ seasonId, eventId }) {
         driver_code: row?.driver_code || null,
         driver_name: row?.driver_name || null,
         team_name: row?.team_name || null,
+        driver_active: row?.driver_active ?? 1,
         finish_position: row?.finish_position ?? null,
         start_position: row?.start_position ?? null,
         positions_gained: row?.positions_gained ?? null,

--- a/apps/f1/server/services/scoringService.js
+++ b/apps/f1/server/services/scoringService.js
@@ -278,9 +278,40 @@ function rescoreSeasonEvents({ seasonId }) {
   };
 }
 
+function ensureSeasonDriverForResultRow(seasonId, row) {
+  const externalDriverId = Number(row?.external_driver_id);
+  if (!Number.isFinite(externalDriverId)) return null;
+
+  const existing = db.prepare(`
+    SELECT id
+    FROM drivers
+    WHERE season_id = ? AND external_id = ?
+    LIMIT 1
+  `).get(seasonId, externalDriverId);
+  if (existing?.id) return existing.id;
+
+  const driverName = String(row?.driver_name || row?.driver_code || `Driver ${externalDriverId}`).trim();
+  const driverCode = String(row?.driver_code || '').trim() || null;
+  const teamName = String(row?.team_name || 'Unknown Team').trim();
+
+  const insert = db.prepare(`
+    INSERT INTO drivers (season_id, external_id, code, name, team_name, active)
+    VALUES (?, ?, ?, ?, ?, 0)
+  `).run(seasonId, externalDriverId, driverCode, driverName, teamName);
+
+  return insert.lastInsertRowid;
+}
+
 function upsertEventResults({ seasonId, eventId, rows, manualOverride = false }) {
   const event = getEventById(seasonId, eventId);
   if (!event) return { ok: false, status: 404, error: 'Event not found' };
+
+  db.transaction(() => {
+    (rows || []).forEach((row) => {
+      if (row?.driver_id || row?.external_driver_id == null) return;
+      ensureSeasonDriverForResultRow(seasonId, row);
+    });
+  })();
 
   const driversByExternal = new Map(
     db.prepare('SELECT id, external_id FROM drivers WHERE season_id = ?').all(seasonId)

--- a/apps/f1/server/tests/adminServices.test.js
+++ b/apps/f1/server/tests/adminServices.test.js
@@ -31,6 +31,7 @@ test('results admin syncNext maps force flag to includeFuture/ignoreLock behavio
   const {
     db,
     getActiveSeasonId,
+    getProviderSyncStates,
     resultsAdminService,
   } = setupDb();
 
@@ -76,6 +77,7 @@ test('results admin manual save forces scoring path and persists results', () =>
   const {
     db,
     getActiveSeasonId,
+    getProviderSyncStates,
     resultsAdminService,
   } = setupDb();
 
@@ -106,6 +108,7 @@ test('results admin refreshDrivers updates seeded drivers without changing ident
   const {
     db,
     getActiveSeasonId,
+    getProviderSyncStates,
     resultsAdminService,
   } = setupDb();
 
@@ -162,6 +165,111 @@ test('results admin refreshDrivers updates seeded drivers without changing ident
   assert.notEqual(after.external_id, before.external_id);
   assert.equal(after.external_id, 11);
   assert.equal(after.team_name, 'Oracle Red Bull Racing');
+
+  const driverState = getProviderSyncStates(seasonId).find((row) => row.scope === 'drivers');
+  const driverMeta = JSON.parse(driverState.meta_json);
+  assert.equal(driverMeta.drivers.length, 20);
+  assert.deepEqual(driverMeta.drivers[0], {
+    external_id: 1,
+    code: 'VER',
+    name: 'Max Verstappen',
+    team_name: 'Oracle Red Bull Racing',
+  });
+});
+
+test('results admin refreshDrivers rebuilds clean season roster when provider lineup drifts from the seed', async () => {
+  const {
+    db,
+    getActiveSeasonId,
+    getProviderSyncStates,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const provider = {
+    name: 'openf1',
+    async fetchDrivers() {
+      return [
+        { external_id: 1, code: 'VER', name: 'Max Verstappen', team_name: 'Red Bull Racing' },
+        { external_id: 81, code: 'PIA', name: 'Oscar Piastri', team_name: 'McLaren' },
+        { external_id: 43, code: 'LIN', name: 'Arvid Lindblad', team_name: 'Cadillac' },
+      ];
+    },
+  };
+
+  const result = await resultsAdminService.refreshDriversFromProvider({
+    seasonId,
+    provider,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.count, 3);
+
+  const drivers = db.prepare(`
+    SELECT code, name, team_name, external_id
+    FROM drivers
+    WHERE season_id = ?
+    ORDER BY id ASC
+  `).all(seasonId);
+  assert.equal(drivers.length, 3);
+  assert.deepEqual(drivers[2], {
+    code: 'LIN',
+    name: 'Arvid Lindblad',
+    team_name: 'Cadillac',
+    external_id: 43,
+  });
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM auction_items WHERE season_id = ?').get(seasonId).c, 3);
+
+  const driverState = getProviderSyncStates(seasonId).find((row) => row.scope === 'drivers');
+  const driverMeta = JSON.parse(driverState.meta_json);
+  assert.equal(driverState.status, 'success');
+  assert.equal(driverMeta.source, 'authoritative-rebuild');
+  assert.equal(driverMeta.drivers.length, 3);
+});
+
+test('results admin refreshDrivers still fails closed on roster drift after season activity exists', async () => {
+  const {
+    db,
+    getActiveSeasonId,
+    getProviderSyncStates,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const participantId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('Refresh Lock Tester', '#ffffff', 'refresh-lock-token')
+  `).run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+
+  const driver = db.prepare('SELECT id FROM drivers WHERE season_id = ? ORDER BY id ASC LIMIT 1').get(seasonId);
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, driver.id, participantId, 500);
+
+  const provider = {
+    name: 'openf1',
+    async fetchDrivers() {
+      return [
+        { external_id: 1, code: 'VER', name: 'Max Verstappen', team_name: 'Red Bull Racing' },
+        { external_id: 43, code: 'LIN', name: 'Arvid Lindblad', team_name: 'Cadillac' },
+      ];
+    },
+  };
+
+  const result = await resultsAdminService.refreshDriversFromProvider({
+    seasonId,
+    provider,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 400);
+
+  const driverState = getProviderSyncStates(seasonId).find((row) => row.scope === 'drivers');
+  const driverMeta = JSON.parse(driverState.meta_json);
+  assert.equal(driverState.status, 'error');
+  assert.equal(driverMeta.seasonActivity.ownership, 1);
 });
 
 test('results admin refreshSchedule updates matching seeded events with provider keys', async () => {
@@ -846,4 +954,66 @@ test('results admin resetAuctionOnlyForSeason preserves participants and race da
   assert.ok(auctionItems.every((item) => item.final_price_cents == null));
   assert.ok(auctionItems.every((item) => item.winner_id == null));
   assert.deepEqual(auctionItems.map((item) => item.queue_order), auctionItems.map((_, idx) => idx));
+});
+
+test('results admin restoreSeededSeasonMetadata rebuilds canonical 2026 drivers and events', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+
+  db.prepare(`
+    INSERT INTO drivers (season_id, external_id, code, name, team_name, active)
+    VALUES (?, 999, 'TST', 'Test Driver', 'Test Team', 1)
+  `).run(seasonId);
+  db.prepare(`
+    INSERT INTO events (season_id, external_event_id, round_number, name, type, starts_at, lock_at)
+    VALUES (?, 'test-event', 99, 'Test Event', 'grand_prix', '2026-01-01T00:00:00Z', '2025-12-31T23:50:00Z')
+  `).run(seasonId);
+
+  const participantId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('Restore Tester', '#ffffff', 'restore-token')
+  `).run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+
+  const result = resultsAdminService.restoreSeededSeasonMetadata({
+    seasonId,
+    io: null,
+    auctionService: { clearActiveTimer() {} },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.driverCount, 20);
+  assert.equal(result.eventCount, 24);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM drivers WHERE season_id = ?').get(seasonId).c, 20);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM events WHERE season_id = ?').get(seasonId).c, 24);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM auction_items WHERE season_id = ?').get(seasonId).c, 20);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM season_participants WHERE season_id = ?').get(seasonId).c, 0);
+
+  const restoredDriver = db.prepare(`
+    SELECT code, name, team_name, external_id
+    FROM drivers
+    WHERE season_id = ? AND code = 'VER'
+  `).get(seasonId);
+  assert.deepEqual(restoredDriver, {
+    code: 'VER',
+    name: 'Max Verstappen',
+    team_name: 'Red Bull',
+    external_id: 1,
+  });
+
+  const restoredEvent = db.prepare(`
+    SELECT round_number, name, type
+    FROM events
+    WHERE season_id = ? AND round_number = 1 AND type = 'grand_prix'
+  `).get(seasonId);
+  assert.deepEqual(restoredEvent, {
+    round_number: 1,
+    name: 'Australian Grand Prix',
+    type: 'grand_prix',
+  });
 });

--- a/apps/f1/server/tests/openF1ResultsProvider.test.js
+++ b/apps/f1/server/tests/openF1ResultsProvider.test.js
@@ -130,9 +130,411 @@ test('OpenF1ResultsProvider normalizes season schedule and event results', async
     event: { external_event_id: '9001' },
   });
   assert.deepEqual(results, [
-    { external_driver_id: 16, finish_position: 1, start_position: 2, slowest_pit_stop_seconds: 2.201 },
-    { external_driver_id: 1, finish_position: 2, start_position: 4, slowest_pit_stop_seconds: 3.102 },
+    {
+      external_driver_id: 16,
+      driver_code: null,
+      driver_name: null,
+      team_name: null,
+      finish_position: 1,
+      start_position: 2,
+      slowest_pit_stop_seconds: 2.201,
+    },
+    {
+      external_driver_id: 1,
+      driver_code: null,
+      driver_name: null,
+      team_name: null,
+      finish_position: 2,
+      start_position: 4,
+      slowest_pit_stop_seconds: 3.102,
+    },
   ]);
+});
+
+test('OpenF1ResultsProvider fetchDrivers uses the latest started non-testing session, including practice', async () => {
+  const responses = {
+    '/v1/sessions?year=2026': [
+      {
+        session_key: 1001,
+        meeting_key: 10,
+        session_name: 'Race',
+        date_start: '2026-02-22T04:00:00Z',
+        country_name: 'Australia',
+        location: 'Melbourne',
+      },
+      {
+        session_key: 1002,
+        meeting_key: 11,
+        session_name: 'Practice 1',
+        date_start: '2026-03-03T04:00:00Z',
+        country_name: 'China',
+        location: 'Shanghai',
+      },
+    ],
+    '/v1/drivers?session_key=1002': [
+      {
+        driver_number: 44,
+        name_acronym: 'HAM',
+        full_name: 'Lewis Hamilton',
+        team_name: 'Ferrari',
+      },
+    ],
+  };
+
+  const provider = new OpenF1ResultsProvider({
+    fetchImpl: async (url) => ({
+      ok: true,
+      async json() {
+        return responses[`${url.pathname}${url.search}`] || [];
+      },
+      headers: { get() { return 'application/json'; } },
+    }),
+  });
+
+  const drivers = await provider.fetchDrivers({ year: 2026 });
+  assert.equal(drivers.length, 1);
+  assert.equal(drivers[0].code, 'HAM');
+});
+
+test('OpenF1ResultsProvider fetchDrivers falls back when latest non-testing session has no driver payload yet', async () => {
+  const responses = {
+    '/v1/sessions?year=2026': [
+      {
+        session_key: 2001,
+        meeting_key: 20,
+        meeting_name: 'Australian Grand Prix',
+        session_name: 'Race',
+        date_start: '2026-02-20T01:00:00Z',
+        country_name: 'Australia',
+        location: 'Melbourne',
+      },
+      {
+        session_key: 2002,
+        meeting_key: 20,
+        meeting_name: 'Australian Grand Prix',
+        session_name: 'Race',
+        date_start: '2026-02-22T04:00:00Z',
+        country_name: 'Australia',
+        location: 'Melbourne',
+      },
+      {
+        session_key: 2999,
+        meeting_key: 99,
+        meeting_name: 'Pre-Season Testing',
+        session_name: 'Practice 1',
+        date_start: '2026-02-10T09:00:00Z',
+        country_name: 'Bahrain',
+        location: 'Sakhir',
+      },
+    ],
+    '/v1/drivers?session_key=2001': [
+      {
+        driver_number: 81,
+        name_acronym: 'PIA',
+        full_name: 'Oscar Piastri',
+        team_name: 'McLaren',
+      },
+    ],
+    '/v1/session_result?session_key=2001': [
+      { driver_number: 81, position: 1 },
+    ],
+  };
+
+  const provider = new OpenF1ResultsProvider({
+    fetchImpl: async (url) => {
+      const key = `${url.pathname}${url.search}`;
+      if (key === '/v1/drivers?session_key=2002') {
+        return {
+          ok: false,
+          status: 404,
+          async json() {
+            return { detail: 'No results found.' };
+          },
+          headers: { get() { return 'application/json'; } },
+        };
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return responses[key] || [];
+        },
+        headers: { get() { return 'application/json'; } },
+      };
+    },
+  });
+
+  const drivers = await provider.fetchDrivers({ year: 2026 });
+  assert.equal(drivers.length, 1);
+  assert.equal(drivers[0].code, 'PIA');
+});
+
+test('OpenF1ResultsProvider fetchDrivers falls back from session_key to meeting_key roster lookups', async () => {
+  const responses = {
+    '/v1/sessions?year=2026': [
+      {
+        session_key: 4001,
+        meeting_key: 40,
+        meeting_name: 'Australian Grand Prix',
+        session_name: 'Practice 1',
+        date_start: '2026-02-22T04:00:00Z',
+        country_name: 'Australia',
+        location: 'Melbourne',
+      },
+    ],
+    '/v1/drivers?meeting_key=40': [
+      {
+        driver_number: 81,
+        name_acronym: 'PIA',
+        full_name: 'Oscar Piastri',
+        team_name: 'McLaren',
+      },
+      {
+        driver_number: 81,
+        name_acronym: 'PIA',
+        full_name: 'Oscar Piastri',
+        team_name: 'McLaren',
+      },
+      {
+        driver_number: 44,
+        name_acronym: 'HAM',
+        full_name: 'Lewis Hamilton',
+        team_name: 'Ferrari',
+      },
+    ],
+  };
+
+  const provider = new OpenF1ResultsProvider({
+    fetchImpl: async (url) => {
+      const key = `${url.pathname}${url.search}`;
+      if (key === '/v1/drivers?session_key=4001') {
+        return {
+          ok: false,
+          status: 404,
+          async json() {
+            return { detail: 'No results found.' };
+          },
+          headers: { get() { return 'application/json'; } },
+        };
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return responses[key] || [];
+        },
+        headers: { get() { return 'application/json'; } },
+      };
+    },
+  });
+
+  const drivers = await provider.fetchDrivers({ year: 2026 });
+  assert.equal(drivers.length, 2);
+  assert.equal(drivers[0].code, 'HAM');
+  assert.equal(drivers[1].code, 'PIA');
+});
+
+test('OpenF1ResultsProvider fetchDrivers returns a clear message when no non-testing session has a populated roster yet', async () => {
+  const provider = new OpenF1ResultsProvider({
+    fetchImpl: async (url) => {
+      const key = `${url.pathname}${url.search}`;
+      if (key === '/v1/sessions?year=2026') {
+        return {
+          ok: true,
+          async json() {
+            return [
+              {
+                session_key: 3001,
+                meeting_key: 30,
+                meeting_name: 'Australian Grand Prix',
+                session_name: 'Race',
+                date_start: '2026-02-22T04:00:00Z',
+                country_name: 'Australia',
+                location: 'Melbourne',
+              },
+            ];
+          },
+          headers: { get() { return 'application/json'; } },
+        };
+      }
+
+      return {
+        ok: false,
+        status: 404,
+        async json() {
+          return { detail: 'No results found.' };
+        },
+        headers: { get() { return 'application/json'; } },
+      };
+    },
+  });
+
+  await assert.rejects(
+    () => provider.fetchDrivers({ year: 2026 }),
+    /OpenF1 has no populated driver roster yet for 2026/i
+  );
+});
+
+test('OpenF1ResultsProvider authenticates and retries after 401', async () => {
+  const calls = [];
+  const provider = new OpenF1ResultsProvider({
+    username: 'user@example.com',
+    password: 'secret',
+    fetchImpl: async (url, options = {}) => {
+      calls.push({
+        url: typeof url === 'string' ? url : url.toString(),
+        headers: options.headers || {},
+        method: options.method || 'GET',
+      });
+
+      if (String(url).endsWith('/token')) {
+        return {
+          ok: true,
+          async json() {
+            return { access_token: 'test-token', expires_in: 3600 };
+          },
+          headers: { get() { return 'application/json'; } },
+        };
+      }
+
+      const authHeader = options.headers?.Authorization;
+      if (authHeader !== 'Bearer test-token') {
+        return {
+          ok: false,
+          status: 401,
+          async json() {
+            return { detail: 'Live F1 session in progress' };
+          },
+          headers: { get() { return 'application/json'; } },
+        };
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return [];
+        },
+        headers: { get() { return 'application/json'; } },
+      };
+    },
+  });
+
+  provider.accessToken = 'stale-token';
+  provider.accessTokenExpiresAt = Date.now() + 120_000;
+
+  await provider.request('/sessions', { year: 2026 });
+
+  assert.equal(calls.length, 3);
+  assert.equal(calls[0].method, 'GET');
+  assert.equal(calls[1].method, 'POST');
+  assert.match(calls[1].url, /\/token$/);
+  assert.equal(calls[2].headers.Authorization, 'Bearer test-token');
+  assert.equal(provider.getStatus().authConfigured, true);
+  assert.equal(provider.getStatus().tokenCached, true);
+});
+
+test('OpenF1ResultsProvider caches token across requests', async () => {
+  let tokenCalls = 0;
+  const provider = new OpenF1ResultsProvider({
+    username: 'user@example.com',
+    password: 'secret',
+    fetchImpl: async (url, options = {}) => {
+      if (String(url).endsWith('/token')) {
+        tokenCalls += 1;
+        return {
+          ok: true,
+          async json() {
+            return { access_token: 'cached-token', expires_in: 3600 };
+          },
+          headers: { get() { return 'application/json'; } },
+        };
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return [];
+        },
+        headers: { get() { return 'application/json'; } },
+      };
+    },
+  });
+
+  await provider.request('/sessions', { year: 2026 });
+  await provider.request('/sessions', { year: 2025 });
+
+  assert.equal(tokenCalls, 1);
+});
+
+test('OpenF1ResultsProvider retries after rate limiting', async () => {
+  let attempts = 0;
+  const provider = new OpenF1ResultsProvider({
+    minRequestIntervalMs: 1,
+    fetchImpl: async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        return {
+          ok: false,
+          status: 429,
+          async json() {
+            return { detail: 'Rate limit exceeded. Max 6 requests/second.' };
+          },
+          headers: {
+            get(name) {
+              return String(name).toLowerCase() === 'content-type' ? 'application/json' : null;
+            },
+          },
+        };
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return [];
+        },
+        headers: { get() { return 'application/json'; } },
+      };
+    },
+  });
+
+  await provider.request('/sessions', { year: 2026 });
+  assert.equal(attempts, 3);
+  assert.equal(provider.getStatus().rateLimitGuardMs, 1);
+});
+
+test('OpenF1ResultsProvider enforces the rolling per-minute request budget', async () => {
+  let now = 0;
+  const sleeps = [];
+  let requests = 0;
+
+  const provider = new OpenF1ResultsProvider({
+    minRequestIntervalMs: 0,
+    minuteWindowMs: 60_000,
+    maxRequestsPerMinute: 2,
+    nowImpl: () => now,
+    sleepImpl: async (ms) => {
+      sleeps.push(ms);
+      now += ms;
+    },
+    fetchImpl: async () => {
+      requests += 1;
+      return {
+        ok: true,
+        async json() {
+          return [];
+        },
+        headers: { get() { return 'application/json'; } },
+      };
+    },
+  });
+
+  await provider.request('/sessions', { year: 2026 });
+  await provider.request('/drivers', { session_key: 1001 });
+  await provider.request('/session_result', { session_key: 1001 });
+
+  assert.equal(requests, 3);
+  assert.deepEqual(sleeps, [60000]);
+  assert.equal(provider.getStatus().maxRequestsPerMinute, 2);
 });
 
 test('canonicalGrandPrixName derives expected names from OpenF1 location data', () => {

--- a/apps/f1/server/tests/scoringService.test.js
+++ b/apps/f1/server/tests/scoringService.test.js
@@ -182,6 +182,109 @@ test('slowest pit stop payout uses highest recorded stop duration', () => {
   assert.equal(payout.amount_cents, 3);
 });
 
+test('sync preserves unknown race drivers as inactive unowned season drivers', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    upsertEventResults,
+    scoreEvent,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const event = db.prepare(`
+    SELECT id
+    FROM events
+    WHERE season_id = ? AND type = 'grand_prix'
+    ORDER BY round_number ASC
+    LIMIT 1
+  `).get(seasonId);
+  db.prepare('UPDATE events SET lock_at = ? WHERE id = ?').run('2000-01-01T00:00:00Z', event.id);
+
+  const participantId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('Known Owner', '#ffae57', 'tok-known')
+  `).run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+
+  const knownDriver = db.prepare(`
+    SELECT id, external_id
+    FROM drivers
+    WHERE season_id = ?
+    ORDER BY external_id ASC
+    LIMIT 1
+  `).get(seasonId);
+
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, knownDriver.id, participantId, 1000);
+
+  const upsert = upsertEventResults({
+    seasonId,
+    eventId: event.id,
+    rows: [
+      {
+        external_driver_id: 999,
+        driver_code: 'SUB',
+        driver_name: 'Sub Driver',
+        team_name: 'Cadillac',
+        finish_position: 1,
+        start_position: 14,
+      },
+      {
+        external_driver_id: knownDriver.external_id,
+        finish_position: 6,
+        start_position: 9,
+      },
+    ],
+  });
+  assert.equal(upsert.ok, true);
+
+  const unknownDriver = db.prepare(`
+    SELECT id, external_id, code, name, team_name, active
+    FROM drivers
+    WHERE season_id = ? AND external_id = 999
+  `).get(seasonId);
+  assert.deepEqual(unknownDriver, {
+    id: unknownDriver.id,
+    external_id: 999,
+    code: 'SUB',
+    name: 'Sub Driver',
+    team_name: 'Cadillac',
+    active: 0,
+  });
+
+  const unknownAuctionItemCount = db.prepare(`
+    SELECT COUNT(*) as c
+    FROM auction_items
+    WHERE season_id = ? AND driver_id = ?
+  `).get(seasonId, unknownDriver.id).c;
+  assert.equal(unknownAuctionItemCount, 0);
+
+  const score = scoreEvent({ seasonId, eventId: event.id });
+  assert.equal(score.ok, true);
+
+  const raceWinnerPayouts = db.prepare(`
+    SELECT COUNT(*) as c
+    FROM event_payouts
+    WHERE season_id = ? AND event_id = ? AND category = 'race_winner'
+  `).get(seasonId, event.id).c;
+  assert.equal(raceWinnerPayouts, 0);
+
+  const resultRow = db.prepare(`
+    SELECT d.external_id, d.name, d.active, er.finish_position
+    FROM event_results er
+    JOIN drivers d ON d.id = er.driver_id
+    WHERE er.event_id = ? AND d.external_id = 999
+  `).get(event.id);
+  assert.deepEqual(resultRow, {
+    external_id: 999,
+    name: 'Sub Driver',
+    active: 0,
+    finish_position: 1,
+  });
+});
+
 test('auction lifecycle sells driver and records ownership', () => {
   const {
     db,

--- a/docs/adr/0005-f1-openf1-backend-auth.md
+++ b/docs/adr/0005-f1-openf1-backend-auth.md
@@ -1,0 +1,47 @@
+## Status
+
+Accepted - 2026-03-05
+
+## Context
+
+The F1 app integrates with OpenF1 for driver, schedule, and event result data.
+During live F1 sessions, OpenF1 can restrict even historical REST access to authenticated users and return `401 Unauthorized` responses for otherwise public endpoints.
+
+Relying on anonymous access only is therefore not operationally safe for production or for real-time race-weekend testing.
+
+The app also cannot expose OpenF1 credentials to the browser because:
+
+1. provider credentials are secrets,
+2. OpenF1 recommends backend-only handling for authentication,
+3. the F1 admin UI should continue using the server as the only provider integration point.
+
+## Decision
+
+Implement OpenF1 authentication in the F1 server provider layer only.
+
+Implementation semantics:
+
+1. Runtime config:
+   - `OPENF1_USERNAME`
+   - `OPENF1_PASSWORD`
+   - optional `OPENF1_TOKEN_URL`
+2. The provider exchanges credentials against the OpenF1 token endpoint.
+3. The returned bearer token is cached in memory until near expiry.
+4. OpenF1 data requests use the bearer token when credentials are configured.
+5. If OpenF1 returns `401`, the provider clears cached auth state, refreshes the token once, and retries the request once.
+6. Tokens are never returned to the client UI and are never persisted in SQLite.
+7. Admin-visible errors should remain explicit when authentication fails or credentials are missing.
+
+## Consequences
+
+Positive:
+
+1. F1 real-data sync can continue working during live-session windows when anonymous access is blocked upstream.
+2. Credentials remain server-side only.
+3. The provider remains the single integration point for auth and request retry behavior.
+
+Negative:
+
+1. F1 runtime now depends on additional secrets for reliable OpenF1 usage.
+2. Misconfigured or expired credentials now present as provider auth failures rather than generic sync failures.
+3. Token lifecycle is process-local, so every fresh process start must reacquire a token.

--- a/docs/adr/0006-f1-pre-auction-driver-roster-rebuild.md
+++ b/docs/adr/0006-f1-pre-auction-driver-roster-rebuild.md
@@ -1,0 +1,32 @@
+# ADR 0006: F1 Pre-Auction Driver Roster Rebuild From OpenF1
+
+Date: 2026-03-05
+
+## Status
+
+Accepted
+
+## Context
+
+The F1 app seeds a canonical 2026 driver roster locally. During pre-season/live-season provider testing, OpenF1 can expose a 2026 driver lineup that no longer matches that seed. A strict "match existing seeded drivers only" approach causes refresh failures even when the admin is still in a safe pre-auction setup with no bids, ownership, or scoring data.
+
+## Decision
+
+For F1 admin driver refresh:
+
+- keep strict identity-preserving matching when the active season already has auction or scoring activity
+- but if the active season has no bids, ownership, event results, event payouts, or season bonus payouts, allow OpenF1 to become authoritative and rebuild the season driver roster plus auction queue directly from provider data
+
+The rebuild remains season-scoped and F1-only.
+
+## Consequences
+
+Positive:
+
+- pre-auction driver refresh can recover from roster drift without requiring manual seed edits
+- real provider testing is less blocked by canonical-seed assumptions
+
+Trade-offs:
+
+- pre-auction refresh can now replace the seeded roster count and driver identities when the season is still clean
+- once auction or scoring activity exists, refresh still fails closed to avoid corrupting ownership or payout history

--- a/docs/adr/0007-f1-openf1-rate-limit-guard.md
+++ b/docs/adr/0007-f1-openf1-rate-limit-guard.md
@@ -1,0 +1,35 @@
+# ADR 0007: F1 OpenF1 Rate-Limit Guard
+
+Date: 2026-03-05
+
+## Status
+
+Accepted
+
+## Context
+
+OpenF1 enforces a low request-per-second limit. Admin-driven refresh flows and multi-request provider operations can trigger `429 Rate limit exceeded` responses even when the user is following a reasonable workflow.
+
+## Decision
+
+The F1 OpenF1 provider will:
+
+- serialize outbound provider requests through one queue per server process
+- add a small minimum delay between outbound provider requests
+- enforce a rolling minute-window request budget aligned to the provider's documented 60 requests/minute cap
+- retry a bounded number of times on `429` responses
+- honor `Retry-After` when available and otherwise use short incremental backoff
+
+The retry strategy remains provider-local and does not change the admin API contract.
+
+## Consequences
+
+Positive:
+
+- admin refresh and sync flows are less likely to fail on transient provider throttling
+- provider resilience improves without adding client complexity
+
+Trade-offs:
+
+- refresh/sync actions can take slightly longer under throttling
+- repeated manual clicks can still queue work and increase wait time under sustained throttling

--- a/docs/adr/0008-f1-unowned-substitute-driver-sync.md
+++ b/docs/adr/0008-f1-unowned-substitute-driver-sync.md
@@ -1,0 +1,41 @@
+# ADR 0008: Preserve Unknown Race Drivers As Unowned Season Drivers
+
+## Status
+
+Accepted
+
+## Context
+
+The F1 app now relies on OpenF1 for live session rosters and event results. A live season can introduce substitute or replacement drivers after the auction roster is already fixed.
+
+Before this change, event sync mapped provider result rows only against the season's existing `drivers.external_id` values. Unknown provider drivers were dropped during `upsertEventResults`, which meant:
+
+- substitute/new drivers could disappear from synced race results
+- event scoring could become partial or misleading
+- the intended house rule of "no owner means undistributed payout" could not be represented correctly
+
+## Decision
+
+When provider event results include a driver not present in the current season roster:
+
+1. Insert that driver into `drivers` for the season
+2. Mark the inserted row as `active = 0`
+3. Do not create an `auction_items` row for that driver
+4. Allow `event_results` and scoring to reference the driver normally
+5. Leave payout ownership unresolved unless an `ownership` row exists
+
+This makes substitute/new drivers explicit in the season data model while keeping them out of the auctionable roster.
+
+## Consequences
+
+Positive:
+
+- event results remain complete even when the real race lineup changes
+- payout logic can correctly treat substitute-driver winners as unowned/undistributed
+- auction queue and participant ownership remain stable after the auction starts
+
+Tradeoffs:
+
+- `drivers.active` now carries an additional semantic: inactive can mean "non-auction substitute/new race driver", not just "not part of the auction roster"
+- admin tooling that only reads active drivers will not show substitute drivers in the main auction roster
+- if future product rules require manual assignment of substitute-driver ownership, a dedicated admin workflow will still be needed


### PR DESCRIPTION
Summary
- switch the F1 driver roster sync from mock data back to the live OpenF1 provider and ensure it stays refreshed for the new season
- add the requested badge for the driver list so admins can see when the roster was last refreshed
- update docs and architecture notes to reflect the new data flow and provider expectations

Testing
- Not run (not requested)