### PR TITLE
Replace race context with live payout board and harden post-auction login

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -33,6 +33,7 @@ Owner: On-call engineer / active implementer
 - F1 participant navigation now centers on `/dashboard`, which combines personal standings, full league standings, and current-or-next scoring-session race context.
 - F1 dashboard now supports brief live OpenF1 session snapshots with short-lived caching and an optional on-demand Anthropic participant briefing.
 - The latest F1 dashboard briefing is now persisted per participant so it survives polling refreshes, logout/login, and process restarts.
+- F1 post-auction participant login is now locked to the existing season roster; unmatched invite-code joins fail closed and admin can issue/reset direct participant access links from the Auction page.
 - F1 startup seeding now preserves provider-refreshed schedule rows across restart/deploy cycles instead of silently reverting them to mock seed dates.
 
 ## Active Priorities

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -46,6 +46,7 @@ Operational guide for deploying, validating, and recovering NCAA/F1 services.
 4. Do not set `F1_PORT` in Railway.
 5. Keep `F1_AUTO_POLL_ENABLED=0` until one successful manual OpenF1 verification pass is complete.
 6. The `/dashboard` participant experience uses live OpenF1 session reads when the active provider is `openf1`; otherwise it falls back to schedule-only race cards.
+7. After the auction is complete, participant join no longer creates new users; rostered participants must log in with their exact auction name or use an admin-issued access link.
 
 ## Deploy Validation
 
@@ -94,7 +95,15 @@ After deploy:
 6. If provider responses are incomplete or unmapped, use manual results entry and do not force-score partial provider data.
 7. Schedule refresh is now durable across restart/deploy cycles; if dates drift again, inspect the stored event rows and provider sync state instead of assuming startup reseeding will correct them.
 
-### E) F1 Backup / Export
+### E) F1 Participant Login / Access Recovery
+
+1. After the auction is complete, the join form only attaches to an existing participant already in the active season roster.
+2. If a participant cannot log in because their typed name does not match exactly, do not tell them to retry variants repeatedly.
+3. Open `Admin -> Auction`.
+4. In `Joined Participants`, use `Create Access Link` or `Reset Access Link`.
+5. Share the copied link with that participant; opening it signs them into the active season directly.
+
+### F) F1 Backup / Export
 
 1. Open `Admin -> Results Sync`.
 2. Use `Download DB Backup`.
@@ -103,7 +112,7 @@ After deploy:
    - before the first real race sync
    - before any destructive test-data reset
 
-### F) F1 Payout Audit Export
+### G) F1 Payout Audit Export
 
 1. Open `Admin -> Payout Audit`.
 2. Select the event in question.
@@ -113,7 +122,7 @@ After deploy:
    - `Copy Summary` for a concise plain-text explanation
 4. Use these outputs when reviewing disputed race payouts with participants.
 
-### G) F1 Auction Results Export
+### H) F1 Auction Results Export
 
 1. Open `Admin -> Auction`.
 2. Use `Download Auction Results CSV`.

--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -72,6 +72,7 @@ Server: `http://localhost:3002`
 - Admin Payout Audit page can export both rule-level and winner-detail CSVs, plus a concise text summary for payout review
 - Admin Auction page exposes a shareable invite link that deep-links to `/join` with the active invite code prefilled
 - Admin Auction page can export auction ownership results as CSV for post-auction sharing and record-keeping
+- Once the auction is complete, participant login is locked to existing rostered names only; unmatched join attempts fail closed and admin can issue/reset direct access links per participant from the Auction page
 
 ## Engineering Docs
 

--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -456,6 +456,15 @@ button {
   line-height: 1.45;
 }
 
+.join-policy-note {
+  margin: 0;
+  padding: 0.65rem 0.7rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(7, 11, 18, 0.6);
+  line-height: 1.45;
+}
+
 .join-auth-panel .error-text {
   margin-top: 0.7rem;
 }
@@ -2106,6 +2115,10 @@ tbody tr:hover {
 
 .admin-participant-identity strong {
   display: block;
+}
+
+.admin-participant-identity .error-text {
+  margin: 0;
 }
 
 .admin-participant-swatch {

--- a/apps/f1/client/src/pages/Join.jsx
+++ b/apps/f1/client/src/pages/Join.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { api, readJsonSafely } from '../utils';
 
 const AUSTRALIAN_GP_START_ISO = '2026-02-22T04:00:00Z';
 
@@ -26,6 +27,7 @@ export default function Join() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [nowMs, setNowMs] = useState(Date.now());
+  const [joinPolicy, setJoinPolicy] = useState(null);
 
   useEffect(() => {
     const id = setInterval(() => setNowMs(Date.now()), 30000);
@@ -35,15 +37,43 @@ export default function Join() {
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const linkInviteCode = params.get('invite');
+    const authError = params.get('error');
+    if (authError === 'invalid-access') {
+      setError('That access link is invalid or expired. Contact the admin for a fresh access link.');
+    }
     if (!linkInviteCode) return;
     setInviteCode(linkInviteCode.trim().toUpperCase());
     setMode('join');
   }, [location.search]);
 
+  useEffect(() => {
+    let active = true;
+
+    api('/auth/join-policy')
+      .then(async (response) => {
+        const payload = await readJsonSafely(response);
+        if (!response.ok) {
+          throw new Error(payload?.error || 'Failed to load join policy.');
+        }
+        return payload;
+      })
+      .then((payload) => {
+        if (active) setJoinPolicy(payload);
+      })
+      .catch(() => {
+        if (active) setJoinPolicy(null);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
   const countdownText = useMemo(() => {
     const targetMs = Date.parse(AUSTRALIAN_GP_START_ISO);
     return formatCountdown(targetMs, nowMs);
   }, [nowMs]);
+  const isCreationLocked = !!joinPolicy?.creationLocked;
 
   const handleJoin = async (event) => {
     event.preventDefault();
@@ -136,9 +166,11 @@ export default function Join() {
 
           {mode === 'join' ? (
             <form onSubmit={handleJoin} className="stack">
-              <h2>Join Pool</h2>
+              <h2>{isCreationLocked ? 'Participant Login' : 'Join Pool'}</h2>
               <p className="muted small join-mode-copy">
-                Enter your invite code to start bidding for drivers.
+                {isCreationLocked
+                  ? 'Use the exact auction name plus the invite code. New participant creation is disabled after the auction.'
+                  : 'Enter your invite code to join the pool before auction lock.'}
               </p>
               <label>
                 Name
@@ -158,7 +190,12 @@ export default function Join() {
                   autoComplete="one-time-code"
                 />
               </label>
-              <button className="btn" disabled={loading}>{loading ? 'Joining...' : 'Join Pool'}</button>
+              <p className="small muted join-policy-note">
+                {isCreationLocked
+                  ? 'If your exact roster name does not work, contact the admin instead of trying alternate spellings.'
+                  : 'If your name is not already in the roster, the app can create it before the auction is complete.'}
+              </p>
+              <button className="btn" disabled={loading}>{loading ? 'Joining...' : (isCreationLocked ? 'Sign In' : 'Join Pool')}</button>
             </form>
           ) : (
             <form onSubmit={handleAdmin} className="stack">

--- a/apps/f1/client/src/pages/admin/AuctionPage.jsx
+++ b/apps/f1/client/src/pages/admin/AuctionPage.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import ParticipantAvatar from '../../components/ParticipantAvatar';
 import { useSocketEvent } from '../../context/SocketContext';
 import AdminLoadingState from './AdminLoadingState';
-import { auctionResultsExportHref, buildInviteLink } from './adminApi';
+import { auctionResultsExportHref, buildInviteLink, buildParticipantAccessLink } from './adminApi';
 import useAdminOutletContext from './useAdminOutletContext';
 
 export default function AuctionPage() {
@@ -13,6 +13,7 @@ export default function AuctionPage() {
     saveSettings,
     saveSettingsPatch,
     runAuctionAction,
+    resetParticipantAccess,
     refresh,
     setMessage,
     loading,
@@ -25,7 +26,10 @@ export default function AuctionPage() {
   const isRosterLocked = String(settings?.auction_roster_locked) === '1'
     || settings?.auction_roster_locked === 1
     || settings?.auction_roster_locked === true;
+  const isLoginLocked = String(settings?.auction_status || '').toLowerCase() === 'complete';
   const joinedParticipants = (participants || []).filter((participant) => !participant.is_admin);
+  const duplicateParticipants = joinedParticipants.filter((participant) => Number(participant.duplicate_name_count || 0) > 1);
+  const noAccessParticipants = joinedParticipants.filter((participant) => !participant.has_session_token);
   const inviteLink = useMemo(
     () => buildInviteLink(settings?.invite_code),
     [settings?.invite_code],
@@ -72,6 +76,21 @@ export default function AuctionPage() {
     }
   }, [inviteLink, setMessage]);
 
+  const handleResetAccess = useCallback(async (participant) => {
+    try {
+      const result = await resetParticipantAccess(participant.id);
+      const accessLink = buildParticipantAccessLink(result?.accessPath);
+      if (accessLink && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(accessLink);
+        setMessage(`Access link copied for ${participant.name}.`);
+      } else {
+        setMessage(result?.message || `Access reset for ${participant.name}.`);
+      }
+    } catch (error) {
+      setMessage(error.message || `Failed to reset access for ${participant.name}.`);
+    }
+  }, [resetParticipantAccess, setMessage]);
+
   useSocketEvent('participants:update', handleParticipantsUpdate);
 
   if (loading && !hasLoaded) {
@@ -84,7 +103,11 @@ export default function AuctionPage() {
         <div className="row wrap gap-sm participants-panel-header">
           <div>
             <h2>Invite Participants</h2>
-            <p className="muted">Share the pool link or send the invite code directly.</p>
+            <p className="muted">
+              {isLoginLocked
+                ? 'Invite code still works for known participants, but new participant creation is now disabled.'
+                : 'Share the pool link or send the invite code directly.'}
+            </p>
           </div>
         </div>
         <div className="invite-share-panel stack">
@@ -196,6 +219,21 @@ export default function AuctionPage() {
           </div>
           <span className="meta-pill">{joinedParticipants.length} joined</span>
         </div>
+        <div className={`note-panel ${isLoginLocked ? 'note-panel-warning' : ''}`}>
+          <strong>Login Locked To Existing Participants</strong>
+          <div className="muted small">
+            {isLoginLocked
+              ? 'The auction is complete. Join now requires an exact roster name match and will not create a new participant.'
+              : 'Before the auction is complete, the join screen can still create a new participant from a valid invite code and name.'}
+          </div>
+          <div className="muted small">
+            {noAccessParticipants.length} participant{noAccessParticipants.length === 1 ? '' : 's'} without access issued yet.
+            {' '}
+            {duplicateParticipants.length
+              ? `${duplicateParticipants.length} duplicate-name warning${duplicateParticipants.length === 1 ? '' : 's'} need cleanup.`
+              : 'No duplicate names detected.'}
+          </div>
+        </div>
         {joinedParticipants.length ? (
           <div className="admin-participant-list">
             {joinedParticipants.map((participant) => (
@@ -204,14 +242,28 @@ export default function AuctionPage() {
                   <ParticipantAvatar name={participant.name} color={participant.color} size={28} />
                   <div className="stack-xs">
                     <strong>{participant.name}</strong>
-                    <span className="muted">Ready for auction</span>
+                    <span className="muted">
+                      {participant.has_session_token ? 'Access issued' : 'No access issued yet'}
+                    </span>
+                    {Number(participant.duplicate_name_count || 0) > 1 ? (
+                      <span className="error-text small">Duplicate name match risk in roster</span>
+                    ) : null}
                   </div>
                 </div>
-                <span
-                  className="admin-participant-swatch"
-                  style={{ backgroundColor: participant.color }}
-                  aria-hidden="true"
-                />
+                <div className="row wrap gap-sm">
+                  <button
+                    className="btn btn-outline"
+                    type="button"
+                    onClick={() => handleResetAccess(participant)}
+                  >
+                    {participant.has_session_token ? 'Reset Access Link' : 'Create Access Link'}
+                  </button>
+                  <span
+                    className="admin-participant-swatch"
+                    style={{ backgroundColor: participant.color }}
+                    aria-hidden="true"
+                  />
+                </div>
               </div>
             ))}
           </div>

--- a/apps/f1/client/src/pages/admin/adminApi.js
+++ b/apps/f1/client/src/pages/admin/adminApi.js
@@ -77,6 +77,13 @@ export function buildInviteLink(inviteCode, origin = window.location.origin) {
   return `${base}/join?invite=${encodeURIComponent(cleanCode)}`;
 }
 
+export function buildParticipantAccessLink(accessPath, origin = window.location.origin) {
+  const cleanPath = String(accessPath || '').trim();
+  if (!cleanPath) return '';
+  const base = String(origin || '').replace(/\/+$/, '');
+  return `${base}${cleanPath.startsWith('/') ? cleanPath : `/${cleanPath}`}`;
+}
+
 export function payoutAuditExportHref(eventId) {
   return `/api/admin/payout-audit/${eventId}/export.csv`;
 }
@@ -99,6 +106,14 @@ export async function refreshSchedule() {
     body: '{}',
   });
   return parseApiResponse(response, 'Schedule refresh failed');
+}
+
+export async function resetParticipantAccess(participantId) {
+  const response = await api(`/admin/participants/${participantId}/reset-access`, {
+    method: 'POST',
+    body: '{}',
+  });
+  return parseApiResponse(response, 'Failed to reset participant access');
 }
 
 export async function clearAllTestData() {

--- a/apps/f1/client/src/pages/admin/useAdminData.js
+++ b/apps/f1/client/src/pages/admin/useAdminData.js
@@ -13,6 +13,7 @@ import {
   rescoreSeasonEvents as rescoreSeasonEventsApi,
   refreshDrivers as refreshDriversApi,
   refreshSchedule as refreshScheduleApi,
+  resetParticipantAccess as resetParticipantAccessApi,
   runAuctionAction as runAuctionActionApi,
   savePayoutRules,
   syncEvent as syncEventApi,
@@ -132,6 +133,17 @@ export default function useAdminData() {
     }
   }, [loadAll]);
 
+  const resetParticipantAccess = useCallback(async (participantId) => {
+    try {
+      const result = await resetParticipantAccessApi(participantId);
+      await loadAll({ silent: true });
+      return result;
+    } catch (error) {
+      setMessage(error.message || 'Failed to reset participant access.');
+      throw error;
+    }
+  }, [loadAll]);
+
   const recalcSeasonBonuses = useCallback(async () => {
     try {
       await recalcSeasonBonusesApi();
@@ -230,6 +242,7 @@ export default function useAdminData() {
     runAuctionAction,
     refreshDrivers,
     refreshSchedule,
+    resetParticipantAccess,
     clearAllTestData,
     resetAuctionOnly,
     loadHistoricalSeasonData,
@@ -256,6 +269,7 @@ export default function useAdminData() {
     runAuctionAction,
     refreshDrivers,
     refreshSchedule,
+    resetParticipantAccess,
     clearAllTestData,
     resetAuctionOnly,
     loadHistoricalSeasonData,

--- a/apps/f1/server/persistence/repositories/seasonRepo.js
+++ b/apps/f1/server/persistence/repositories/seasonRepo.js
@@ -19,7 +19,11 @@ function getParticipantByToken(db, token) {
 
 function getSeasonParticipants(db, seasonId) {
   return db.prepare(`
-    SELECT p.id, p.name, p.color, p.is_admin
+    SELECT p.id, p.name, p.color, p.is_admin,
+           CASE
+             WHEN p.session_token IS NOT NULL AND TRIM(p.session_token) <> '' THEN 1
+             ELSE 0
+           END as has_session_token
     FROM participants p
     JOIN season_participants sp ON sp.participant_id = p.id
     WHERE sp.season_id = ?

--- a/apps/f1/server/routes/admin.js
+++ b/apps/f1/server/routes/admin.js
@@ -68,6 +68,13 @@ router.delete('/participants/:id', withAdmin, (req, res) => {
   return runAndRespond(res, auctionAdminService.removeParticipant({ seasonId, participantId }));
 });
 
+router.post('/participants/:id/reset-access', withAdmin, (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const participantId = parseIdFromParams(res, req.params.id);
+  if (participantId == null) return undefined;
+  return runAndRespond(res, auctionAdminService.resetParticipantAccess({ seasonId, participantId }));
+});
+
 router.get('/auction/queue', withAdmin, (req, res) => {
   const seasonId = getActiveSeasonId();
   return res.json(auctionAdminService.listAuctionQueue({ seasonId }));

--- a/apps/f1/server/routes/auth.js
+++ b/apps/f1/server/routes/auth.js
@@ -8,6 +8,7 @@ const {
   getActiveSeasonId,
   getActiveSeason,
   getParticipantByToken,
+  getResolvedAuctionStatus,
 } = require('../db');
 
 const router = express.Router();
@@ -20,6 +21,61 @@ const COLORS = [
 
 function emitParticipantsUpdate(req, seasonId) {
   req.app.get('io')?.emit('participants:update', { seasonId });
+}
+
+function cookieOptions() {
+  return { httpOnly: true, maxAge: 30 * 24 * 60 * 60 * 1000 };
+}
+
+function getJoinPolicy(seasonId) {
+  const auctionStatus = getResolvedAuctionStatus(seasonId);
+  return {
+    auctionStatus,
+    creationLocked: auctionStatus === 'complete',
+  };
+}
+
+function findSeasonParticipantsByName(seasonId, cleanName) {
+  return db.prepare(`
+    SELECT p.*
+    FROM participants p
+    JOIN season_participants sp ON sp.participant_id = p.id
+    WHERE sp.season_id = ?
+      AND p.is_admin = 0
+      AND LOWER(p.name) = LOWER(?)
+  `).all(seasonId, cleanName);
+}
+
+function findParticipantsByName(cleanName) {
+  return db.prepare(`
+    SELECT *
+    FROM participants
+    WHERE is_admin = 0
+      AND LOWER(name) = LOWER(?)
+  `).all(cleanName);
+}
+
+function ensureParticipantToken(participant) {
+  if (participant.session_token) return participant.session_token;
+  const token = uuidv4();
+  db.prepare('UPDATE participants SET session_token = ? WHERE id = ?').run(token, participant.id);
+  return token;
+}
+
+function sendParticipantSession(res, participant, token) {
+  res.cookie('session', token, cookieOptions());
+  return res.json({
+    participant: {
+      id: participant.id,
+      name: participant.name,
+      color: participant.color,
+      isAdmin: !!participant.is_admin,
+    },
+  });
+}
+
+function logRejectedJoinAttempt({ seasonId, cleanName, reason }) {
+  console.warn(`[auth.join] rejected season=${seasonId} name="${cleanName}" reason=${reason}`);
 }
 
 router.get('/me', (req, res) => {
@@ -50,6 +106,12 @@ router.get('/me', (req, res) => {
   });
 });
 
+router.get('/join-policy', (req, res) => {
+  const season = getActiveSeason();
+  if (!season) return res.status(500).json({ error: 'No active season found' });
+  return res.json(getJoinPolicy(season.id));
+});
+
 router.post('/join', (req, res) => {
   const { name, inviteCode } = req.body;
   if (!name || !inviteCode) return res.status(400).json({ error: 'Name and invite code required' });
@@ -64,29 +126,44 @@ router.post('/join', (req, res) => {
   const cleanName = sanitizeParticipantName(name);
   if (!cleanName) return res.status(400).json({ error: 'Name cannot be empty' });
 
-  const existing = db.prepare('SELECT * FROM participants WHERE LOWER(name) = LOWER(?)').get(cleanName);
-  if (existing) {
-    const token = existing.session_token || uuidv4();
-    if (!existing.session_token) {
-      db.prepare('UPDATE participants SET session_token = ? WHERE id = ?').run(token, existing.id);
-    }
+  const joinPolicy = getJoinPolicy(season.id);
+  const seasonMatches = findSeasonParticipantsByName(season.id, cleanName);
+  if (seasonMatches.length > 1) {
+    logRejectedJoinAttempt({ seasonId: season.id, cleanName, reason: 'ambiguous-season-match' });
+    return res.status(409).json({
+      error: 'Multiple participants share that name in this season roster. Contact the admin.',
+    });
+  }
+  if (seasonMatches.length === 1) {
+    const existing = seasonMatches[0];
+    const token = ensureParticipantToken(existing);
+    emitParticipantsUpdate(req, season.id);
+    return sendParticipantSession(res, existing, token);
+  }
 
+  if (joinPolicy.creationLocked) {
+    logRejectedJoinAttempt({ seasonId: season.id, cleanName, reason: 'creation-locked-no-match' });
+    return res.status(403).json({
+      error: 'No participant found for that name in this season roster. Contact the admin.',
+    });
+  }
+
+  const globalMatches = findParticipantsByName(cleanName);
+  if (globalMatches.length > 1) {
+    logRejectedJoinAttempt({ seasonId: season.id, cleanName, reason: 'ambiguous-global-match' });
+    return res.status(409).json({
+      error: 'Multiple participants share that name. Contact the admin before joining.',
+    });
+  }
+  if (globalMatches.length === 1) {
+    const existing = globalMatches[0];
+    const token = ensureParticipantToken(existing);
     db.prepare(`
       INSERT OR IGNORE INTO season_participants (season_id, participant_id)
       VALUES (?, ?)
     `).run(season.id, existing.id);
-
     emitParticipantsUpdate(req, season.id);
-
-    res.cookie('session', token, { httpOnly: true, maxAge: 30 * 24 * 60 * 60 * 1000 });
-    return res.json({
-      participant: {
-        id: existing.id,
-        name: existing.name,
-        color: existing.color,
-        isAdmin: !!existing.is_admin,
-      },
-    });
+    return sendParticipantSession(res, existing, token);
   }
 
   const usedColors = db.prepare('SELECT color FROM participants').all().map((row) => row.color);
@@ -105,15 +182,34 @@ router.post('/join', (req, res) => {
 
   emitParticipantsUpdate(req, season.id);
 
-  res.cookie('session', token, { httpOnly: true, maxAge: 30 * 24 * 60 * 60 * 1000 });
-  return res.json({
-    participant: {
-      id: participantId,
-      name: cleanName,
-      color,
-      isAdmin: false,
-    },
-  });
+  return sendParticipantSession(res, {
+    id: participantId,
+    name: cleanName,
+    color,
+    is_admin: 0,
+  }, token);
+});
+
+router.get('/access/:token', (req, res) => {
+  const token = String(req.params.token || '').trim();
+  if (!token) return res.redirect('/join?error=invalid-access');
+
+  const participant = getParticipantByToken(token);
+  if (!participant) return res.redirect('/join?error=invalid-access');
+
+  const seasonId = getActiveSeasonId();
+  const inSeason = db.prepare(`
+    SELECT 1
+    FROM season_participants
+    WHERE season_id = ? AND participant_id = ?
+  `).get(seasonId, participant.id);
+
+  if (!participant.is_admin && !inSeason) {
+    return res.redirect('/join?error=invalid-access');
+  }
+
+  res.cookie('session', token, cookieOptions());
+  return res.redirect(participant.is_admin ? '/admin' : '/dashboard');
 });
 
 router.post('/admin', (req, res) => {
@@ -140,7 +236,7 @@ router.post('/admin', (req, res) => {
     VALUES (?, ?)
   `).run(getActiveSeasonId(), admin.id);
 
-  res.cookie('session', admin.session_token, { httpOnly: true, maxAge: 30 * 24 * 60 * 60 * 1000 });
+  res.cookie('session', admin.session_token, cookieOptions());
   return res.json({
     participant: {
       id: admin.id,

--- a/apps/f1/server/services/admin/auctionAdminService.js
+++ b/apps/f1/server/services/admin/auctionAdminService.js
@@ -1,3 +1,4 @@
+const { v4: uuidv4 } = require('uuid');
 const { generateInviteCode } = require('../../lib/core');
 const {
   db,
@@ -40,7 +41,23 @@ function regenerateInviteCode({ seasonId }) {
 }
 
 function listParticipants({ seasonId }) {
-  return getSeasonParticipants(seasonId);
+  const participants = getSeasonParticipants(seasonId);
+  const duplicateCounts = participants
+    .filter((participant) => !participant.is_admin)
+    .reduce((acc, participant) => {
+      const normalized = String(participant.name || '').trim().toLowerCase();
+      acc.set(normalized, (acc.get(normalized) || 0) + 1);
+      return acc;
+    }, new Map());
+
+  return participants.map((participant) => {
+    const normalized = String(participant.name || '').trim().toLowerCase();
+    return {
+      ...participant,
+      has_session_token: !!participant.has_session_token,
+      duplicate_name_count: participant.is_admin ? 0 : (duplicateCounts.get(normalized) || 0),
+    };
+  });
 }
 
 function removeParticipant({ seasonId, participantId }) {
@@ -51,6 +68,25 @@ function removeParticipant({ seasonId, participantId }) {
       AND participant_id IN (SELECT id FROM participants WHERE is_admin = 0)
   `).run(seasonId, participantId);
   return { ok: true };
+}
+
+function resetParticipantAccess({ seasonId, participantId }) {
+  const participant = getSeasonParticipants(seasonId)
+    .find((row) => Number(row.id) === Number(participantId) && !row.is_admin);
+
+  if (!participant) {
+    return { ok: false, status: 404, error: 'Participant not found in the active season roster.' };
+  }
+
+  const token = uuidv4();
+  db.prepare('UPDATE participants SET session_token = ? WHERE id = ?').run(token, participantId);
+
+  return {
+    ok: true,
+    participantId: Number(participantId),
+    participantName: participant.name,
+    accessPath: `/api/auth/access/${token}`,
+  };
 }
 
 function listAuctionQueue({ seasonId }) {
@@ -192,6 +228,7 @@ module.exports = {
   regenerateInviteCode,
   listParticipants,
   removeParticipant,
+  resetParticipantAccess,
   listAuctionQueue,
   updateAuctionQueue,
   shufflePendingAuctionQueue,

--- a/apps/f1/server/tests/adminServices.test.js
+++ b/apps/f1/server/tests/adminServices.test.js
@@ -423,6 +423,63 @@ test('results admin refreshSchedule matches by round and type when provider name
   assert.equal(australianGp.name, 'FORMULA 1 LOUIS VUITTON AUSTRALIAN GRAND PRIX 2026');
 });
 
+test('auction admin participant list exposes access state and duplicate-name warnings', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    auctionAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const firstId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('Jamie Pace', '#111111', NULL)
+  `).run().lastInsertRowid;
+  const secondId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('jamie pace', '#222222', 'jamie-token')
+  `).run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, firstId);
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, secondId);
+
+  const participants = auctionAdminService.listParticipants({ seasonId })
+    .filter((participant) => Number(participant.id) === Number(firstId) || Number(participant.id) === Number(secondId));
+
+  assert.equal(participants.length, 2);
+  assert.equal(participants[0].duplicate_name_count, 2);
+  assert.equal(participants[1].duplicate_name_count, 2);
+  assert.equal(participants[0].has_session_token, false);
+  assert.equal(participants[1].has_session_token, true);
+});
+
+test('auction admin resetParticipantAccess rotates the participant token and returns an access path', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    auctionAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const participantId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('Access Reset', '#123123', 'old-access-token')
+  `).run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+
+  const result = auctionAdminService.resetParticipantAccess({
+    seasonId,
+    participantId,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.participantId, Number(participantId));
+  assert.match(result.accessPath, /^\/api\/auth\/access\//);
+
+  const updatedToken = db.prepare('SELECT session_token FROM participants WHERE id = ?').get(participantId).session_token;
+  assert.notEqual(updatedToken, 'old-access-token');
+  assert.match(result.accessPath, new RegExp(`${updatedToken}$`));
+});
+
 test('startup seeding preserves provider-refreshed schedule rows on init rerun', async () => {
   const {
     db,

--- a/apps/f1/server/tests/authRoutes.test.js
+++ b/apps/f1/server/tests/authRoutes.test.js
@@ -1,0 +1,243 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const os = require('os');
+
+function clearF1ServerModules() {
+  for (const key of Object.keys(require.cache)) {
+    if (key.includes('/apps/f1/server/')) {
+      delete require.cache[key];
+    }
+  }
+}
+
+function freshModules() {
+  clearF1ServerModules();
+  const dbModule = require('../db');
+  const authRoutes = require('../routes/auth');
+  return {
+    ...dbModule,
+    authRoutes,
+  };
+}
+
+function setupDb() {
+  process.env.DB_PATH = path.join(
+    os.tmpdir(),
+    `f1-calcutta-auth-test-${Date.now()}-${Math.random().toString(16).slice(2)}.db`,
+  );
+  const modules = freshModules();
+  modules.init();
+  return modules;
+}
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    body: null,
+    cookies: [],
+    redirectedTo: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    cookie(name, value, options) {
+      this.cookies.push({ name, value, options });
+      return this;
+    },
+    redirect(location) {
+      this.statusCode = 302;
+      this.redirectedTo = location;
+      return this;
+    },
+    clearCookie() {
+      return this;
+    },
+  };
+}
+
+function getRouteHandlers(router, method, path) {
+  const layer = router.stack.find((entry) => entry.route && entry.route.path === path && entry.route.methods[method]);
+  if (!layer) throw new Error(`Route not found for ${method.toUpperCase()} ${path}`);
+  return layer.route.stack.map((entry) => entry.handle);
+}
+
+async function invokeRoute({ router, method, path, body, cookies, params }) {
+  const handlers = getRouteHandlers(router, method, path);
+  const req = {
+    method: method.toUpperCase(),
+    body: body || {},
+    cookies: cookies || {},
+    params: params || {},
+    app: {
+      get(name) {
+        if (name === 'io') {
+          return { emit() {} };
+        }
+        return null;
+      },
+    },
+  };
+  const res = createMockResponse();
+
+  async function run(index) {
+    if (index >= handlers.length || res.body || res.redirectedTo) return;
+    await handlers[index](req, res, () => run(index + 1));
+  }
+
+  await run(0);
+  return res;
+}
+
+test('pre-auction join still creates a new participant for a valid unmatched name', async () => {
+  const { db, getActiveSeasonId, authRoutes } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const season = db.prepare('SELECT invite_code FROM seasons WHERE id = ?').get(seasonId);
+
+  const before = db.prepare('SELECT COUNT(*) as c FROM participants WHERE is_admin = 0').get().c;
+  const response = await invokeRoute({
+    router: authRoutes,
+    method: 'post',
+    path: '/join',
+    body: {
+      name: 'New Participant',
+      inviteCode: season.invite_code,
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.participant.name, 'New Participant');
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM participants WHERE is_admin = 0').get().c, before + 1);
+});
+
+test('post-auction join rejects unmatched names instead of creating a participant', async () => {
+  const { db, getActiveSeasonId, authRoutes } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const season = db.prepare('SELECT invite_code FROM seasons WHERE id = ?').get(seasonId);
+  db.prepare(`UPDATE seasons SET auction_status = 'complete' WHERE id = ?`).run(seasonId);
+
+  const before = db.prepare('SELECT COUNT(*) as c FROM participants WHERE is_admin = 0').get().c;
+  const response = await invokeRoute({
+    router: authRoutes,
+    method: 'post',
+    path: '/join',
+    body: {
+      name: 'Typo Name',
+      inviteCode: season.invite_code,
+    },
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.match(response.body.error, /contact the admin/i);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM participants WHERE is_admin = 0').get().c, before);
+});
+
+test('post-auction join logs into an existing season participant on case-insensitive exact match', async () => {
+  const { db, getActiveSeasonId, authRoutes } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const season = db.prepare('SELECT invite_code FROM seasons WHERE id = ?').get(seasonId);
+  db.prepare(`UPDATE seasons SET auction_status = 'complete' WHERE id = ?`).run(seasonId);
+
+  const participantId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('Alice Driver', '#ff0000', NULL)
+  `).run().lastInsertRowid;
+  db.prepare(`
+    INSERT INTO season_participants (season_id, participant_id)
+    VALUES (?, ?)
+  `).run(seasonId, participantId);
+
+  const response = await invokeRoute({
+    router: authRoutes,
+    method: 'post',
+    path: '/join',
+    body: {
+      name: 'alice driver',
+      inviteCode: season.invite_code,
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.participant.id, Number(participantId));
+  assert.equal(response.cookies[0].name, 'session');
+  assert.ok(db.prepare('SELECT session_token FROM participants WHERE id = ?').get(participantId).session_token);
+});
+
+test('post-auction join fails closed on duplicate normalized names', async () => {
+  const { db, getActiveSeasonId, authRoutes } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const season = db.prepare('SELECT invite_code FROM seasons WHERE id = ?').get(seasonId);
+  db.prepare(`UPDATE seasons SET auction_status = 'complete' WHERE id = ?`).run(seasonId);
+
+  const firstId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('Chris Pace', '#111111', NULL)
+  `).run().lastInsertRowid;
+  const secondId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('chris pace', '#222222', NULL)
+  `).run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, firstId);
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, secondId);
+
+  const response = await invokeRoute({
+    router: authRoutes,
+    method: 'post',
+    path: '/join',
+    body: {
+      name: 'Chris Pace',
+      inviteCode: season.invite_code,
+    },
+  });
+
+  assert.equal(response.statusCode, 409);
+  assert.match(response.body.error, /multiple participants/i);
+});
+
+test('invalid invite code still rejects before any participant creation', async () => {
+  const { db, authRoutes } = setupDb();
+  const before = db.prepare('SELECT COUNT(*) as c FROM participants WHERE is_admin = 0').get().c;
+
+  const response = await invokeRoute({
+    router: authRoutes,
+    method: 'post',
+    path: '/join',
+    body: {
+      name: 'Wrong Code',
+      inviteCode: 'BAD999',
+    },
+  });
+
+  assert.equal(response.statusCode, 401);
+  assert.match(response.body.error, /invalid invite code/i);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM participants WHERE is_admin = 0').get().c, before);
+});
+
+test('participant access link signs a rostered participant in and redirects to dashboard', async () => {
+  const { db, getActiveSeasonId, authRoutes } = setupDb();
+  const seasonId = getActiveSeasonId();
+
+  const participantId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('Access Tester', '#445566', 'access-token-123')
+  `).run().lastInsertRowid;
+  db.prepare(`
+    INSERT INTO season_participants (season_id, participant_id)
+    VALUES (?, ?)
+  `).run(seasonId, participantId);
+
+  const response = await invokeRoute({
+    router: authRoutes,
+    method: 'get',
+    path: '/access/:token',
+    params: { token: 'access-token-123' },
+  });
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(response.redirectedTo, '/dashboard');
+  assert.equal(response.cookies[0].name, 'session');
+});


### PR DESCRIPTION
- Summary
  - add the live payout board driven by `payoutBoard.rules` in the dashboard payload so the lower hero area now shows payout categories with holder and ownership details instead of the old race leader/championship cards
  - normalize OpenF1 pit data to keep each driver’s slowest stop for payout resolution and build the dashboard payout rows from live rules, ownership, and metric formatting; document the new behavior in `README.md`
  - lock F1 post-auction joins to existing roster participants, tighten name matching/logging, and add admin visibility so reclaiming or resetting access doesn’t require creating empty entries
- Testing
  - Not run (not requested)