### PR TITLE
Add Built With AI experience for F1 public site

### DIFF
--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -15,6 +15,7 @@ A dedicated Formula 1 Calcutta app for a full season pool.
 - Results sync via provider adapter (`openf1` for real data, `mock` for local/dev/test)
 - Admin controls for auction, sync, payout rules, and settings
 - Results Sync admin view shows collapsible driver/event lists after provider refreshes
+- Public-facing explainer pages for both pool rules (`/guide`) and the agentic build case study (`/built-with-ai`)
 
 ## Run
 

--- a/apps/f1/client/src/App.jsx
+++ b/apps/f1/client/src/App.jsx
@@ -5,6 +5,7 @@ import { SocketProvider } from './context/SocketContext';
 import Nav from './components/Nav';
 import Join from './pages/Join';
 import Guide from './pages/Guide';
+import BuiltWithAI from './pages/BuiltWithAI';
 import Auction from './pages/Auction';
 import Events from './pages/Events';
 import Standings from './pages/Standings';
@@ -44,6 +45,7 @@ function AppRoutes() {
         <Routes>
           <Route path="/join" element={participant ? <Navigate to={participant.isAdmin ? '/admin' : '/auction'} replace /> : <Join />} />
           <Route path="/guide" element={<Guide />} />
+          <Route path="/built-with-ai" element={<BuiltWithAI />} />
           <Route path="/" element={<Navigate to="/auction" replace />} />
           <Route path="/auction" element={<ProtectedRoute><Auction /></ProtectedRoute>} />
           <Route path="/events" element={<ProtectedRoute><Events /></ProtectedRoute>} />

--- a/apps/f1/client/src/content/builtWithAIContent.js
+++ b/apps/f1/client/src/content/builtWithAIContent.js
@@ -1,0 +1,77 @@
+export const BUILT_WITH_AI_OUTCOMES = [
+  'AI generated the first implementation plan and technical direction.',
+  'Normal engineering discipline stayed in place through GitHub branches and pull requests.',
+  'Deploys ran through Railway with production environment controls.',
+  'Azure DevOps stayed connected to backlog planning and story management.',
+  'OpenF1 turned the product into a live race data application instead of a static demo.',
+];
+
+export const BUILT_WITH_AI_TIMELINE = [
+  {
+    step: '01',
+    title: 'Prompt to Plan',
+    body: 'The build started with a plain-language product prompt. Codex and Claude Code turned that into an implementation plan, stack recommendation, and first delivery path.',
+  },
+  {
+    step: '02',
+    title: 'First Working Version',
+    body: 'The first iteration of the app was scaffolded and implemented by AI agents, then refined through fast review loops instead of long specification cycles.',
+  },
+  {
+    step: '03',
+    title: 'GitHub Workflow',
+    body: 'Changes moved through a normal engineering workflow with repo integration, isolated branches, and pull-request style iteration instead of direct ad hoc edits.',
+  },
+  {
+    step: '04',
+    title: 'Cloud Deployment',
+    body: 'Railway provided cloud hosting, environment configuration, and deployment flow so the product could move from local build to live system quickly.',
+  },
+  {
+    step: '05',
+    title: 'Backlog and Execution',
+    body: 'Azure DevOps was used to create and manage user stories, feature ideas, and implementation work so product direction stayed visible and structured.',
+  },
+  {
+    step: '06',
+    title: 'Live Data Integration',
+    body: 'OpenF1 was wired in to bring live drivers, sessions, and race data into the app, turning the project from concept into an operational product.',
+  },
+  {
+    step: '07',
+    title: 'Operational Discipline',
+    body: 'Files like SOUL.md, AGENTS.md, HEARTBEAT.md, and ADRs made the build repeatable by documenting operating rules, architecture, runtime state, and key decisions.',
+  },
+];
+
+export const BUILT_WITH_AI_FLOW = [
+  { label: 'Ryan Milton', detail: 'Product direction' },
+  { label: 'Codex + Claude Code', detail: 'Planning and implementation' },
+  { label: 'GitHub', detail: 'Repo, branching, PR flow' },
+  { label: 'Railway', detail: 'Deploy and hosting' },
+  { label: 'Azure DevOps', detail: 'Backlog and stories' },
+  { label: 'OpenF1', detail: 'Live race data' },
+];
+
+export const BUILT_WITH_AI_PRACTICE = [
+  {
+    title: 'AI did not replace engineering discipline',
+    body: 'The agents handled planning, implementation, and iteration, but the workflow still relied on version control, clear scope boundaries, and testable delivery steps.',
+  },
+  {
+    title: 'The stack was chosen as part of the planning process',
+    body: 'The initial prompt did not just generate code. It produced a plan, recommended the stack, and established the first working architecture before refinement began.',
+  },
+  {
+    title: 'Operational files made the system governable',
+    body: 'Documents like AGENTS.md, SOUL.md, HEARTBEAT.md, RUNBOOK.md, and ADRs created a control plane for how the app should evolve, deploy, and recover.',
+  },
+];
+
+export const BUILT_WITH_AI_WHY = [
+  'Agentic engineering is shifting software work from isolated tasks to guided execution loops.',
+  'Planning, implementation, testing, and operations can now live inside one continuous workflow.',
+  'Traditional engineering practices still matter, but they are becoming more orchestrated and faster-moving.',
+  'Governance, runtime visibility, and version control become more important as AI takes on more delivery work.',
+  'This project is a practical example of how software teams may build and operate products going forward.',
+];

--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -458,6 +458,8 @@ button {
 .join-guide-links {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
   margin-top: 0.1rem;
   margin-bottom: 0.15rem;
 }
@@ -482,6 +484,20 @@ button {
 .join-guide-cta:hover {
   filter: brightness(1.06);
   border-color: rgba(195, 111, 116, 0.82);
+}
+
+.join-built-link {
+  color: #d8e0eb;
+  font-size: var(--text-sm);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding-bottom: 0.12rem;
+  border-bottom: 1px solid rgba(216, 224, 235, 0.28);
+}
+
+.join-built-link:hover {
+  color: #fff;
+  border-color: rgba(216, 224, 235, 0.56);
 }
 
 .join-entry-page {
@@ -653,6 +669,371 @@ button {
 
 .guide-footer-cta p {
   margin: 0;
+}
+
+.built-page {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding-bottom: var(--space-4);
+}
+
+.built-hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 420px);
+  gap: clamp(1.5rem, 4vw, 3rem);
+  padding: clamp(1.4rem, 3vw, 2.4rem) 0 clamp(1.8rem, 4vw, 3rem);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.built-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(55% 70% at 22% 18%, rgba(159, 63, 67, 0.2), rgba(159, 63, 67, 0) 72%),
+    linear-gradient(90deg, rgba(12, 17, 24, 0.25), rgba(12, 17, 24, 0));
+  pointer-events: none;
+}
+
+.built-hero-copy,
+.built-hero-art {
+  position: relative;
+  z-index: 1;
+}
+
+.built-hero-copy {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.built-hero-subhead {
+  margin: 0;
+  max-width: 50ch;
+  color: #cad2de;
+  line-height: 1.55;
+}
+
+.built-hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.built-hero-meta span {
+  padding: 0.34rem 0.48rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #d8e0eb;
+  font-size: var(--text-xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.built-hero-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.built-contact-link {
+  color: #cfd7e2;
+  font-size: var(--text-sm);
+  text-decoration: underline;
+  text-underline-offset: 0.2rem;
+}
+
+.built-contact-link:hover {
+  color: #fff;
+}
+
+.built-hero-art {
+  min-height: 320px;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.built-hero-arc {
+  position: absolute;
+  border: 1px solid rgba(178, 192, 209, 0.18);
+  border-radius: 999px;
+}
+
+.built-hero-arc-a {
+  width: 420px;
+  height: 420px;
+  top: 4%;
+  right: -18%;
+}
+
+.built-hero-arc-b {
+  width: 280px;
+  height: 280px;
+  top: 20%;
+  right: 10%;
+}
+
+.built-hero-arc-c {
+  width: 170px;
+  height: 170px;
+  bottom: 6%;
+  right: 26%;
+}
+
+.built-hero-signal {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  transform: translateX(10%);
+}
+
+.built-hero-signal span {
+  display: block;
+  width: 64px;
+  background: linear-gradient(180deg, rgba(217, 109, 115, 0.84), rgba(217, 109, 115, 0.12));
+  border: 1px solid rgba(217, 109, 115, 0.34);
+}
+
+.built-hero-signal span:nth-child(1) {
+  height: 78px;
+}
+
+.built-hero-signal span:nth-child(2) {
+  height: 148px;
+}
+
+.built-hero-signal span:nth-child(3) {
+  height: 230px;
+}
+
+.built-outcomes {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding-top: 0.35rem;
+}
+
+.built-outcomes p {
+  margin: 0;
+  padding-top: 0.55rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: #d1d9e4;
+  line-height: 1.5;
+}
+
+.built-section {
+  display: grid;
+  gap: var(--space-4);
+  padding-top: var(--space-2);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.built-section-head {
+  display: grid;
+  gap: 0.55rem;
+  max-width: 58ch;
+}
+
+.built-section-head h2,
+.built-section-head p {
+  margin: 0;
+}
+
+.built-section-head p {
+  color: #c5ceda;
+  line-height: 1.55;
+}
+
+.built-timeline {
+  display: grid;
+  gap: 0;
+}
+
+.built-timeline-item {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.built-timeline-step {
+  position: relative;
+  color: #d2858b;
+  font-size: 0.74rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding-top: 0.2rem;
+}
+
+.built-timeline-step::after {
+  content: '';
+  position: absolute;
+  top: 1.4rem;
+  left: 0.45rem;
+  bottom: -1rem;
+  width: 1px;
+  background: linear-gradient(180deg, rgba(159, 63, 67, 0.6), rgba(255, 255, 255, 0.08));
+}
+
+.built-timeline-item:last-child .built-timeline-step::after {
+  display: none;
+}
+
+.built-timeline-content {
+  padding: 0 0 1.25rem 1.25rem;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.built-timeline-content h3,
+.built-timeline-content p {
+  margin: 0;
+}
+
+.built-timeline-content h3 {
+  margin-bottom: 0.3rem;
+}
+
+.built-timeline-content p {
+  color: #cbd3de;
+  line-height: 1.55;
+}
+
+.built-flow {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.9rem;
+  position: relative;
+  padding-top: 0.35rem;
+}
+
+.built-flow::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 1rem;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(159, 63, 67, 0.55), rgba(255, 255, 255, 0.18));
+}
+
+.built-flow-step {
+  position: relative;
+  padding-top: 1.6rem;
+}
+
+.built-flow-step h3,
+.built-flow-step p {
+  margin: 0;
+}
+
+.built-flow-step h3 {
+  margin-bottom: 0.35rem;
+  font-size: 1rem;
+}
+
+.built-flow-step p {
+  color: #bcc7d5;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.built-flow-marker {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  padding: 0.24rem 0.42rem;
+  border: 1px solid rgba(159, 63, 67, 0.52);
+  background: rgba(13, 18, 26, 0.94);
+  color: #d6a0a4;
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.built-practice-grid {
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  align-items: start;
+}
+
+.built-practice-list {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.built-practice-item {
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.built-practice-item:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.built-practice-item h3,
+.built-practice-item p {
+  margin: 0;
+}
+
+.built-practice-item h3 {
+  margin-bottom: 0.32rem;
+}
+
+.built-practice-item p {
+  color: #c8d0dc;
+  line-height: 1.55;
+}
+
+.built-why-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.built-why-list p {
+  margin: 0;
+  color: #d2dae5;
+  padding-left: 1rem;
+  position: relative;
+}
+
+.built-why-list p::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.62rem;
+  width: 0.42rem;
+  height: 1px;
+  background: rgba(217, 109, 115, 0.72);
+}
+
+.built-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding-top: var(--space-2);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.built-footer p {
+  margin: 0;
+  color: #cfd6e0;
+}
+
+.built-footer a {
+  color: #e1e7ef;
+}
+
+.built-footer-links {
+  display: flex;
+  gap: 1rem;
+  font-size: var(--text-sm);
 }
 
 .page-copyright {
@@ -1994,6 +2375,52 @@ tbody tr:hover {
   .guide-section-nav {
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
+
+  .built-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .built-hero-art {
+    min-height: 220px;
+    border-left: 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding-top: 1rem;
+  }
+
+  .built-flow {
+    grid-template-columns: 1fr;
+    gap: 1.15rem;
+    padding-left: 1.1rem;
+  }
+
+  .built-flow::before {
+    left: 0.65rem;
+    right: auto;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    height: auto;
+    background: linear-gradient(180deg, rgba(159, 63, 67, 0.55), rgba(255, 255, 255, 0.18));
+  }
+
+  .built-flow-step {
+    padding-top: 0;
+    padding-left: 1.3rem;
+  }
+
+  .built-flow-marker {
+    top: 0.1rem;
+    left: -0.45rem;
+  }
+
+  .built-practice-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .built-footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 @media (max-width: 560px) {
@@ -2011,6 +2438,22 @@ tbody tr:hover {
   }
 
   .guide-section-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .built-timeline-item {
+    grid-template-columns: 52px minmax(0, 1fr);
+  }
+
+  .built-timeline-content {
+    padding-left: 0.9rem;
+  }
+
+  .built-hero-signal span {
+    width: 48px;
+  }
+
+  .built-outcomes {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/f1/client/src/pages/BuiltWithAI.jsx
+++ b/apps/f1/client/src/pages/BuiltWithAI.jsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  BUILT_WITH_AI_FLOW,
+  BUILT_WITH_AI_OUTCOMES,
+  BUILT_WITH_AI_PRACTICE,
+  BUILT_WITH_AI_TIMELINE,
+  BUILT_WITH_AI_WHY,
+} from '../content/builtWithAIContent';
+
+export default function BuiltWithAI() {
+  return (
+    <div className="built-page fade-in stack-lg">
+      <section className="built-hero">
+        <div className="built-hero-copy">
+          <div className="hero-kicker">Case Study</div>
+          <h1>Built With AI</h1>
+          <p className="built-hero-subhead">
+            This F1 Calcutta was planned, built, deployed, and operated through an agentic engineering workflow using
+            OpenAI Codex, Anthropic Claude Code, GitHub, Railway, Azure DevOps, and OpenF1.
+          </p>
+          <div className="built-hero-meta">
+            <span>OpenAI Codex</span>
+            <span>Anthropic Claude Code</span>
+            <span>GitHub</span>
+            <span>Railway</span>
+            <span>Azure DevOps</span>
+            <span>OpenF1</span>
+          </div>
+          <div className="built-hero-links">
+            <Link className="btn" to="/join">View App Entry</Link>
+            <a className="built-contact-link" href="mailto:ryan@ryanmilton.com">Questions? Contact Ryan</a>
+          </div>
+        </div>
+        <div className="built-hero-art" aria-hidden="true">
+          <div className="built-hero-arc built-hero-arc-a" />
+          <div className="built-hero-arc built-hero-arc-b" />
+          <div className="built-hero-arc built-hero-arc-c" />
+          <div className="built-hero-signal">
+            <span />
+            <span />
+            <span />
+          </div>
+        </div>
+      </section>
+
+      <section className="built-outcomes">
+        {BUILT_WITH_AI_OUTCOMES.map((item) => (
+          <p key={item}>{item}</p>
+        ))}
+      </section>
+
+      <section className="built-section">
+        <div className="built-section-head">
+          <div className="hero-kicker">Delivery Story</div>
+          <h2>From prompt to production</h2>
+          <p>
+            The value was not just code generation. The workflow combined planning, implementation, backlog control,
+            deployment, and live data integration into one operating loop.
+          </p>
+        </div>
+        <div className="built-timeline" aria-label="Delivery timeline">
+          {BUILT_WITH_AI_TIMELINE.map((item) => (
+            <article key={item.step} className="built-timeline-item">
+              <div className="built-timeline-step">{item.step}</div>
+              <div className="built-timeline-content">
+                <h3>{item.title}</h3>
+                <p>{item.body}</p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="built-section">
+        <div className="built-section-head">
+          <div className="hero-kicker">Workflow</div>
+          <h2>How the system moved work forward</h2>
+          <p>
+            This is the operating flow behind the product: human direction, agent execution, standard engineering
+            controls, cloud delivery, backlog management, and live race data.
+          </p>
+        </div>
+        <div className="built-flow" role="img" aria-label="Ryan Milton to AI agents to GitHub to Railway to Azure DevOps to OpenF1 flow">
+          {BUILT_WITH_AI_FLOW.map((item, index) => (
+            <article key={item.label} className="built-flow-step">
+              <div className="built-flow-marker" aria-hidden="true">{String(index + 1).padStart(2, '0')}</div>
+              <h3>{item.label}</h3>
+              <p>{item.detail}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="built-section built-practice-grid">
+        <div className="built-section-head">
+          <div className="hero-kicker">In Practice</div>
+          <h2>What actually made this work</h2>
+        </div>
+        <div className="built-practice-list">
+          {BUILT_WITH_AI_PRACTICE.map((item) => (
+            <article key={item.title} className="built-practice-item">
+              <h3>{item.title}</h3>
+              <p>{item.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="built-section built-why">
+        <div className="built-section-head">
+          <div className="hero-kicker">Where It Leads</div>
+          <h2>Where agentic engineering is going</h2>
+        </div>
+        <div className="built-why-list">
+          {BUILT_WITH_AI_WHY.map((item) => (
+            <p key={item}>{item}</p>
+          ))}
+        </div>
+      </section>
+
+      <section className="built-footer">
+        <p>Questions? <a href="mailto:ryan@ryanmilton.com">Contact Ryan</a></p>
+        <div className="built-footer-links">
+          <Link to="/guide">F1 Calcutta Guide</Link>
+          <Link to="/join">Join Page</Link>
+        </div>
+      </section>
+
+      <footer className="page-copyright">
+        © 2026 Ryan Milton.
+      </footer>
+    </div>
+  );
+}

--- a/apps/f1/client/src/pages/Guide.jsx
+++ b/apps/f1/client/src/pages/Guide.jsx
@@ -51,6 +51,7 @@ export default function Guide() {
           <div className="row wrap gap-sm">
             <Link className="btn" to="/join">Join Pool</Link>
             <Link className="btn btn-outline" to="/join">Admin Login</Link>
+            <Link className="btn btn-outline" to="/built-with-ai">Built With AI</Link>
           </div>
           <p className="muted small">Admin login uses the Admin tab on the join screen.</p>
         </div>
@@ -134,6 +135,7 @@ export default function Guide() {
         <div className="row wrap gap-sm">
           <Link className="btn" to="/join">Join Pool</Link>
           <Link className="btn btn-outline" to="/join">Go to Login</Link>
+          <Link className="btn btn-outline" to="/built-with-ai">See How It Was Built</Link>
         </div>
       </section>
       <footer className="page-copyright">

--- a/apps/f1/client/src/pages/Join.jsx
+++ b/apps/f1/client/src/pages/Join.jsx
@@ -86,6 +86,7 @@ export default function Join() {
           </p>
           <div className="join-guide-links">
             <Link className="btn join-guide-cta" to="/guide">How It Works</Link>
+            <Link className="join-built-link" to="/built-with-ai">Built With AI</Link>
           </div>
           <div className="join-hero-cards">
             <div>
@@ -172,7 +173,7 @@ export default function Join() {
           )}
           {error ? <p className="error-text">{error}</p> : null}
           <p className="small muted join-guide-secondary">
-            New here? <Link className="join-guide-link-inline" to="/guide">Read the F1 Calcutta guide</Link> before joining.
+            New here? <Link className="join-guide-link-inline" to="/guide">Read the F1 Calcutta guide</Link> or see <Link className="join-guide-link-inline" to="/built-with-ai">how the app was built</Link>.
           </p>
         </section>
       </div>


### PR DESCRIPTION
**Summary**
- add the new `/built-with-ai` editorial case-study page using the F1 visual system, including hero, executive strip, timeline, workflow diagram, narrative sections, and CTA
- wire the F1 landing and guide public pages to the new route for broader discovery
- organize story content via a reusable constants module while keeping copy client-friendly and aligned with the requested visuals & terminology

**Testing**
- Not run (not requested)