### PR TITLE
Improve F1 participant mobile UX

### DIFF
--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -15,6 +15,7 @@ A dedicated Formula 1 Calcutta app for a full season pool.
 - Season bonus payouts from remaining pool
 - Participant dashboard at `/dashboard` with personal KPIs, full standings, current-or-next race focus, and a live payout-category board driven by OpenF1 timing
 - On-demand Anthropic briefing on the dashboard for a concise personal race/standings summary, persisted per participant across refreshes and login sessions
+- Participant mobile UX now uses a compact nav shell, join-first login layout, card-based dashboard/portfolio views, and a list-to-detail event flow instead of relying on wide desktop tables
 - Results sync via provider adapter (`openf1` for real data, `mock` for local/dev/test)
 - Admin controls for auction, sync, payout rules, and settings
 - Results Sync admin view shows collapsible driver/event lists after provider refreshes

--- a/apps/f1/client/src/components/Nav.jsx
+++ b/apps/f1/client/src/components/Nav.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import useMediaQuery from '../useMediaQuery';
 
 const BASE_LINKS = [
   { to: '/dashboard', label: 'Dashboard' },
@@ -11,6 +12,8 @@ const BASE_LINKS = [
 export default function Nav() {
   const location = useLocation();
   const { participant, logout } = useAuth();
+  const isMobileNav = useMediaQuery('(max-width: 760px)');
+  const [menuOpen, setMenuOpen] = useState(false);
   const participantInitial = (participant?.name || '?').trim().charAt(0).toUpperCase() || '?';
 
   const links = participant?.isAdmin
@@ -27,38 +30,106 @@ export default function Nav() {
     return location.pathname === to;
   };
 
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!isMobileNav) setMenuOpen(false);
+  }, [isMobileNav]);
+
   return (
-    <header className="top-nav">
-      <div className="top-nav-inner">
-        <div className="brand">F1 Calcutta</div>
-        <nav className="top-nav-links">
+    <>
+      <header className="top-nav">
+        <div className="top-nav-inner">
+          <div className="brand">F1 Calcutta</div>
+
+          <nav className="top-nav-links top-nav-links-desktop">
+            {links.map((link) => (
+              <Link
+                key={link.to}
+                className={`nav-link ${isLinkActive(link.to) ? 'active' : ''}`}
+                to={link.to}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+
+          <div className="top-nav-actions top-nav-actions-desktop">
+            <div className="nav-user-chip">
+              <span
+                className="avatar nav-user-avatar"
+                style={{
+                  backgroundColor: `${participant?.color || '#e10600'}22`,
+                  borderColor: `${participant?.color || '#e10600'}66`,
+                  color: participant?.color || '#e10600',
+                }}
+              >
+                {participantInitial}
+              </span>
+              <span className="nav-user-name">{participant?.name || 'Participant'}</span>
+            </div>
+            <button className="btn btn-outline" onClick={logout}>Logout</button>
+          </div>
+
+          <div className="top-nav-mobile-bar">
+            <button
+              type="button"
+              className={`btn btn-outline mobile-menu-btn ${menuOpen ? 'active' : ''}`}
+              onClick={() => setMenuOpen((open) => !open)}
+              aria-expanded={menuOpen}
+              aria-controls="mobile-nav-panel"
+            >
+              {menuOpen ? 'Close' : 'Menu'}
+            </button>
+          </div>
+        </div>
+
+        {isMobileNav && menuOpen ? (
+          <div id="mobile-nav-panel" className="top-nav-mobile-panel">
+            <div className="nav-user-chip nav-user-chip-mobile">
+              <span
+                className="avatar nav-user-avatar"
+                style={{
+                  backgroundColor: `${participant?.color || '#e10600'}22`,
+                  borderColor: `${participant?.color || '#e10600'}66`,
+                  color: participant?.color || '#e10600',
+                }}
+              >
+                {participantInitial}
+              </span>
+              <span className="nav-user-name">{participant?.name || 'Participant'}</span>
+            </div>
+            <div className="top-nav-mobile-links">
+              {links.map((link) => (
+                <Link
+                  key={link.to}
+                  className={`nav-link ${isLinkActive(link.to) ? 'active' : ''}`}
+                  to={link.to}
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+            <button className="btn btn-outline mobile-logout-btn" onClick={logout}>Logout</button>
+          </div>
+        ) : null}
+      </header>
+
+      {isMobileNav && !participant?.isAdmin ? (
+        <nav className="bottom-tab-nav" aria-label="Primary navigation">
           {links.map((link) => (
             <Link
               key={link.to}
-              className={`nav-link ${isLinkActive(link.to) ? 'active' : ''}`}
+              className={`bottom-tab-link ${isLinkActive(link.to) ? 'active' : ''}`}
               to={link.to}
             >
-              {link.label}
+              <span>{link.label}</span>
             </Link>
           ))}
         </nav>
-        <div className="top-nav-actions">
-          <div className="nav-user-chip">
-            <span
-              className="avatar nav-user-avatar"
-              style={{
-                backgroundColor: `${participant?.color || '#e10600'}22`,
-                borderColor: `${participant?.color || '#e10600'}66`,
-                color: participant?.color || '#e10600',
-              }}
-            >
-              {participantInitial}
-            </span>
-            <span className="nav-user-name">{participant?.name || 'Participant'}</span>
-          </div>
-          <button className="btn btn-outline" onClick={logout}>Logout</button>
-        </div>
-      </div>
-    </header>
+      ) : null}
+    </>
   );
 }

--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -184,6 +184,12 @@ button {
   gap: var(--space-3);
 }
 
+.top-nav-mobile-bar,
+.top-nav-mobile-panel,
+.bottom-tab-nav {
+  display: none;
+}
+
 .nav-user-chip {
   display: inline-flex;
   align-items: center;
@@ -2604,6 +2610,66 @@ tbody tr:hover {
   background: rgba(159, 63, 67, 0.09);
 }
 
+.mobile-card-list {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.mobile-info-card {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  background: rgba(10, 14, 20, 0.72);
+  padding: 0.8rem;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.mobile-info-card-active {
+  border-color: rgba(159, 63, 67, 0.42);
+  background: rgba(159, 63, 67, 0.11);
+}
+
+.mobile-info-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.mobile-card-note {
+  margin: 0;
+}
+
+.mobile-card-stack {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.mobile-holder-card {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0.65rem;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.mobile-holder-meta {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.mobile-stat-grid {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.mobile-stat-grid > div {
+  display: grid;
+  gap: 0.16rem;
+}
+
 .fade-in {
   animation: fadeIn 220ms ease-out;
 }
@@ -2640,6 +2706,7 @@ tbody tr:hover {
   .join-landing {
     grid-template-columns: 1fr;
     min-height: 0;
+    padding: var(--space-3);
   }
 
   .join-bg-graphic {
@@ -2648,12 +2715,16 @@ tbody tr:hover {
   }
 
   .join-hero {
-    min-height: 280px;
+    order: 2;
+    min-height: 220px;
+    gap: var(--space-3);
   }
 
   .join-auth-panel {
+    order: 1;
     width: min(100%, 560px);
-    justify-self: center;
+    justify-self: stretch;
+    align-self: start;
   }
 
   .admin-layout {
@@ -2677,6 +2748,10 @@ tbody tr:hover {
 
   .events-redesign {
     grid-template-columns: 1fr;
+  }
+
+  .events-layout {
+    gap: var(--space-3);
   }
 
   .events-detail-header {
@@ -2751,13 +2826,25 @@ tbody tr:hover {
 }
 
 @media (max-width: 560px) {
+  .join-landing {
+    padding: var(--space-2);
+  }
+
   .join-hero {
-    min-height: 250px;
-    padding: 0.9rem;
+    min-height: 0;
+    padding: 0.5rem 0.2rem 0;
   }
 
   .join-hero-cards {
     grid-template-columns: repeat(2, minmax(120px, 1fr));
+  }
+
+  .join-hero-cards > div:last-child {
+    display: none;
+  }
+
+  .join-live-pill {
+    padding: 0.24rem 0.5rem 0.28rem;
   }
 
   .guide-table-grid {
@@ -2790,22 +2877,102 @@ tbody tr:hover {
 }
 
 @media (max-width: 760px) {
+  .page-shell {
+    width: min(1200px, 95vw);
+    padding-bottom: calc(5.8rem + env(safe-area-inset-bottom, 0px));
+  }
+
   .top-nav-inner {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .top-nav-links {
-    width: 100%;
-  }
-
-  .top-nav-actions {
-    width: 100%;
+    width: min(1200px, 95vw);
+    padding: 0.55rem 0;
     justify-content: space-between;
   }
 
+  .top-nav-links-desktop,
+  .top-nav-actions-desktop {
+    display: none;
+  }
+
+  .top-nav-mobile-bar {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-2);
+  }
+
+  .nav-user-chip-mobile {
+    width: fit-content;
+  }
+
+  .mobile-menu-btn {
+    flex-shrink: 0;
+    padding-inline: 0.78rem;
+  }
+
+  .top-nav-mobile-panel {
+    width: min(1200px, 95vw);
+    margin: 0 auto;
+    padding: 0 0 0.65rem;
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .top-nav-mobile-links {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .top-nav-mobile-links .nav-link,
+  .mobile-logout-btn {
+    display: flex;
+    width: 100%;
+    justify-content: center;
+  }
+
+  .bottom-tab-nav {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 12;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1px;
+    padding: 0.4rem 0.45rem calc(0.4rem + env(safe-area-inset-bottom, 0px));
+    background: rgba(11, 15, 20, 0.97);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(12px);
+  }
+
+  .bottom-tab-link {
+    min-width: 0;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-sm);
+    padding: 0.48rem 0.35rem;
+    text-align: center;
+    font-size: var(--text-xs);
+    color: var(--muted);
+    background: rgba(16, 22, 32, 0.68);
+  }
+
+  .bottom-tab-link.active {
+    color: var(--text);
+    border-color: rgba(159, 63, 67, 0.52);
+    background: rgba(159, 63, 67, 0.16);
+  }
+
+  .driver-id-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
   .bid-form {
-    grid-template-columns: 30px minmax(0, 1fr) auto auto;
+    grid-template-columns: 36px minmax(0, 1fr);
+    grid-template-areas:
+      "prefix input"
+      "quick quick"
+      "submit submit";
   }
 
   .events-payout-row-head {
@@ -2822,18 +2989,48 @@ tbody tr:hover {
     grid-template-columns: 1fr;
   }
 
+  .currency-prefix {
+    grid-area: prefix;
+  }
+
+  .bid-form input {
+    grid-area: input;
+  }
+
+  .quick-bid-btn {
+    grid-area: quick;
+  }
+
   .bid-form .btn {
     grid-column: auto;
     padding: 0.42rem 0.58rem;
     font-size: var(--text-xs);
   }
 
-  .page-shell {
-    width: min(1200px, 95vw);
+  .bid-form .btn[type="submit"] {
+    grid-area: submit;
   }
 
   .sold-lanes {
     grid-template-columns: 1fr;
+  }
+
+  .sold-driver-row {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+  }
+
+  .sold-driver-price {
+    font-size: 1rem;
+  }
+
+  .mobile-stat-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .events-back-btn {
+    width: fit-content;
+    margin-bottom: var(--space-2);
   }
 }
 

--- a/apps/f1/client/src/pages/Auction.jsx
+++ b/apps/f1/client/src/pages/Auction.jsx
@@ -324,7 +324,7 @@ export default function Auction() {
   };
 
   return (
-    <div className="stack-lg">
+    <div className="stack-lg auction-page">
       <section className="panel telemetry-strip stagger-in">
         <div className="strip-item">
           <span className="label">Status</span>
@@ -359,7 +359,7 @@ export default function Auction() {
       )}
 
       {active ? (
-        <section className="panel">
+        <section className="panel auction-bid-panel">
           <h3>Place Bid</h3>
           {canPlaceBid ? (
             <form className="bid-form" onSubmit={submitBid}>

--- a/apps/f1/client/src/pages/Dashboard.jsx
+++ b/apps/f1/client/src/pages/Dashboard.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import DriverIdentity from '../components/DriverIdentity';
 import { useSocketEvent } from '../context/SocketContext';
+import useMediaQuery from '../useMediaQuery';
 import {
   api,
   eventTypeLabel,
@@ -57,6 +58,10 @@ function payoutStatusLabel(rule) {
   return 'Live';
 }
 
+function HolderKey(prefix, holder) {
+  return `${prefix}-${holder.driverId || holder.driverCode || holder.driverName}`;
+}
+
 function PayoutBoardTable({ rules }) {
   if (!rules?.length) {
     return <p className="muted">No payout categories are configured for this event.</p>;
@@ -90,7 +95,7 @@ function PayoutBoardTable({ rules }) {
                   <div className="dashboard-payout-stack">
                     {rule.holders.map((holder) => (
                       <div
-                        key={`${rule.category}-${holder.driverId || holder.driverCode || holder.driverName}`}
+                        key={HolderKey(rule.category, holder)}
                         className="dashboard-payout-holder"
                       >
                         <DriverIdentity
@@ -112,7 +117,7 @@ function PayoutBoardTable({ rules }) {
                 {rule.holders?.length ? (
                   <div className="dashboard-payout-stack">
                     {rule.holders.map((holder) => (
-                      <div key={`${rule.category}-owner-${holder.driverId || holder.driverCode || holder.driverName}`} className="dashboard-owner-line">
+                      <div key={HolderKey(`${rule.category}-owner`, holder)} className="dashboard-owner-line">
                         {holder.participantName ? (
                           <>
                             <span
@@ -141,7 +146,7 @@ function PayoutBoardTable({ rules }) {
                 {rule.holders?.length ? (
                   <div className="dashboard-payout-stack">
                     {rule.holders.map((holder) => (
-                      <div key={`${rule.category}-metric-${holder.driverId || holder.driverCode || holder.driverName}`}>
+                      <div key={HolderKey(`${rule.category}-metric`, holder)}>
                         {holder.displayValue || rule.metric?.display || '-'}
                       </div>
                     ))}
@@ -158,7 +163,136 @@ function PayoutBoardTable({ rules }) {
   );
 }
 
+function PayoutBoardCards({ rules }) {
+  if (!rules?.length) {
+    return <p className="muted">No payout categories are configured for this event.</p>;
+  }
+
+  return (
+    <div className="mobile-card-list">
+      {rules.map((rule) => (
+        <article key={rule.category} className="mobile-info-card">
+          <div className="mobile-info-card-head">
+            <div>
+              <strong>{rule.label}</strong>
+              <div className="muted small">Pool {formatBpsPercent(rule.bps)}</div>
+            </div>
+            <span className={`dashboard-payout-status ${rule.status}`}>{payoutStatusLabel(rule)}</span>
+          </div>
+
+          {rule.note ? <p className="muted small mobile-card-note">{rule.note}</p> : null}
+
+          {rule.holders?.length ? (
+            <div className="mobile-card-stack">
+              {rule.holders.map((holder) => (
+                <div key={HolderKey(rule.category, holder)} className="mobile-holder-card">
+                  <DriverIdentity
+                    driverName={holder.driverName}
+                    driverCode={holder.driverCode}
+                    teamName={holder.teamName}
+                    compact
+                    showCode={false}
+                  />
+                  <div className="mobile-holder-meta">
+                    <div className="dashboard-owner-line">
+                      {holder.participantName ? (
+                        <>
+                          <span
+                            className="avatar dashboard-participant-avatar"
+                            style={{
+                              backgroundColor: `${holder.participantColor || '#e10600'}22`,
+                              color: holder.participantColor || '#e10600',
+                              borderColor: `${holder.participantColor || '#e10600'}66`,
+                            }}
+                          >
+                            {(holder.participantName || '?').trim().charAt(0).toUpperCase() || '?'}
+                          </span>
+                          <span>{holder.participantName}</span>
+                        </>
+                      ) : (
+                        <span className="muted">Unowned</span>
+                      )}
+                      {holder.isViewerOwner ? <span className="dashboard-owner-badge">Yours</span> : null}
+                    </div>
+                    <div className="mobile-stat-grid">
+                      <div>
+                        <span className="label">Metric</span>
+                        <strong>{holder.displayValue || rule.metric?.display || '-'}</strong>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="mobile-stat-grid">
+              <div>
+                <span className="label">Current Holder</span>
+                <strong>{payoutStatusLabel(rule)}</strong>
+              </div>
+              <div>
+                <span className="label">Metric</span>
+                <strong>{rule.metric?.display || '-'}</strong>
+              </div>
+            </div>
+          )}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function StandingsCards({ rows }) {
+  return (
+    <div className="mobile-card-list">
+      {rows.map((row) => (
+        <article key={row.id} className={`mobile-info-card ${row.isViewer ? 'mobile-info-card-active' : ''}`}>
+          <div className="mobile-info-card-head">
+            <div className="dashboard-participant-cell">
+              <span
+                className="avatar dashboard-participant-avatar"
+                style={{
+                  backgroundColor: `${row.color || '#e10600'}22`,
+                  color: row.color || '#e10600',
+                  borderColor: `${row.color || '#e10600'}66`,
+                }}
+              >
+                {(row.name || '?').trim().charAt(0).toUpperCase() || '?'}
+              </span>
+              <div>
+                <strong>{row.name}</strong>
+                <div className="muted small">Rank #{row.rank}</div>
+              </div>
+            </div>
+            {row.isViewer ? <span className="dashboard-owner-badge">You</span> : null}
+          </div>
+
+          <div className="mobile-stat-grid">
+            <div>
+              <span className="label">Drivers</span>
+              <strong>{row.drivers_owned}</strong>
+            </div>
+            <div>
+              <span className="label">Spent</span>
+              <strong>{fmtCents(row.total_spent_cents)}</strong>
+            </div>
+            <div>
+              <span className="label">Earned</span>
+              <strong>{fmtCents(row.total_earned_cents)}</strong>
+            </div>
+            <div>
+              <span className="label">Net</span>
+              <strong className={row.net_cents >= 0 ? 'text-pos' : 'text-neg'}>{fmtCents(row.net_cents)}</strong>
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
 export default function Dashboard() {
+  const isMobileCards = useMediaQuery('(max-width: 760px)');
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -398,7 +532,7 @@ export default function Dashboard() {
           ) : null}
         </div>
 
-        <PayoutBoardTable rules={payoutBoard.rules} />
+        {isMobileCards ? <PayoutBoardCards rules={payoutBoard.rules} /> : <PayoutBoardTable rules={payoutBoard.rules} />}
       </section>
 
       <section className="panel">
@@ -411,46 +545,50 @@ export default function Dashboard() {
 
         {error ? <p className="error-text">{error}</p> : null}
 
-        <div className="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>Participant</th>
-                <th>Drivers</th>
-                <th>Spent</th>
-                <th>Earned</th>
-                <th>Net</th>
-              </tr>
-            </thead>
-            <tbody>
-              {highlightedStandings.map((row) => (
-                <tr key={row.id} className={row.isViewer ? 'dashboard-table-row-active' : ''}>
-                  <td>{row.rank}</td>
-                  <td>
-                    <div className="dashboard-participant-cell">
-                      <span
-                        className="avatar dashboard-participant-avatar"
-                        style={{
-                          backgroundColor: `${row.color || '#e10600'}22`,
-                          color: row.color || '#e10600',
-                          borderColor: `${row.color || '#e10600'}66`,
-                        }}
-                      >
-                        {(row.name || '?').trim().charAt(0).toUpperCase() || '?'}
-                      </span>
-                      <span>{row.name}</span>
-                    </div>
-                  </td>
-                  <td>{row.drivers_owned}</td>
-                  <td>{fmtCents(row.total_spent_cents)}</td>
-                  <td>{fmtCents(row.total_earned_cents)}</td>
-                  <td className={row.net_cents >= 0 ? 'text-pos' : 'text-neg'}>{fmtCents(row.net_cents)}</td>
+        {isMobileCards ? (
+          <StandingsCards rows={highlightedStandings} />
+        ) : (
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Participant</th>
+                  <th>Drivers</th>
+                  <th>Spent</th>
+                  <th>Earned</th>
+                  <th>Net</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {highlightedStandings.map((row) => (
+                  <tr key={row.id} className={row.isViewer ? 'dashboard-table-row-active' : ''}>
+                    <td>{row.rank}</td>
+                    <td>
+                      <div className="dashboard-participant-cell">
+                        <span
+                          className="avatar dashboard-participant-avatar"
+                          style={{
+                            backgroundColor: `${row.color || '#e10600'}22`,
+                            color: row.color || '#e10600',
+                            borderColor: `${row.color || '#e10600'}66`,
+                          }}
+                        >
+                          {(row.name || '?').trim().charAt(0).toUpperCase() || '?'}
+                        </span>
+                        <span>{row.name}</span>
+                      </div>
+                    </td>
+                    <td>{row.drivers_owned}</td>
+                    <td>{fmtCents(row.total_spent_cents)}</td>
+                    <td>{fmtCents(row.total_earned_cents)}</td>
+                    <td className={row.net_cents >= 0 ? 'text-pos' : 'text-neg'}>{fmtCents(row.net_cents)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </section>
     </div>
   );

--- a/apps/f1/client/src/pages/Events.jsx
+++ b/apps/f1/client/src/pages/Events.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import DriverIdentity from '../components/DriverIdentity';
 import { getEventLocation } from '../eventLocations';
+import useMediaQuery from '../useMediaQuery';
 import {
   api,
   auditRuleSummary,
@@ -65,6 +66,7 @@ function isInactiveRaceOnlyDriver(driver) {
 }
 
 export default function Events() {
+  const isMobileFlow = useMediaQuery('(max-width: 980px)');
   const [events, setEvents] = useState([]);
   const [selectedEventId, setSelectedEventId] = useState(null);
   const [hasUserSelection, setHasUserSelection] = useState(false);
@@ -74,6 +76,7 @@ export default function Events() {
   const [detailLoading, setDetailLoading] = useState(false);
   const [activeTab, setActiveTab] = useState('payouts');
   const [expandedPayoutId, setExpandedPayoutId] = useState(null);
+  const [mobileDetailOpen, setMobileDetailOpen] = useState(false);
 
   const loadEvents = useCallback(async () => {
     const response = await api('/events');
@@ -206,6 +209,7 @@ export default function Events() {
     setHasUserSelection(true);
     setActiveTab('payouts');
     setExpandedPayoutId(null);
+    setMobileDetailOpen(true);
   }, []);
 
   const findAuditRuleForPayout = useCallback((payout) => {
@@ -225,9 +229,12 @@ export default function Events() {
   const visibleEvents = raceListMode === 'upcoming'
     ? eventView.upcomingEvents
     : eventView.pastEvents;
+  const showListPane = !isMobileFlow || !mobileDetailOpen;
+  const showDetailPane = !isMobileFlow || mobileDetailOpen;
 
   return (
     <div className="two-col events-layout events-redesign">
+      {showListPane ? (
       <section className="panel events-navigator">
         <div className="events-nav-header">
           <h2>Race Weekends</h2>
@@ -298,7 +305,9 @@ export default function Events() {
           )}
         </section>
       </section>
+      ) : null}
 
+      {showDetailPane ? (
       <section className="panel events-detail-shell">
         {!selectedEventSummary ? (
           <>
@@ -308,6 +317,15 @@ export default function Events() {
         ) : (
           <>
             <header className="events-detail-header">
+              {isMobileFlow ? (
+                <button
+                  type="button"
+                  className="btn btn-outline events-back-btn"
+                  onClick={() => setMobileDetailOpen(false)}
+                >
+                  Back to Races
+                </button>
+              ) : null}
               <h2>{selectedEventSummary.name}</h2>
               <p className="muted">
                 {eventTypeLabel(selectedEventSummary.type)} • {fmtWhen(selectedEventSummary.starts_at)} • {selectedEventSummary.displayLocation}
@@ -478,6 +496,7 @@ export default function Events() {
           </>
         )}
       </section>
+      ) : null}
     </div>
   );
 }

--- a/apps/f1/client/src/pages/MyDrivers.jsx
+++ b/apps/f1/client/src/pages/MyDrivers.jsx
@@ -1,11 +1,13 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import DriverIdentity from '../components/DriverIdentity';
 import { useAuth } from '../context/AuthContext';
+import useMediaQuery from '../useMediaQuery';
 import { api, fmtCents } from '../utils';
 import { getTeamColorStyle } from '../teamMeta';
 
 export default function MyDrivers() {
   const { participant } = useAuth();
+  const isMobileCards = useMediaQuery('(max-width: 760px)');
   const [drivers, setDrivers] = useState([]);
   const [totalSpentCents, setTotalSpentCents] = useState(0);
   const [totalEarnedCents, setTotalEarnedCents] = useState(0);
@@ -45,60 +47,116 @@ export default function MyDrivers() {
       <section className="panel">
         <h2>My Drivers</h2>
         {!drivers.length ? <p className="muted">No drivers purchased yet.</p> : (
-          <div className="table-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th>Code</th>
-                  <th>Driver</th>
-                  <th>Team</th>
-                  <th>Purchase</th>
-                  <th>Event Earnings</th>
-                  <th>Bonus Earnings</th>
-                  <th>Total</th>
-                </tr>
-              </thead>
-              <tbody>
-                {drivers.map((driver) => {
-                  const total = driver.event_earnings_cents + driver.bonus_earnings_cents;
-                  return (
-                    <tr key={driver.driver_id}>
-                      <td>
-                        <span
-                          className="team-accent-text"
-                          style={getTeamColorStyle({ teamName: driver.team_name, driverCode: driver.driver_code })}
-                        >
-                          {driver.driver_code}
-                        </span>
-                      </td>
-                      <td>
-                        <DriverIdentity
-                          driverName={driver.driver_name}
-                          driverCode={driver.driver_code}
-                          teamName={driver.team_name}
-                          compact
-                          showCode={false}
-                          showTeam={false}
-                        />
-                      </td>
-                      <td>
-                        <span
-                          className="team-accent-text"
-                          style={getTeamColorStyle({ teamName: driver.team_name, driverCode: driver.driver_code })}
-                        >
-                          {driver.team_name}
-                        </span>
-                      </td>
-                      <td>{fmtCents(driver.purchase_price_cents)}</td>
-                      <td>{fmtCents(driver.event_earnings_cents)}</td>
-                      <td>{fmtCents(driver.bonus_earnings_cents)}</td>
-                      <td>{fmtCents(total)}</td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+          isMobileCards ? (
+            <div className="mobile-card-list">
+              {drivers.map((driver) => {
+                const total = driver.event_earnings_cents + driver.bonus_earnings_cents;
+                return (
+                  <article key={driver.driver_id} className="mobile-info-card">
+                    <div className="mobile-info-card-head">
+                      <DriverIdentity
+                        driverName={driver.driver_name}
+                        driverCode={driver.driver_code}
+                        teamName={driver.team_name}
+                        compact
+                        showCode={false}
+                        showTeam={false}
+                      />
+                      <span
+                        className="dashboard-owner-badge"
+                        style={getTeamColorStyle({ teamName: driver.team_name, driverCode: driver.driver_code })}
+                      >
+                        {driver.driver_code}
+                      </span>
+                    </div>
+
+                    <p className="muted small">
+                      <span
+                        className="team-accent-text"
+                        style={getTeamColorStyle({ teamName: driver.team_name, driverCode: driver.driver_code })}
+                      >
+                        {driver.team_name}
+                      </span>
+                    </p>
+
+                    <div className="mobile-stat-grid">
+                      <div>
+                        <span className="label">Purchase</span>
+                        <strong>{fmtCents(driver.purchase_price_cents)}</strong>
+                      </div>
+                      <div>
+                        <span className="label">Event</span>
+                        <strong>{fmtCents(driver.event_earnings_cents)}</strong>
+                      </div>
+                      <div>
+                        <span className="label">Bonus</span>
+                        <strong>{fmtCents(driver.bonus_earnings_cents)}</strong>
+                      </div>
+                      <div>
+                        <span className="label">Total</span>
+                        <strong>{fmtCents(total)}</strong>
+                      </div>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Code</th>
+                    <th>Driver</th>
+                    <th>Team</th>
+                    <th>Purchase</th>
+                    <th>Event Earnings</th>
+                    <th>Bonus Earnings</th>
+                    <th>Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {drivers.map((driver) => {
+                    const total = driver.event_earnings_cents + driver.bonus_earnings_cents;
+                    return (
+                      <tr key={driver.driver_id}>
+                        <td>
+                          <span
+                            className="team-accent-text"
+                            style={getTeamColorStyle({ teamName: driver.team_name, driverCode: driver.driver_code })}
+                          >
+                            {driver.driver_code}
+                          </span>
+                        </td>
+                        <td>
+                          <DriverIdentity
+                            driverName={driver.driver_name}
+                            driverCode={driver.driver_code}
+                            teamName={driver.team_name}
+                            compact
+                            showCode={false}
+                            showTeam={false}
+                          />
+                        </td>
+                        <td>
+                          <span
+                            className="team-accent-text"
+                            style={getTeamColorStyle({ teamName: driver.team_name, driverCode: driver.driver_code })}
+                          >
+                            {driver.team_name}
+                          </span>
+                        </td>
+                        <td>{fmtCents(driver.purchase_price_cents)}</td>
+                        <td>{fmtCents(driver.event_earnings_cents)}</td>
+                        <td>{fmtCents(driver.bonus_earnings_cents)}</td>
+                        <td>{fmtCents(total)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )
         )}
       </section>
     </div>

--- a/apps/f1/client/src/useMediaQuery.js
+++ b/apps/f1/client/src/useMediaQuery.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+function readMatch(query) {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia(query).matches;
+}
+
+export default function useMediaQuery(query) {
+  const [matches, setMatches] = useState(() => readMatch(query));
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia(query);
+    const onChange = (event) => setMatches(event.matches);
+
+    setMatches(mediaQuery.matches);
+    mediaQuery.addEventListener('change', onChange);
+    return () => mediaQuery.removeEventListener('change', onChange);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- add a compact mobile navigation shell for participants with bottom tabs
- make the join experience mobile-first and convert dashboard and my-drivers tables into mobile cards
- switch events to a mobile list-to-detail flow and simplify the narrow-screen auction bid layout
- document the participant mobile behavior in the F1 README

## Verification
- npm run build:f1