### PR TITLE
Add audit/export path and invite link documentation

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -101,6 +101,16 @@ After deploy:
    - before the first real race sync
    - before any destructive test-data reset
 
+### F) F1 Payout Audit Export
+
+1. Open `Admin -> Payout Audit`.
+2. Select the event in question.
+3. Use:
+   - `Download CSV` for a shareable rule-by-rule export
+   - `Download Winner CSV` for spreadsheet-friendly winner rows
+   - `Copy Summary` for a concise plain-text explanation
+4. Use these outputs when reviewing disputed race payouts with participants.
+
 ## Rollback Procedure
 
 1. Open service Deployments in Railway.

--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -17,6 +17,7 @@ A dedicated Formula 1 Calcutta app for a full season pool.
 - Admin controls for auction, sync, payout rules, and settings
 - Results Sync admin view shows collapsible driver/event lists after provider refreshes
 - Results Sync admin view exposes a live database backup download and a visible driver-roster freeze guard after auction/scoring activity begins
+- Payout Audit admin view supports rule-level CSV export, winner-detail CSV export, and copyable text summaries for payout review and dispute handling
 - Public-facing explainer pages for both pool rules (`/guide`) and the agentic build case study (`/built-with-ai`)
 
 ## Run
@@ -63,6 +64,8 @@ Server: `http://localhost:3002`
 - Admin Results Sync page can download a live SQLite backup snapshot before auction night or race scoring operations
 - Admin Results Sync page disables `Refresh Drivers` once the season has bids, ownership, or scored payout activity so the auction roster is not changed casually after go-live
 - Admin Auction page can explicitly lock or unlock the season roster; Results Sync respects that lock in addition to activity-based safeguards
+- Admin Payout Audit page can export both rule-level and winner-detail CSVs, plus a concise text summary for payout review
+- Admin Auction page exposes a shareable invite link that deep-links to `/join` with the active invite code prefilled
 
 ## Engineering Docs
 

--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -252,6 +252,11 @@ button {
   transform: none;
 }
 
+.btn-disabled-link {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
 .btn-outline {
   background: rgba(16, 22, 32, 0.48);
   border-color: var(--border);
@@ -2044,6 +2049,41 @@ tbody tr:hover {
   align-items: flex-start;
 }
 
+.invite-share-panel {
+  gap: 1rem;
+}
+
+.invite-share-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 240px) minmax(0, 1fr);
+}
+
+.invite-share-card {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(6, 10, 18, 0.72);
+}
+
+.invite-share-card strong {
+  display: block;
+  font-size: 1.2rem;
+  line-height: 1.25;
+}
+
+.invite-share-link-card {
+  min-width: 0;
+}
+
+.invite-share-link {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
 .admin-participant-list {
   display: grid;
   gap: 0.8rem;
@@ -2446,6 +2486,10 @@ tbody tr:hover {
   }
 
   .admin-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .invite-share-grid {
     grid-template-columns: 1fr;
   }
 

--- a/apps/f1/client/src/pages/Join.jsx
+++ b/apps/f1/client/src/pages/Join.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 const AUSTRALIAN_GP_START_ISO = '2026-02-22T04:00:00Z';
@@ -17,6 +17,7 @@ function formatCountdown(targetMs, nowMs) {
 }
 
 export default function Join() {
+  const location = useLocation();
   const { join, adminLogin } = useAuth();
   const [mode, setMode] = useState('join');
   const [name, setName] = useState('');
@@ -30,6 +31,14 @@ export default function Join() {
     const id = setInterval(() => setNowMs(Date.now()), 30000);
     return () => clearInterval(id);
   }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const linkInviteCode = params.get('invite');
+    if (!linkInviteCode) return;
+    setInviteCode(linkInviteCode.trim().toUpperCase());
+    setMode('join');
+  }, [location.search]);
 
   const countdownText = useMemo(() => {
     const targetMs = Date.parse(AUSTRALIAN_GP_START_ISO);

--- a/apps/f1/client/src/pages/admin/AuctionPage.jsx
+++ b/apps/f1/client/src/pages/admin/AuctionPage.jsx
@@ -1,7 +1,8 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import ParticipantAvatar from '../../components/ParticipantAvatar';
 import { useSocketEvent } from '../../context/SocketContext';
 import AdminLoadingState from './AdminLoadingState';
+import { buildInviteLink } from './adminApi';
 import useAdminOutletContext from './useAdminOutletContext';
 
 export default function AuctionPage() {
@@ -13,9 +14,11 @@ export default function AuctionPage() {
     saveSettingsPatch,
     runAuctionAction,
     refresh,
+    setMessage,
     loading,
     hasLoaded,
   } = useAdminOutletContext();
+  const [inviteBusy, setInviteBusy] = useState(false);
   const budgetCapValue = typeof settings?.auction_budget_cap_cents === 'string'
     ? settings.auction_budget_cap_cents
     : String(settings?.auction_budget_cap_cents == null ? 200 : (Number(settings.auction_budget_cap_cents) / 100));
@@ -23,10 +26,51 @@ export default function AuctionPage() {
     || settings?.auction_roster_locked === 1
     || settings?.auction_roster_locked === true;
   const joinedParticipants = (participants || []).filter((participant) => !participant.is_admin);
+  const inviteLink = useMemo(
+    () => buildInviteLink(settings?.invite_code),
+    [settings?.invite_code],
+  );
 
   const handleParticipantsUpdate = useCallback(() => {
     refresh({ silent: true });
   }, [refresh]);
+
+  const handleCopyInviteLink = useCallback(async () => {
+    if (!inviteLink) return;
+    setInviteBusy(true);
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      setMessage('Invite link copied.');
+    } catch (error) {
+      setMessage(error.message || 'Failed to copy invite link.');
+    } finally {
+      setInviteBusy(false);
+    }
+  }, [inviteLink, setMessage]);
+
+  const handleShareInviteLink = useCallback(async () => {
+    if (!inviteLink) return;
+    setInviteBusy(true);
+    try {
+      if (navigator.share) {
+        await navigator.share({
+          title: 'Join the F1 Calcutta',
+          text: 'Use this link to join the F1 Calcutta pool.',
+          url: inviteLink,
+        });
+        setMessage('Invite link shared.');
+      } else {
+        await navigator.clipboard.writeText(inviteLink);
+        setMessage('Sharing is not available here. Invite link copied instead.');
+      }
+    } catch (error) {
+      if (error?.name !== 'AbortError') {
+        setMessage(error.message || 'Failed to share invite link.');
+      }
+    } finally {
+      setInviteBusy(false);
+    }
+  }, [inviteLink, setMessage]);
 
   useSocketEvent('participants:update', handleParticipantsUpdate);
 
@@ -36,6 +80,45 @@ export default function AuctionPage() {
 
   return (
     <div className="stack-lg">
+      <section className="panel stack">
+        <div className="row wrap gap-sm participants-panel-header">
+          <div>
+            <h2>Invite Participants</h2>
+            <p className="muted">Share the pool link or send the invite code directly.</p>
+          </div>
+        </div>
+        <div className="invite-share-panel stack">
+          <div className="invite-share-grid">
+            <div className="invite-share-card">
+              <span className="label">Invite Code</span>
+              <strong>{settings?.invite_code || '—'}</strong>
+            </div>
+            <div className="invite-share-card invite-share-link-card">
+              <span className="label">Shareable Link</span>
+              <strong className="invite-share-link">{inviteLink || 'Unavailable'}</strong>
+            </div>
+          </div>
+          <div className="row wrap gap-sm">
+            <button
+              className="btn"
+              type="button"
+              onClick={handleCopyInviteLink}
+              disabled={!inviteLink || inviteBusy}
+            >
+              Copy Invite Link
+            </button>
+            <button
+              className="btn btn-outline"
+              type="button"
+              onClick={handleShareInviteLink}
+              disabled={!inviteLink || inviteBusy}
+            >
+              Share Invite Link
+            </button>
+          </div>
+        </div>
+      </section>
+
       <section className="panel stack">
         <h2>Auction Controls</h2>
         <div className="row wrap gap-sm">

--- a/apps/f1/client/src/pages/admin/PayoutAuditPage.jsx
+++ b/apps/f1/client/src/pages/admin/PayoutAuditPage.jsx
@@ -7,6 +7,10 @@ import {
   fmtCents,
   fmtWhen,
 } from '../../utils';
+import {
+  payoutAuditExportHref,
+  payoutAuditWinnerExportHref,
+} from './adminApi';
 import AdminLoadingState from './AdminLoadingState';
 import useAdminOutletContext from './useAdminOutletContext';
 
@@ -41,6 +45,7 @@ export default function PayoutAuditPage() {
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState('');
   const [expandedRuleKey, setExpandedRuleKey] = useState('');
+  const [copyStatus, setCopyStatus] = useState('');
 
   useEffect(() => {
     if (!selectedEventId && events?.length) {
@@ -77,15 +82,46 @@ export default function PayoutAuditPage() {
 
   useEffect(() => {
     setExpandedRuleKey('');
+    setCopyStatus('');
     if (!selectedEventId) return;
     loadEventAudit(selectedEventId);
   }, [selectedEventId, loadEventAudit]);
 
+  const audit = eventDetail?.payout_audit;
+
+  const auditSummaryText = useMemo(() => {
+    if (!audit || !selectedEvent) return '';
+    const lines = [
+      `${selectedEvent.name} payout audit`,
+      `${eventTypeLabel(selectedEvent.type)} • Total pot ${fmtCents(audit.total_pot_cents || 0)} • Random position ${audit.random_bonus_position || '—'}`,
+    ];
+
+    (audit.rules || []).forEach((rule) => {
+      const winnerSummary = (rule.winners || []).length
+        ? rule.winners.map((winner) => {
+          const owner = winner.owner_participant_name || 'Unowned';
+          return `${winner.driver_name || winner.driver_code || 'Driver'} (${owner}) ${fmtCents(winner.received_cents)}`;
+        }).join(', ')
+        : 'No winners';
+      lines.push(`${categoryLabel(rule.category)} | ${rule.bps} bps | ${fmtCents(rule.category_pot_cents)} | ${rule.status_reason} | ${winnerSummary}`);
+    });
+
+    return lines.join('\n');
+  }, [audit, selectedEvent]);
+
+  const copyAuditSummary = useCallback(async () => {
+    if (!auditSummaryText) return;
+    try {
+      await navigator.clipboard.writeText(auditSummaryText);
+      setCopyStatus('Audit summary copied.');
+    } catch {
+      setCopyStatus('Failed to copy audit summary.');
+    }
+  }, [auditSummaryText]);
+
   if (loading && !hasLoaded) {
     return <AdminLoadingState />;
   }
-
-  const audit = eventDetail?.payout_audit;
 
   return (
     <section className="panel stack-lg">
@@ -109,6 +145,36 @@ export default function PayoutAuditPage() {
             ))}
           </select>
         </label>
+        <div className="row wrap gap-sm">
+          <a
+            className={`btn btn-outline ${selectedEventId ? '' : 'btn-disabled-link'}`}
+            href={selectedEventId ? payoutAuditExportHref(selectedEventId) : undefined}
+            aria-disabled={!selectedEventId}
+            onClick={(event) => {
+              if (!selectedEventId) event.preventDefault();
+            }}
+          >
+            Download CSV
+          </a>
+          <a
+            className={`btn btn-outline ${selectedEventId ? '' : 'btn-disabled-link'}`}
+            href={selectedEventId ? payoutAuditWinnerExportHref(selectedEventId) : undefined}
+            aria-disabled={!selectedEventId}
+            onClick={(event) => {
+              if (!selectedEventId) event.preventDefault();
+            }}
+          >
+            Download Winner CSV
+          </a>
+          <button
+            type="button"
+            className="btn btn-outline"
+            onClick={copyAuditSummary}
+            disabled={!auditSummaryText}
+          >
+            Copy Summary
+          </button>
+        </div>
       </div>
 
       {selectedEvent ? (
@@ -119,6 +185,7 @@ export default function PayoutAuditPage() {
 
       {detailLoading ? <p className="muted">Loading payout audit...</p> : null}
       {detailError ? <p className="error-text">{detailError}</p> : null}
+      {copyStatus ? <p className="muted small">{copyStatus}</p> : null}
 
       {!detailLoading && !detailError && audit ? (
         <>

--- a/apps/f1/client/src/pages/admin/adminApi.js
+++ b/apps/f1/client/src/pages/admin/adminApi.js
@@ -66,6 +66,21 @@ export function databaseBackupHref() {
   return '/api/admin/ops/database-backup';
 }
 
+export function buildInviteLink(inviteCode, origin = window.location.origin) {
+  const cleanCode = String(inviteCode || '').trim().toUpperCase();
+  if (!cleanCode) return '';
+  const base = String(origin || '').replace(/\/+$/, '');
+  return `${base}/join?invite=${encodeURIComponent(cleanCode)}`;
+}
+
+export function payoutAuditExportHref(eventId) {
+  return `/api/admin/payout-audit/${eventId}/export.csv`;
+}
+
+export function payoutAuditWinnerExportHref(eventId) {
+  return `/api/admin/payout-audit/${eventId}/export-winners.csv`;
+}
+
 export async function refreshDrivers() {
   const response = await api('/admin/results/refresh-drivers', {
     method: 'POST',

--- a/apps/f1/server/routes/admin.js
+++ b/apps/f1/server/routes/admin.js
@@ -11,6 +11,10 @@ const payoutRulesAdminService = require('../services/admin/payoutRulesAdminServi
 const resultsAdminService = require('../services/admin/resultsAdminService');
 const { OpenF1ResultsProvider } = require('../providers/openF1ResultsProvider');
 const {
+  buildEventPayoutAuditCsv,
+  buildEventPayoutAuditWinnerCsv,
+} = require('../services/payoutAuditService');
+const {
   parseForceFlag,
   parseIntegerParam,
   runAndRespond,
@@ -166,6 +170,38 @@ router.get('/ops/database-backup', withAdmin, async (req, res) => {
     fs.unlink(backupPath, () => {});
     return res.status(500).json({ error: error.message || 'Failed to create database backup.' });
   }
+});
+
+router.get('/payout-audit/:id/export.csv', withAdmin, (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const eventId = parseIdFromParams(res, req.params.id);
+  if (eventId == null) return undefined;
+
+  const csv = buildEventPayoutAuditCsv({ seasonId, eventId });
+  if (!csv) {
+    return res.status(404).json({ error: 'Payout audit event not found.' });
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="f1-payout-audit-${eventId}-${timestamp}.csv"`);
+  return res.send(csv);
+});
+
+router.get('/payout-audit/:id/export-winners.csv', withAdmin, (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const eventId = parseIdFromParams(res, req.params.id);
+  if (eventId == null) return undefined;
+
+  const csv = buildEventPayoutAuditWinnerCsv({ seasonId, eventId });
+  if (!csv) {
+    return res.status(404).json({ error: 'Payout audit event not found.' });
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="f1-payout-audit-winners-${eventId}-${timestamp}.csv"`);
+  return res.send(csv);
 });
 
 router.post('/test-data/clear-all', withAdmin, (req, res) => {

--- a/apps/f1/server/services/payoutAuditService.js
+++ b/apps/f1/server/services/payoutAuditService.js
@@ -166,6 +166,154 @@ function buildEventPayoutAudit({ seasonId, eventId }) {
   };
 }
 
+function csvCell(value) {
+  if (value == null) return '';
+  const text = String(value);
+  if (/[",\n]/.test(text)) return `"${text.replace(/"/g, '""')}"`;
+  return text;
+}
+
+function formatWinnerSummary(winners) {
+  if (!Array.isArray(winners) || winners.length === 0) return 'No winners';
+  return winners.map((winner) => {
+    const owner = winner.owner_participant_name || 'Unowned';
+    const finish = winner.finish_position ?? 'N/A';
+    const start = winner.start_position ?? 'N/A';
+    const gain = winner.positions_gained ?? 'N/A';
+    const stop = Number(winner.slowest_pit_stop_seconds);
+    const stopText = Number.isFinite(stop) && stop > 0 ? `, slowest stop ${stop.toFixed(3)}s` : '';
+    return `${winner.driver_name || winner.driver_code || 'Driver'} (${winner.team_name || 'Team N/A'}) - owner ${owner}, finish ${finish}, start ${start}, gain ${gain}${stopText}, received ${winner.received_cents}`;
+  }).join(' | ');
+}
+
+function buildEventPayoutAuditCsv({ seasonId, eventId }) {
+  const event = getEventById(seasonId, eventId);
+  const audit = buildEventPayoutAudit({ seasonId, eventId });
+  if (!event || !audit) return null;
+
+  const rows = [
+    ['Event Name', event.name],
+    ['Event Type', event.type],
+    ['Total Pot Cents', audit.total_pot_cents],
+    ['Random Bonus Position', audit.random_bonus_position || ''],
+    ['Has Results', audit.has_results ? 'yes' : 'no'],
+    [],
+    [
+      'Rule Label',
+      'Category',
+      'BPS',
+      'Percent Of Pot',
+      'Rule Pot Cents',
+      'Winner Count',
+      'Status',
+      'Status Reason',
+      'Distributed Cents',
+      'Undistributed Cents',
+      'Resolution Metric',
+      'Resolution Target',
+      'Winner Summary',
+    ],
+    ...(audit.rules || []).map((rule) => [
+      rule.label || rule.category,
+      rule.category,
+      rule.bps,
+      rule.category_pct_of_pot,
+      rule.category_pot_cents,
+      rule.winner_count,
+      rule.status,
+      rule.status_reason,
+      rule.distributed_cents,
+      rule.undistributed_cents,
+      rule.resolution?.metric || '',
+      rule.resolution?.target_value ?? '',
+      formatWinnerSummary(rule.winners),
+    ]),
+  ];
+
+  return rows.map((row) => row.map(csvCell).join(',')).join('\n');
+}
+
+function buildEventPayoutAuditWinnerCsv({ seasonId, eventId }) {
+  const event = getEventById(seasonId, eventId);
+  const audit = buildEventPayoutAudit({ seasonId, eventId });
+  if (!event || !audit) return null;
+
+  const rows = [
+    ['Event Name', event.name],
+    ['Event Type', event.type],
+    ['Total Pot Cents', audit.total_pot_cents],
+    ['Random Bonus Position', audit.random_bonus_position || ''],
+    [],
+    [
+      'Rule Label',
+      'Category',
+      'Rule Pot Cents',
+      'Rule Status',
+      'Driver Name',
+      'Driver Code',
+      'Team Name',
+      'Driver Active',
+      'Owner Participant',
+      'Finish Position',
+      'Start Position',
+      'Positions Gained',
+      'Slowest Pit Stop Seconds',
+      'Split Share Cents',
+      'Received Cents',
+      'Undistributed Cents',
+    ],
+  ];
+
+  (audit.rules || []).forEach((rule) => {
+    if (!rule.winners?.length) {
+      rows.push([
+        rule.label || rule.category,
+        rule.category,
+        rule.category_pot_cents,
+        rule.status,
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        0,
+        0,
+        rule.undistributed_cents,
+      ]);
+      return;
+    }
+
+    rule.winners.forEach((winner) => {
+      rows.push([
+        rule.label || rule.category,
+        rule.category,
+        rule.category_pot_cents,
+        rule.status,
+        winner.driver_name || '',
+        winner.driver_code || '',
+        winner.team_name || '',
+        winner.driver_active ?? '',
+        winner.owner_participant_name || 'Unowned',
+        winner.finish_position ?? '',
+        winner.start_position ?? '',
+        winner.positions_gained ?? '',
+        winner.slowest_pit_stop_seconds ?? '',
+        winner.split_share_cents ?? 0,
+        winner.received_cents ?? 0,
+        rule.undistributed_cents ?? 0,
+      ]);
+    });
+  });
+
+  return rows.map((row) => row.map(csvCell).join(',')).join('\n');
+}
+
 module.exports = {
   buildEventPayoutAudit,
+  buildEventPayoutAuditCsv,
+  buildEventPayoutAuditWinnerCsv,
 };

--- a/apps/f1/server/tests/payoutAuditService.test.js
+++ b/apps/f1/server/tests/payoutAuditService.test.js
@@ -243,3 +243,96 @@ test('buildEventPayoutAudit includes random bonus target and winner details', ()
   assert.equal(randomRule.winner_count, 1);
   assert.equal(randomRule.winners[0].owner_participant_name, 'Audit-Random');
 });
+
+test('buildEventPayoutAuditCsv returns a rule-level CSV export', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    upsertEventResults,
+    scoreEvent,
+    buildEventPayoutAuditCsv,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const event = db.prepare(`
+    SELECT id
+    FROM events
+    WHERE season_id = ? AND type = 'grand_prix'
+    ORDER BY round_number ASC
+    LIMIT 1
+  `).get(seasonId);
+
+  db.prepare('UPDATE events SET lock_at = ? WHERE id = ?').run('2000-01-01T00:00:00Z', event.id);
+  const participantId = seedParticipant(db, seasonId, { name: 'Audit-CSV', color: '#36cfc9', token: 'audit-csv' });
+  const driver = db.prepare(`
+    SELECT id, external_id
+    FROM drivers
+    WHERE season_id = ?
+    ORDER BY external_id ASC
+    LIMIT 1
+  `).get(seasonId);
+
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, driver.id, participantId, 1000);
+
+  upsertEventResults({
+    seasonId,
+    eventId: event.id,
+    rows: [{ external_driver_id: driver.external_id, finish_position: 1, start_position: 3 }],
+  });
+  assert.equal(scoreEvent({ seasonId, eventId: event.id }).ok, true);
+
+  const csv = buildEventPayoutAuditCsv({ seasonId, eventId: event.id });
+  assert.match(csv, /Event Name,Australian Grand Prix/i);
+  assert.match(csv, /Rule Label,Category,BPS/i);
+  assert.match(csv, /Race Winner/);
+  assert.match(csv, /Audit-CSV/);
+});
+
+test('buildEventPayoutAuditWinnerCsv returns one row per winner or empty outcome', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    upsertEventResults,
+    scoreEvent,
+    buildEventPayoutAuditWinnerCsv,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const event = db.prepare(`
+    SELECT id
+    FROM events
+    WHERE season_id = ? AND type = 'grand_prix'
+    ORDER BY round_number ASC
+    LIMIT 1
+  `).get(seasonId);
+
+  db.prepare('UPDATE events SET lock_at = ? WHERE id = ?').run('2000-01-01T00:00:00Z', event.id);
+  const participantId = seedParticipant(db, seasonId, { name: 'Audit-Winner-CSV', color: '#73d13d', token: 'audit-winner-csv' });
+  const driver = db.prepare(`
+    SELECT id, external_id
+    FROM drivers
+    WHERE season_id = ?
+    ORDER BY external_id ASC
+    LIMIT 1
+  `).get(seasonId);
+
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, driver.id, participantId, 1000);
+
+  upsertEventResults({
+    seasonId,
+    eventId: event.id,
+    rows: [{ external_driver_id: driver.external_id, finish_position: 1, start_position: 2 }],
+  });
+  assert.equal(scoreEvent({ seasonId, eventId: event.id }).ok, true);
+
+  const csv = buildEventPayoutAuditWinnerCsv({ seasonId, eventId: event.id });
+  assert.match(csv, /Rule Label,Category,Rule Pot Cents,Rule Status,Driver Name/i);
+  assert.match(csv, /Audit-Winner-CSV/);
+  assert.match(csv, /Race Winner/);
+});


### PR DESCRIPTION
- **Summary**
  - Documented agent expectations, architecture, runbooks, and soul fundamentals across the repo and both apps to reflect the new operational policies.
  - Added the payout audit/export flow, roster freeze safeguards, and shareable invite link support throughout the F1 client, server, docs, and admin tooling.
  - Updated related ADRs, READMEs, and operational files to keep the apps in sync with the new behaviors.
- **Testing**
  - Not run (not requested)