### PR TITLE
Add live payout board to F1 dashboard

### DIFF
--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -13,7 +13,7 @@ A dedicated Formula 1 Calcutta app for a full season pool.
 - Auto-drawn random finishing position bonus per event
 - Grand Prix novelty rule for slowest recorded pit stop via OpenF1 `stop_duration`
 - Season bonus payouts from remaining pool
-- Participant dashboard at `/dashboard` with personal KPIs, full standings, current-or-next race focus, and live OpenF1 race widgets
+- Participant dashboard at `/dashboard` with personal KPIs, full standings, current-or-next race focus, and a live payout-category board driven by OpenF1 timing
 - On-demand Anthropic briefing on the dashboard for a concise personal race/standings summary, persisted per participant across refreshes and login sessions
 - Results sync via provider adapter (`openf1` for real data, `mock` for local/dev/test)
 - Admin controls for auction, sync, payout rules, and settings

--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -2516,6 +2516,66 @@ tbody tr:hover {
   text-align: right;
 }
 
+.dashboard-payout-board {
+  margin-top: var(--space-1);
+}
+
+.dashboard-payout-cell {
+  display: grid;
+  gap: 0.28rem;
+}
+
+.dashboard-payout-stack {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.dashboard-payout-holder,
+.dashboard-owner-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 26px;
+}
+
+.dashboard-payout-status,
+.dashboard-owner-badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  padding: 0.14rem 0.44rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dashboard-payout-status.live {
+  color: #b9d8c8;
+  border-color: rgba(127, 184, 157, 0.42);
+  background: rgba(127, 184, 157, 0.12);
+}
+
+.dashboard-payout-status.pending,
+.dashboard-payout-status.draw_pending {
+  color: #d9c38d;
+  border-color: rgba(217, 195, 141, 0.34);
+  background: rgba(217, 195, 141, 0.08);
+}
+
+.dashboard-payout-status.unavailable {
+  color: #c9b7ba;
+  border-color: rgba(201, 183, 186, 0.2);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.dashboard-owner-badge {
+  color: #d4a6aa;
+  border-color: rgba(159, 63, 67, 0.4);
+  background: rgba(159, 63, 67, 0.14);
+}
+
 .dashboard-participant-cell {
   display: inline-flex;
   align-items: center;

--- a/apps/f1/client/src/pages/Dashboard.jsx
+++ b/apps/f1/client/src/pages/Dashboard.jsx
@@ -11,12 +11,6 @@ import {
   toTimestampMs,
 } from '../utils';
 
-function formatSignedNumber(value) {
-  if (value == null || !Number.isFinite(Number(value))) return '0';
-  const num = Number(value);
-  return `${num > 0 ? '+' : ''}${num}`;
-}
-
 function formatCountdown(iso) {
   const targetMs = toTimestampMs(iso);
   if (targetMs == null) return 'TBD';
@@ -50,9 +44,22 @@ function LiveStatusPill({ liveSession, primaryEvent }) {
   return <span className={liveClassName}>{label}</span>;
 }
 
-function DriverTrackerTable({ rows, emptyText }) {
-  if (!rows?.length) {
-    return <p className="muted">{emptyText}</p>;
+function formatBpsPercent(bps) {
+  const num = Number(bps);
+  if (!Number.isFinite(num)) return '-';
+  return `${(num / 100).toFixed(2)}%`;
+}
+
+function payoutStatusLabel(rule) {
+  if (rule?.status === 'draw_pending') return 'Draw Pending';
+  if (rule?.status === 'pending') return 'TBD';
+  if (rule?.status === 'unavailable') return 'Live Unavailable';
+  return 'Live';
+}
+
+function PayoutBoardTable({ rules }) {
+  if (!rules?.length) {
+    return <p className="muted">No payout categories are configured for this event.</p>;
   }
 
   return (
@@ -60,56 +67,94 @@ function DriverTrackerTable({ rows, emptyText }) {
       <table>
         <thead>
           <tr>
-            <th>Driver</th>
-            <th>Pos</th>
-            <th>Delta</th>
-            <th>Gap</th>
-            <th>Pit</th>
+            <th>Category</th>
+            <th>Pool</th>
+            <th>Current Holder</th>
+            <th>Owner</th>
+            <th>Metric</th>
           </tr>
         </thead>
         <tbody>
-          {rows.map((driver) => (
-            <tr key={`${driver.external_driver_id || driver.driver_id}`}>
+          {rules.map((rule) => (
+            <tr key={rule.category}>
               <td>
-                <DriverIdentity
-                  driverName={driver.driver_name}
-                  driverCode={driver.driver_code}
-                  teamName={driver.team_name}
-                  compact
-                  showCode={false}
-                />
+                <div className="dashboard-payout-cell">
+                  <strong>{rule.label}</strong>
+                  <span className={`dashboard-payout-status ${rule.status}`}>{payoutStatusLabel(rule)}</span>
+                  {rule.note ? <span className="muted small">{rule.note}</span> : null}
+                </div>
               </td>
-              <td>{driver.position ? `P${driver.position}` : '-'}</td>
-              <td className={(driver.positionsGained || 0) >= 0 ? 'text-pos' : 'text-neg'}>
-                {driver.positionsGained == null ? '-' : formatSignedNumber(driver.positionsGained)}
+              <td>{formatBpsPercent(rule.bps)}</td>
+              <td>
+                {rule.holders?.length ? (
+                  <div className="dashboard-payout-stack">
+                    {rule.holders.map((holder) => (
+                      <div
+                        key={`${rule.category}-${holder.driverId || holder.driverCode || holder.driverName}`}
+                        className="dashboard-payout-holder"
+                      >
+                        <DriverIdentity
+                          driverName={holder.driverName}
+                          driverCode={holder.driverCode}
+                          teamName={holder.teamName}
+                          compact
+                          showCode={false}
+                        />
+                        {holder.isViewerOwner ? <span className="dashboard-owner-badge">Yours</span> : null}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <span className="muted">{payoutStatusLabel(rule)}</span>
+                )}
               </td>
-              <td>{driver.gapToLeader || driver.intervalToAhead || '-'}</td>
-              <td>{driver.lastPitStopSeconds ? `${Number(driver.lastPitStopSeconds).toFixed(2)}s` : '-'}</td>
+              <td>
+                {rule.holders?.length ? (
+                  <div className="dashboard-payout-stack">
+                    {rule.holders.map((holder) => (
+                      <div key={`${rule.category}-owner-${holder.driverId || holder.driverCode || holder.driverName}`} className="dashboard-owner-line">
+                        {holder.participantName ? (
+                          <>
+                            <span
+                              className="avatar dashboard-participant-avatar"
+                              style={{
+                                backgroundColor: `${holder.participantColor || '#e10600'}22`,
+                                color: holder.participantColor || '#e10600',
+                                borderColor: `${holder.participantColor || '#e10600'}66`,
+                              }}
+                            >
+                              {(holder.participantName || '?').trim().charAt(0).toUpperCase() || '?'}
+                            </span>
+                            <span>{holder.participantName}</span>
+                          </>
+                        ) : (
+                          <span className="muted">Unowned</span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <span className="muted">-</span>
+                )}
+              </td>
+              <td>
+                {rule.holders?.length ? (
+                  <div className="dashboard-payout-stack">
+                    {rule.holders.map((holder) => (
+                      <div key={`${rule.category}-metric-${holder.driverId || holder.driverCode || holder.driverName}`}>
+                        {holder.displayValue || rule.metric?.display || '-'}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <span className="muted">{rule.metric?.display || '-'}</span>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
     </div>
-  );
-}
-
-function CompactRankingList({ rows, emptyText, valueLabel }) {
-  if (!rows?.length) return <p className="muted">{emptyText}</p>;
-
-  return (
-    <ul className="list dashboard-ranking-list">
-      {rows.map((row) => (
-        <li key={`${row.external_driver_id || row.driver_code || row.driver_name}`}>
-          <div className="dashboard-ranking-main">
-            <strong>{row.driver_name || row.driver_code || 'Driver'}</strong>
-            <span className="muted small">{row.team_name || 'Team N/A'}</span>
-          </div>
-          <div className="dashboard-ranking-value">
-            <strong>{valueLabel(row)}</strong>
-          </div>
-        </li>
-      ))}
-    </ul>
   );
 }
 
@@ -191,6 +236,7 @@ export default function Dashboard() {
   const summary = data?.summary || {};
   const primaryEvent = data?.primaryEvent || null;
   const liveSession = data?.liveSession || null;
+  const payoutBoard = data?.payoutBoard || { rules: [] };
   const isAdmin = !!data?.viewer?.isAdmin;
 
   const highlightedStandings = useMemo(() => standings.map((row, index) => ({
@@ -199,10 +245,6 @@ export default function Dashboard() {
     net_cents: rowNet(row),
     isViewer: Number(row.id) === Number(data?.viewer?.id),
   })), [standings, data?.viewer?.id]);
-
-  const raceLeaders = liveSession?.leaders || [];
-  const ownedDrivers = liveSession?.ownedDrivers || [];
-  const championshipDrivers = liveSession?.championshipDrivers || [];
 
   if (loading && !data) {
     return <section className="loading-panel">Loading dashboard...</section>;
@@ -343,70 +385,21 @@ export default function Dashboard() {
         </section>
       </div>
 
-      <div className="dashboard-main-grid">
-        <section className="panel stack">
-          <div className="dashboard-card-head">
-            <div>
-              <h2>{isAdmin ? 'Race Leaders' : 'My Drivers Live'}</h2>
-              <p className="muted">
-                {isAdmin
-                  ? 'Top runners in the current scoring session.'
-                  : 'Your purchased drivers with live position, gains, and pit context.'}
-              </p>
-            </div>
-            {!isAdmin ? (
-              <Link className="btn btn-outline" to="/my-drivers">Open My Drivers</Link>
-            ) : null}
+      <section className="panel stack dashboard-payout-board">
+        <div className="dashboard-card-head">
+          <div>
+            <h2>Live Payout Board</h2>
+            <p className="muted">
+              Current holders for the active payout categories on this {primaryEvent ? eventTypeLabel(payoutBoard?.eventType || primaryEvent?.type) : 'scoring event'}.
+            </p>
           </div>
-
-          <DriverTrackerTable
-            rows={isAdmin ? raceLeaders : ownedDrivers}
-            emptyText={isAdmin ? 'No live leaders available right now.' : 'No owned drivers are currently showing live race data.'}
-          />
-        </section>
-
-        <section className="panel stack">
-          <div className="dashboard-card-head">
-            <div>
-              <h2>{isAdmin ? 'Championship Snapshot' : 'Race Context'}</h2>
-              <p className="muted">
-                {isAdmin
-                  ? 'Driver standings from the live session payload.'
-                  : 'Session leaders and championship context for the current weekend.'}
-              </p>
-            </div>
-          </div>
-
           {!isAdmin ? (
-            <>
-              <CompactRankingList
-                rows={raceLeaders}
-                emptyText="Leader board will populate when live data is available."
-                valueLabel={(row) => (row.position ? `P${row.position}` : '-')}
-              />
-              <CompactRankingList
-                rows={championshipDrivers}
-                emptyText="Championship positions are unavailable right now."
-                valueLabel={(row) => (
-                  row.championshipPosition
-                    ? `P${row.championshipPosition} • ${row.championshipPoints ?? 0} pts`
-                    : '-'
-                )}
-              />
-            </>
-          ) : (
-            <CompactRankingList
-              rows={championshipDrivers}
-              emptyText="Championship data is unavailable right now."
-              valueLabel={(row) => (
-                row.championshipPosition
-                  ? `P${row.championshipPosition} • ${row.championshipPoints ?? 0} pts`
-                  : '-'
-              )}
-            />
-          )}
-        </section>
-      </div>
+            <Link className="btn btn-outline" to="/my-drivers">Open My Drivers</Link>
+          ) : null}
+        </div>
+
+        <PayoutBoardTable rules={payoutBoard.rules} />
+      </section>
 
       <section className="panel">
         <div className="dashboard-card-head">

--- a/apps/f1/server/providers/openF1ResultsProvider.js
+++ b/apps/f1/server/providers/openF1ResultsProvider.js
@@ -623,12 +623,20 @@ class OpenF1ResultsProvider {
     });
 
     const latestPitByDriver = new Map();
+    const slowestPitByDriver = new Map();
     (pitStops || []).forEach((row) => {
       const driverNumber = Number(row.driver_number);
       if (!Number.isFinite(driverNumber)) return;
       const current = latestPitByDriver.get(driverNumber);
       const candidate = pickMostRecentRow([current, row].filter(Boolean), ['date', 'date_of_pit_in', 'date_of_pit_out']);
       latestPitByDriver.set(driverNumber, candidate);
+
+      const stopDuration = Number(row.stop_duration);
+      if (!Number.isFinite(stopDuration) || stopDuration <= 0) return;
+      const currentSlowest = slowestPitByDriver.get(driverNumber);
+      if (currentSlowest == null || stopDuration > currentSlowest) {
+        slowestPitByDriver.set(driverNumber, stopDuration);
+      }
     });
 
     const championshipByDriver = new Map();
@@ -659,6 +667,7 @@ class OpenF1ResultsProvider {
           intervalToAhead: intervalRow?.interval || intervalRow?.interval_to_position_ahead || null,
           status: positionRow?.status || intervalRow?.status || null,
           lastPitStopSeconds: Number(pitRow?.stop_duration) > 0 ? Number(pitRow.stop_duration) : null,
+          slowestPitStopSeconds: slowestPitByDriver.get(driverNumber) ?? null,
           lastPitAt: parseIsoDate(pitRow?.date || pitRow?.date_of_pit_out || pitRow?.date_of_pit_in),
           championshipPosition: Number(championshipRow?.position) || null,
           championshipPoints: Number(championshipRow?.points) || null,

--- a/apps/f1/server/services/dashboardService.js
+++ b/apps/f1/server/services/dashboardService.js
@@ -1,11 +1,15 @@
 const {
   getEvents,
+  getEventPayoutRules,
+  getDrivers,
+  getOwnership,
   getParticipantPortfolio,
   getSeasonParticipants,
   getStandings,
   getTotalPotCents,
 } = require('../db');
 const { dashboardBriefingService } = require('./dashboardBriefingService');
+const { evaluateCategoryRule } = require('./payoutRuleResolvers');
 
 const LIVE_CACHE_TTL_MS = 15_000;
 const ACTIVE_SESSION_GRACE_MS = 20 * 60 * 1000;
@@ -226,6 +230,226 @@ function buildPrimaryEvent(event, state, liveSession) {
   };
 }
 
+function normalizeNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function getRandomBonusPosition(event) {
+  const num = normalizeNumber(event?.random_bonus_position);
+  return num != null && num > 0 ? num : null;
+}
+
+function formatSignedValue(value) {
+  const num = normalizeNumber(value);
+  if (num == null) return null;
+  return `${num > 0 ? '+' : ''}${num}`;
+}
+
+function formatMetricDisplay(metricKey, value) {
+  const num = normalizeNumber(value);
+  if (num == null) return null;
+
+  switch (metricKey) {
+    case 'finish_position':
+    case 'best_finish_at_or_below':
+      return `P${num}`;
+    case 'positions_gained':
+      return formatSignedValue(num);
+    case 'slowest_pit_stop_seconds':
+      return `${num.toFixed(2)}s`;
+    default:
+      return String(value);
+  }
+}
+
+function buildLivePayoutRows({ liveSession, drivers }) {
+  const driversByExternalId = new Map(
+    (drivers || []).map((driver) => [Number(driver.external_id), driver]),
+  );
+
+  return (liveSession?.driverStates || [])
+    .map((state) => {
+      const externalDriverId = Number(state.external_driver_id);
+      if (!Number.isFinite(externalDriverId)) return null;
+
+      const seasonDriver = driversByExternalId.get(externalDriverId) || null;
+      return {
+        driver_id: seasonDriver?.id != null ? `driver:${seasonDriver.id}` : `external:${externalDriverId}`,
+        season_driver_id: seasonDriver?.id != null ? Number(seasonDriver.id) : null,
+        external_driver_id: externalDriverId,
+        driver_code: state.driver_code || seasonDriver?.code || null,
+        driver_name: state.driver_name || seasonDriver?.name || null,
+        team_name: state.team_name || seasonDriver?.team_name || null,
+        finish_position: normalizeNumber(state.position),
+        positions_gained: normalizeNumber(state.positionsGained),
+        slowest_pit_stop_seconds: normalizeNumber(state.slowestPitStopSeconds),
+      };
+    })
+    .filter((row) => row && row.finish_position != null);
+}
+
+function buildHolderDisplayValue({ category, row }) {
+  switch (category) {
+    case 'race_winner':
+    case 'sprint_winner':
+    case 'second_place':
+    case 'third_place':
+    case 'best_p6_or_lower':
+    case 'best_p11_or_lower':
+    case 'random_finish_bonus':
+      return row.finish_position != null ? `P${row.finish_position}` : null;
+    case 'most_positions_gained':
+      return formatSignedValue(row.positions_gained);
+    case 'slowest_pit_stop':
+      return formatMetricDisplay('slowest_pit_stop_seconds', row.slowest_pit_stop_seconds);
+    default:
+      return null;
+  }
+}
+
+function buildRuleMetric(evaluation) {
+  const metricKey = evaluation?.resolution?.metric || null;
+  const value = evaluation?.resolution?.target_value;
+  if (!metricKey || value == null) return null;
+
+  return {
+    key: metricKey,
+    value,
+    display: formatMetricDisplay(metricKey, value),
+  };
+}
+
+function buildRuleStatus({ selectionState, liveSession, category, event }) {
+  if (selectionState === 'upcoming') return 'pending';
+  if (selectionState !== 'live') return 'unavailable';
+  if (!liveSession?.available) return 'unavailable';
+  if (category === 'random_finish_bonus' && getRandomBonusPosition(event) == null) {
+    return 'draw_pending';
+  }
+  return 'live';
+}
+
+function buildRuleNote({ selectionState, liveSession, status, evaluation }) {
+  if (status === 'pending') {
+    return 'TBD until live timing data is available.';
+  }
+  if (status === 'draw_pending') {
+    return 'Random finish target has not been drawn yet.';
+  }
+  if (status === 'unavailable') {
+    if (selectionState === 'live') {
+      return liveSession?.degradedReason || 'Live data is unavailable right now.';
+    }
+    return 'No active live scoring session.';
+  }
+  if (!evaluation?.winnerDriverIds?.length) {
+    return 'No current holder yet.';
+  }
+  return evaluation?.resolution?.note || null;
+}
+
+function buildPayoutBoard({
+  event,
+  selectionState,
+  liveSession,
+  rules,
+  liveRows,
+  ownershipRows,
+  viewerId,
+}) {
+  if (!event) {
+    return {
+      eventType: null,
+      isLive: false,
+      rules: [],
+    };
+  }
+
+  const ownershipByDriverId = new Map(
+    (ownershipRows || []).map((row) => [
+      Number(row.driver_id),
+      {
+        participantId: Number(row.participant_id),
+        participantName: row.owner_name,
+        participantColor: row.owner_color,
+      },
+    ]),
+  );
+  const liveRowsByResolverId = new Map(
+    (liveRows || []).map((row) => [row.driver_id, row]),
+  );
+
+  return {
+    eventType: event.type,
+    isLive: selectionState === 'live' && !!liveSession?.available,
+    rules: (rules || []).map((rule) => {
+      const status = buildRuleStatus({
+        selectionState,
+        liveSession,
+        category: rule.category,
+        event,
+      });
+
+      if (status !== 'live') {
+        return {
+          category: rule.category,
+          label: rule.label,
+          bps: Number(rule.bps || 0),
+          status,
+          holders: [],
+          metric: status === 'draw_pending'
+            ? {
+                key: 'finish_position',
+                value: null,
+                display: 'Pending',
+              }
+            : null,
+          note: buildRuleNote({ selectionState, liveSession, status, evaluation: null }),
+        };
+      }
+
+      const evaluation = evaluateCategoryRule({
+        category: rule.category,
+        rows: liveRows,
+        event,
+        rankOrder: Number(rule.rank_order || 1),
+      });
+
+      const holders = (evaluation.winnerDriverIds || [])
+        .map((resolverId) => liveRowsByResolverId.get(resolverId))
+        .filter(Boolean)
+        .map((row) => {
+          const owner = row.season_driver_id != null
+            ? ownershipByDriverId.get(Number(row.season_driver_id)) || null
+            : null;
+
+          return {
+            driverId: row.season_driver_id,
+            driverCode: row.driver_code,
+            driverName: row.driver_name,
+            teamName: row.team_name,
+            participantId: owner?.participantId || null,
+            participantName: owner?.participantName || null,
+            participantColor: owner?.participantColor || null,
+            isViewerOwner: owner ? Number(owner.participantId) === Number(viewerId) : false,
+            displayValue: buildHolderDisplayValue({ category: rule.category, row }),
+          };
+        });
+
+      return {
+        category: rule.category,
+        label: rule.label,
+        bps: Number(rule.bps || 0),
+        status,
+        holders,
+        metric: buildRuleMetric(evaluation),
+        note: buildRuleNote({ selectionState, liveSession, status, evaluation }),
+      };
+    }),
+  };
+}
+
 function buildFallbackLiveState({ event, session, state, error }) {
   if (!event) {
     return {
@@ -282,6 +506,11 @@ async function buildDashboardPayload({
       });
 
   const selection = await selectPrimaryEvent({ events, provider, now });
+  const [drivers, ownershipRows, eventRules] = await Promise.all([
+    Promise.resolve(getDrivers(seasonId)),
+    Promise.resolve(getOwnership(seasonId)),
+    selection.event ? Promise.resolve(getEventPayoutRules(seasonId, selection.event.type)) : Promise.resolve([]),
+  ]);
 
   let liveSession = buildFallbackLiveState({
     event: selection.event,
@@ -324,6 +553,16 @@ async function buildDashboardPayload({
     };
   }
 
+  const payoutBoard = buildPayoutBoard({
+    event: selection.event,
+    selectionState: selection.state,
+    liveSession,
+    rules: eventRules,
+    liveRows: buildLivePayoutRows({ liveSession, drivers }),
+    ownershipRows,
+    viewerId: viewer.id,
+  });
+
   const summary = buildStandingsSummary({
     viewer: viewerShape,
     standings,
@@ -346,6 +585,7 @@ async function buildDashboardPayload({
     primaryEvent: buildPrimaryEvent(selection.event, selection.state, liveSession),
     liveSession,
     portfolio,
+    payoutBoard,
   };
 
   payload.briefingMeta = dashboardBriefingService.getMeta({ dashboardPayload: payload });

--- a/apps/f1/server/tests/dashboardService.test.js
+++ b/apps/f1/server/tests/dashboardService.test.js
@@ -178,6 +178,8 @@ test('GET /api/standings/dashboard returns participant summary, portfolio, and f
   assert.equal(payload.briefingMeta.mode, 'on_demand');
   assert.equal(payload.briefing.text, 'Persistent participant briefing.');
   assert.ok(payload.primaryEvent);
+  assert.ok(Array.isArray(payload.payoutBoard.rules));
+  assert.ok(payload.payoutBoard.rules.length > 0);
   assert.equal(Array.isArray(payload.standings), true);
 });
 
@@ -324,6 +326,265 @@ test('selectPrimaryEvent prefers live, then upcoming, then most recent', async (
   });
   assert.equal(recentSelection.event.id, 2);
   assert.equal(recentSelection.state, 'recent');
+});
+
+test('buildDashboardPayload resolves live grand prix payout board with ownership and draw pending state', async () => {
+  const { db, getActiveSeasonId, dashboardService } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const alphaId = createParticipant(db, seasonId, {
+    name: 'Alpha',
+    token: 'alpha-live-gp',
+    color: '#ff0000',
+  });
+  const bravoId = createParticipant(db, seasonId, {
+    name: 'Bravo',
+    token: 'bravo-live-gp',
+    color: '#00ff00',
+  });
+
+  const drivers = db.prepare(`
+    SELECT id, external_id, code, name, team_name
+    FROM drivers
+    WHERE season_id = ?
+    ORDER BY id ASC
+    LIMIT 5
+  `).all(seasonId);
+
+  db.prepare(`
+    UPDATE events
+    SET external_event_id = '9001'
+    WHERE season_id = ? AND round_number = 1 AND type = 'grand_prix'
+  `).run(seasonId);
+
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, drivers[0].id, alphaId, 2500);
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, drivers[3].id, bravoId, 1900);
+
+  const payload = await dashboardService.buildDashboardPayload({
+    seasonId,
+    viewer: {
+      id: alphaId,
+      name: 'Alpha',
+      color: '#ff0000',
+      is_admin: 0,
+    },
+    nowImpl: () => Date.parse('2026-03-08T05:00:00Z'),
+    provider: {
+      name: 'openf1',
+      async fetchSessionMetadata() {
+        return {
+          date_start: '2026-03-08T04:00:00Z',
+          date_end: '2026-03-08T06:00:00Z',
+        };
+      },
+      async fetchLiveSessionSnapshot() {
+        return {
+          available: true,
+          isLive: true,
+          fetchedAt: '2026-03-08T05:00:05Z',
+          headline: 'Live snapshot',
+          statusText: 'Race live',
+          trackStatus: null,
+          driverStates: [
+            { external_driver_id: drivers[0].external_id, driver_code: drivers[0].code, driver_name: drivers[0].name, team_name: drivers[0].team_name, position: 1, positionsGained: 0, slowestPitStopSeconds: null },
+            { external_driver_id: drivers[1].external_id, driver_code: drivers[1].code, driver_name: drivers[1].name, team_name: drivers[1].team_name, position: 2, positionsGained: -1, slowestPitStopSeconds: null },
+            { external_driver_id: drivers[2].external_id, driver_code: drivers[2].code, driver_name: drivers[2].name, team_name: drivers[2].team_name, position: 3, positionsGained: 1, slowestPitStopSeconds: null },
+            { external_driver_id: drivers[3].external_id, driver_code: drivers[3].code, driver_name: drivers[3].name, team_name: drivers[3].team_name, position: 6, positionsGained: 3, slowestPitStopSeconds: 5.12 },
+            { external_driver_id: drivers[4].external_id, driver_code: drivers[4].code, driver_name: drivers[4].name, team_name: drivers[4].team_name, position: 11, positionsGained: 4, slowestPitStopSeconds: 3.21 },
+          ],
+          leaders: [],
+          championshipDrivers: [],
+          ownedDrivers: [],
+        };
+      },
+    },
+  });
+
+  assert.equal(payload.payoutBoard.eventType, 'grand_prix');
+  assert.equal(payload.payoutBoard.isLive, true);
+  assert.deepEqual(
+    payload.payoutBoard.rules.map((rule) => rule.category),
+    [
+      'race_winner',
+      'second_place',
+      'third_place',
+      'best_p6_or_lower',
+      'best_p11_or_lower',
+      'most_positions_gained',
+      'slowest_pit_stop',
+      'random_finish_bonus',
+    ],
+  );
+
+  const raceWinner = payload.payoutBoard.rules.find((rule) => rule.category === 'race_winner');
+  assert.equal(raceWinner.status, 'live');
+  assert.equal(raceWinner.holders[0].driverId, drivers[0].id);
+  assert.equal(raceWinner.holders[0].participantName, 'Alpha');
+  assert.equal(raceWinner.holders[0].isViewerOwner, true);
+  assert.equal(raceWinner.holders[0].displayValue, 'P1');
+
+  const bestP6 = payload.payoutBoard.rules.find((rule) => rule.category === 'best_p6_or_lower');
+  assert.equal(bestP6.holders[0].driverId, drivers[3].id);
+  assert.equal(bestP6.holders[0].participantName, 'Bravo');
+  assert.equal(bestP6.metric.display, 'P6');
+
+  const bestP11 = payload.payoutBoard.rules.find((rule) => rule.category === 'best_p11_or_lower');
+  assert.equal(bestP11.holders[0].driverId, drivers[4].id);
+  assert.equal(bestP11.holders[0].participantName, null);
+
+  const mostGained = payload.payoutBoard.rules.find((rule) => rule.category === 'most_positions_gained');
+  assert.equal(mostGained.holders[0].driverId, drivers[4].id);
+  assert.equal(mostGained.holders[0].displayValue, '+4');
+  assert.equal(mostGained.metric.display, '+4');
+
+  const slowestPit = payload.payoutBoard.rules.find((rule) => rule.category === 'slowest_pit_stop');
+  assert.equal(slowestPit.holders[0].driverId, drivers[3].id);
+  assert.equal(slowestPit.holders[0].displayValue, '5.12s');
+  assert.equal(slowestPit.metric.display, '5.12s');
+
+  const randomBonus = payload.payoutBoard.rules.find((rule) => rule.category === 'random_finish_bonus');
+  assert.equal(randomBonus.status, 'draw_pending');
+  assert.equal(randomBonus.holders.length, 0);
+});
+
+test('buildDashboardPayload limits sprint payout board to sprint-active categories', async () => {
+  const { db, getActiveSeasonId, dashboardService } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const viewerId = createParticipant(db, seasonId, {
+    name: 'Sprint Viewer',
+    token: 'sprint-viewer',
+    color: '#112233',
+  });
+
+  const drivers = db.prepare(`
+    SELECT id, external_id, code, name, team_name
+    FROM drivers
+    WHERE season_id = ?
+    ORDER BY id ASC
+    LIMIT 3
+  `).all(seasonId);
+
+  db.prepare(`
+    UPDATE events
+    SET external_event_id = '9002'
+    WHERE season_id = ? AND round_number = 2 AND type = 'sprint'
+  `).run(seasonId);
+
+  const payload = await dashboardService.buildDashboardPayload({
+    seasonId,
+    viewer: {
+      id: viewerId,
+      name: 'Sprint Viewer',
+      color: '#112233',
+      is_admin: 0,
+    },
+    nowImpl: () => Date.parse('2026-03-14T03:15:00Z'),
+    provider: {
+      name: 'openf1',
+      async fetchSessionMetadata() {
+        return {
+          date_start: '2026-03-14T03:00:00Z',
+          date_end: '2026-03-14T04:00:00Z',
+        };
+      },
+      async fetchLiveSessionSnapshot() {
+        return {
+          available: true,
+          isLive: true,
+          fetchedAt: '2026-03-14T03:15:00Z',
+          statusText: 'Sprint live',
+          driverStates: [
+            { external_driver_id: drivers[0].external_id, driver_code: drivers[0].code, driver_name: drivers[0].name, team_name: drivers[0].team_name, position: 1, positionsGained: 0, slowestPitStopSeconds: null },
+            { external_driver_id: drivers[1].external_id, driver_code: drivers[1].code, driver_name: drivers[1].name, team_name: drivers[1].team_name, position: 6, positionsGained: 2, slowestPitStopSeconds: null },
+            { external_driver_id: drivers[2].external_id, driver_code: drivers[2].code, driver_name: drivers[2].name, team_name: drivers[2].team_name, position: 8, positionsGained: 4, slowestPitStopSeconds: null },
+          ],
+          leaders: [],
+          championshipDrivers: [],
+          ownedDrivers: [],
+        };
+      },
+    },
+  });
+
+  assert.equal(payload.payoutBoard.eventType, 'sprint');
+  assert.deepEqual(
+    payload.payoutBoard.rules.map((rule) => rule.category),
+    ['sprint_winner', 'best_p6_or_lower', 'most_positions_gained', 'random_finish_bonus'],
+  );
+});
+
+test('buildDashboardPayload returns pending payout board for upcoming events', async () => {
+  const { db, getActiveSeasonId, dashboardService } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const viewerId = createParticipant(db, seasonId, {
+    name: 'Pending Viewer',
+    token: 'pending-viewer',
+    color: '#334455',
+  });
+
+  const payload = await dashboardService.buildDashboardPayload({
+    seasonId,
+    viewer: {
+      id: viewerId,
+      name: 'Pending Viewer',
+      color: '#334455',
+      is_admin: 0,
+    },
+    nowImpl: () => Date.parse('2026-03-07T12:00:00Z'),
+    provider: { name: 'mock' },
+  });
+
+  assert.ok(payload.payoutBoard.rules.length > 0);
+  assert.ok(payload.payoutBoard.rules.every((rule) => rule.status === 'pending'));
+  assert.ok(payload.payoutBoard.rules.every((rule) => rule.note === 'TBD until live timing data is available.'));
+});
+
+test('buildDashboardPayload marks payout board unavailable when live session load fails', async () => {
+  const { db, getActiveSeasonId, dashboardService } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const viewerId = createParticipant(db, seasonId, {
+    name: 'Fallback Viewer',
+    token: 'fallback-viewer',
+    color: '#556677',
+  });
+
+  db.prepare(`
+    UPDATE events
+    SET external_event_id = '9001'
+    WHERE season_id = ? AND round_number = 1 AND type = 'grand_prix'
+  `).run(seasonId);
+
+  const payload = await dashboardService.buildDashboardPayload({
+    seasonId,
+    viewer: {
+      id: viewerId,
+      name: 'Fallback Viewer',
+      color: '#556677',
+      is_admin: 0,
+    },
+    nowImpl: () => Date.parse('2026-03-08T05:00:00Z'),
+    provider: {
+      name: 'openf1',
+      async fetchSessionMetadata() {
+        return {
+          date_start: '2026-03-08T04:00:00Z',
+          date_end: '2026-03-08T06:00:00Z',
+        };
+      },
+      async fetchLiveSessionSnapshot() {
+        throw new Error('OpenF1 temporarily unavailable.');
+      },
+    },
+  });
+
+  assert.ok(payload.payoutBoard.rules.length > 0);
+  assert.ok(payload.payoutBoard.rules.every((rule) => rule.status === 'unavailable'));
+  assert.match(payload.payoutBoard.rules[0].note, /temporarily unavailable/i);
 });
 
 test('dashboard briefing service caches and refreshes on force', async () => {

--- a/apps/f1/server/tests/openF1ResultsProvider.test.js
+++ b/apps/f1/server/tests/openF1ResultsProvider.test.js
@@ -416,6 +416,7 @@ test('OpenF1ResultsProvider fetchLiveSessionSnapshot normalizes live race data',
       { driver_number: 81, interval: 'LEADER', gap_to_leader: 'LEADER', date: '2026-02-22T04:20:01Z' },
     ],
     '/v1/pit?session_key=9001': [
+      { driver_number: 1, stop_duration: 5.41, date_of_pit_out: '2026-02-22T04:08:00Z' },
       { driver_number: 1, stop_duration: 2.98, date_of_pit_out: '2026-02-22T04:10:00Z' },
     ],
     '/v1/race_control?session_key=9001': [
@@ -451,6 +452,7 @@ test('OpenF1ResultsProvider fetchLiveSessionSnapshot normalizes live race data',
   assert.equal(snapshot.leaders[1].positionsGained, 2);
   assert.equal(snapshot.trackStatus.flag, 'SC');
   assert.equal(snapshot.driverStates[1].lastPitStopSeconds, 2.98);
+  assert.equal(snapshot.driverStates[1].slowestPitStopSeconds, 5.41);
   assert.equal(snapshot.championshipDrivers[0].championshipPosition, 1);
 });
 


### PR DESCRIPTION
Summary
- replace the lower dashboard leader/championship cards with a single live payout board driven by the active event payout rules
- compute current payout holders from live OpenF1 timing plus season ownership so each row shows the current driver, benefiting participant, and viewer-owned state
- update live pit normalization so slowest-pit payout logic uses each driver’s max pit duration seen so far, then add dashboard/provider coverage for live, pending, and degraded states

Testing
- npm run test:f1
- npm run build:f1