### PR TITLE
Expand F1 dashboard briefings and random draw controls

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -33,6 +33,7 @@ Owner: On-call engineer / active implementer
 - F1 participant navigation now centers on `/dashboard`, which combines personal standings, full league standings, and current-or-next scoring-session race context.
 - F1 dashboard now supports brief live OpenF1 session snapshots with short-lived caching and an optional on-demand Anthropic participant briefing.
 - The latest F1 dashboard briefing is now persisted per participant so it survives polling refreshes, logout/login, and process restarts.
+- F1 dashboard briefing history now stores structured per-event entries so participants can revisit prior pre-race/live/post-race AI summaries instead of only the latest generated text.
 - F1 post-auction participant login is now locked to the existing season roster; unmatched invite-code joins fail closed and admin can issue/reset direct participant access links from the Auction page.
 - F1 startup seeding now preserves provider-refreshed schedule rows across restart/deploy cycles instead of silently reverting them to mock seed dates.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -112,7 +112,15 @@ After deploy:
    - before the first real race sync
    - before any destructive test-data reset
 
-### G) F1 Payout Audit Export
+### G) F1 Pre-Draw Random Bonus Position
+
+1. Open `Admin -> Results Sync`.
+2. Find the event you want to reveal before the race.
+3. Use `Draw Random`.
+4. The drawn event row will then show the persisted random finishing position.
+5. Later scoring will reuse that same position; it is not redrawn at score time.
+
+### H) F1 Payout Audit Export
 
 1. Open `Admin -> Payout Audit`.
 2. Select the event in question.
@@ -122,7 +130,7 @@ After deploy:
    - `Copy Summary` for a concise plain-text explanation
 4. Use these outputs when reviewing disputed race payouts with participants.
 
-### H) F1 Auction Results Export
+### I) F1 Auction Results Export
 
 1. Open `Admin -> Auction`.
 2. Use `Download Auction Results CSV`.

--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -14,12 +14,13 @@ A dedicated Formula 1 Calcutta app for a full season pool.
 - Grand Prix novelty rule for slowest recorded pit stop via OpenF1 `stop_duration`
 - Season bonus payouts from remaining pool
 - Participant dashboard at `/dashboard` with personal KPIs, full standings, current-or-next race focus, and a live payout-category board driven by OpenF1 timing
-- On-demand Anthropic briefing on the dashboard for a concise personal race/standings summary, persisted per participant across refreshes and login sessions
+- On-demand Anthropic briefing on the dashboard with saved per-event history, contextual pre-race/live/post-race labels, and compact structured sections for faster reading
 - Participant mobile UX now uses a compact nav shell, join-first login layout, card-based dashboard/portfolio views, and a list-to-detail event flow instead of relying on wide desktop tables
 - Results sync via provider adapter (`openf1` for real data, `mock` for local/dev/test)
 - Admin controls for auction, sync, payout rules, and settings
 - Results Sync admin view shows collapsible driver/event lists after provider refreshes
 - Results Sync admin view exposes a live database backup download and a visible driver-roster freeze guard after auction/scoring activity begins
+- Results Sync admin view can pre-draw and reveal the random finishing bonus position for any event before scoring; once drawn it is locked and reused at score time
 - Payout Audit admin view supports rule-level CSV export, winner-detail CSV export, and copyable text summaries for payout review and dispute handling
 - Public-facing explainer pages for both pool rules (`/guide`) and the agentic build case study (`/built-with-ai`)
 
@@ -69,6 +70,8 @@ Server: `http://localhost:3002`
 - Admin Test Data page can rescore all scored events after payout-rule changes
 - Admin Results Sync page can download a live SQLite backup snapshot before auction night or race scoring operations
 - Admin Results Sync page disables `Refresh Drivers` once the season has bids, ownership, or scored payout activity so the auction roster is not changed casually after go-live
+- Admin Results Sync page can pre-draw the random event bonus position before race start so participants know the target position while watching live
+- Participant dashboard payout board now shows the drawn random bonus target for the current/next event when it has already been revealed
 - Admin Auction page can explicitly lock or unlock the season roster; Results Sync respects that lock in addition to activity-based safeguards
 - Admin Payout Audit page can export both rule-level and winner-detail CSVs, plus a concise text summary for payout review
 - Admin Auction page exposes a shareable invite link that deep-links to `/join` with the active invite code prefilled

--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -2518,6 +2518,78 @@ tbody tr:hover {
   background: rgba(11, 15, 21, 0.6);
 }
 
+.dashboard-briefing-history {
+  display: flex;
+  gap: var(--space-2);
+  overflow-x: auto;
+  padding-bottom: 0.15rem;
+}
+
+.dashboard-briefing-nav-btn {
+  min-width: 190px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-sm);
+  background: rgba(10, 14, 20, 0.72);
+  color: var(--text);
+  padding: 0.55rem 0.65rem;
+  text-align: left;
+  display: grid;
+  gap: 0.18rem;
+  cursor: pointer;
+}
+
+.dashboard-briefing-nav-btn span {
+  font-size: var(--text-xs);
+  color: var(--muted);
+}
+
+.dashboard-briefing-nav-btn.active {
+  border-color: rgba(159, 63, 67, 0.48);
+  background: rgba(159, 63, 67, 0.14);
+}
+
+.dashboard-briefing-body {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.dashboard-briefing-meta {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.dashboard-briefing-meta h3,
+.dashboard-briefing-section h4 {
+  margin: 0;
+}
+
+.dashboard-briefing-summary {
+  margin: 0;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid rgba(159, 63, 67, 0.22);
+  border-radius: var(--radius-md);
+  background: rgba(11, 15, 21, 0.52);
+}
+
+.dashboard-briefing-sections {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.dashboard-briefing-section {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: var(--space-2);
+}
+
+.dashboard-briefing-section ul {
+  margin: 0.45rem 0 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
 .dashboard-ranking-list {
   margin-top: 0;
 }
@@ -2577,10 +2649,17 @@ tbody tr:hover {
 }
 
 .dashboard-payout-status.pending,
-.dashboard-payout-status.draw_pending {
+.dashboard-payout-status.draw_pending,
+.dashboard-payout-status.pre_race {
   color: #d9c38d;
   border-color: rgba(217, 195, 141, 0.34);
   background: rgba(217, 195, 141, 0.08);
+}
+
+.dashboard-payout-status.post_race {
+  color: #c3cde0;
+  border-color: rgba(159, 177, 208, 0.24);
+  background: rgba(159, 177, 208, 0.08);
 }
 
 .dashboard-payout-status.unavailable {
@@ -3032,6 +3111,10 @@ tbody tr:hover {
     width: fit-content;
     margin-bottom: var(--space-2);
   }
+
+  .dashboard-briefing-nav-btn {
+    min-width: 160px;
+  }
 }
 
 @media (max-width: 720px) {
@@ -3042,6 +3125,11 @@ tbody tr:hover {
 
   .dashboard-status-pill {
     white-space: normal;
+  }
+
+  .dashboard-briefing-meta {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }
 

--- a/apps/f1/client/src/pages/Dashboard.jsx
+++ b/apps/f1/client/src/pages/Dashboard.jsx
@@ -291,12 +291,81 @@ function StandingsCards({ rows }) {
   );
 }
 
+function formatBriefingHistoryLabel(briefing) {
+  const eventName = briefing?.eventName || 'Saved Briefing';
+  const phase = briefing?.phaseLabel || 'Saved';
+  return `${eventName} • ${phase}`;
+}
+
+function BriefingHistoryNav({ history, selectedId, onSelect }) {
+  if (!history?.length) return null;
+
+  return (
+    <div className="dashboard-briefing-history" role="tablist" aria-label="Briefing history">
+      {history.map((entry) => (
+        <button
+          key={entry.id || `${entry.generatedAt || 'briefing'}-${entry.snapshotHash || ''}`}
+          type="button"
+          role="tab"
+          aria-selected={selectedId === entry.id}
+          className={`dashboard-briefing-nav-btn ${selectedId === entry.id ? 'active' : ''}`}
+          onClick={() => onSelect(entry.id)}
+        >
+          <strong>{entry.eventName || 'Saved Briefing'}</strong>
+          <span>{entry.phaseLabel || 'Saved'}{entry.generatedAt ? ` • ${fmtWhen(entry.generatedAt)}` : ''}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function BriefingContent({ briefing }) {
+  if (!briefing) {
+    return <p className="muted">Generate a briefing when you want a concise race-and-standings summary.</p>;
+  }
+
+  return (
+    <div className="dashboard-briefing-body">
+      <div className="dashboard-briefing-meta">
+        <div>
+          <h3>{briefing.title || formatBriefingHistoryLabel(briefing)}</h3>
+          <p className="muted small">
+            {formatBriefingHistoryLabel(briefing)}
+            {briefing.generatedAt ? ` • ${fmtWhen(briefing.generatedAt)}` : ''}
+          </p>
+        </div>
+        <span className={`dashboard-payout-status ${briefing.phase || 'pending'}`}>{briefing.phaseLabel || 'Saved'}</span>
+      </div>
+
+      {briefing.summary ? <p className="dashboard-briefing-summary">{briefing.summary}</p> : null}
+
+      {Array.isArray(briefing.sections) && briefing.sections.length ? (
+        <div className="dashboard-briefing-sections">
+          {briefing.sections.map((section) => (
+            <section key={`${briefing.id || briefing.generatedAt}-${section.heading}`} className="dashboard-briefing-section">
+              <h4>{section.heading}</h4>
+              <ul>
+                {(section.bullets || []).map((bullet) => (
+                  <li key={`${section.heading}-${bullet}`}>{bullet}</li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      ) : briefing.text ? (
+        <p className="dashboard-briefing-text">{briefing.text}</p>
+      ) : null}
+    </div>
+  );
+}
+
 export default function Dashboard() {
   const isMobileCards = useMediaQuery('(max-width: 760px)');
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [briefing, setBriefing] = useState(null);
+  const [briefingHistory, setBriefingHistory] = useState([]);
+  const [selectedBriefingId, setSelectedBriefingId] = useState(null);
   const [briefingLoading, setBriefingLoading] = useState(false);
   const [briefingError, setBriefingError] = useState('');
 
@@ -309,7 +378,14 @@ export default function Dashboard() {
 
     setData(payload);
     setError('');
-    setBriefing(payload?.briefing || null);
+    const nextHistory = Array.isArray(payload?.briefingHistory)
+      ? payload.briefingHistory
+      : (payload?.briefing ? [payload.briefing] : []);
+    setBriefingHistory(nextHistory);
+    setSelectedBriefingId((currentId) => {
+      if (currentId && nextHistory.some((entry) => entry.id === currentId)) return currentId;
+      return nextHistory[0]?.id || null;
+    });
   }, []);
 
   useEffect(() => {
@@ -357,7 +433,11 @@ export default function Dashboard() {
         throw new Error(payload?.error || 'Dashboard briefing failed to load.');
       }
 
-      setBriefing(payload?.briefing || null);
+      const nextHistory = Array.isArray(payload?.briefingHistory)
+        ? payload.briefingHistory
+        : (payload?.briefing ? [payload.briefing] : []);
+      setBriefingHistory(nextHistory);
+      setSelectedBriefingId(payload?.briefing?.id || nextHistory[0]?.id || null);
       if (payload?.briefing?.error) setBriefingError(payload.briefing.error);
     } catch (loadError) {
       setBriefingError(loadError.message || 'Dashboard briefing failed to load.');
@@ -372,6 +452,11 @@ export default function Dashboard() {
   const liveSession = data?.liveSession || null;
   const payoutBoard = data?.payoutBoard || { rules: [] };
   const isAdmin = !!data?.viewer?.isAdmin;
+  const selectedBriefing = useMemo(
+    () => briefingHistory.find((entry) => entry.id === selectedBriefingId) || briefingHistory[0] || null,
+    [briefingHistory, selectedBriefingId],
+  );
+  const latestBriefing = briefingHistory[0] || null;
 
   const highlightedStandings = useMemo(() => standings.map((row, index) => ({
     ...row,
@@ -494,9 +579,9 @@ export default function Dashboard() {
             <button
               className="btn btn-outline"
               disabled={briefingLoading || !data?.briefingMeta?.available}
-              onClick={() => requestBriefing({ force: !!briefing?.generatedAt })}
+              onClick={() => requestBriefing({ force: !!latestBriefing?.generatedAt })}
             >
-              {briefingLoading ? 'Loading...' : (briefing?.generatedAt ? 'Refresh Briefing' : 'Generate Briefing')}
+              {briefingLoading ? 'Loading...' : (latestBriefing?.generatedAt ? 'Refresh Briefing' : 'Generate Briefing')}
             </button>
           </div>
 
@@ -504,16 +589,20 @@ export default function Dashboard() {
             <p className="muted">Anthropic is not configured for the F1 service yet.</p>
           ) : null}
 
-          {briefing?.text ? (
-            <>
-              <p className="dashboard-briefing-text">{briefing.text}</p>
-              <p className="muted small">
-                {briefing.cached ? 'Cached' : 'Fresh'} briefing{briefing.generatedAt ? ` • ${fmtWhen(briefing.generatedAt)}` : ''}.
-              </p>
-            </>
-          ) : (
-            <p className="muted">Generate a briefing when you want a concise race-and-standings summary.</p>
-          )}
+          <BriefingHistoryNav
+            history={briefingHistory}
+            selectedId={selectedBriefing?.id || null}
+            onSelect={setSelectedBriefingId}
+          />
+
+          <BriefingContent briefing={selectedBriefing} />
+
+          {selectedBriefing?.generatedAt ? (
+            <p className="muted small">
+              {selectedBriefing.cached ? 'Cached' : 'Saved'} briefing
+              {selectedBriefing.generatedAt ? ` • ${fmtWhen(selectedBriefing.generatedAt)}` : ''}.
+            </p>
+          ) : null}
 
           {briefingError ? <p className="error-text">{briefingError}</p> : null}
         </section>

--- a/apps/f1/client/src/pages/admin/ResultsPage.jsx
+++ b/apps/f1/client/src/pages/admin/ResultsPage.jsx
@@ -39,6 +39,18 @@ function formatRefreshTime(value) {
   });
 }
 
+function ordinal(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return '—';
+  const mod100 = number % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${number}th`;
+  const mod10 = number % 10;
+  if (mod10 === 1) return `${number}st`;
+  if (mod10 === 2) return `${number}nd`;
+  if (mod10 === 3) return `${number}rd`;
+  return `${number}th`;
+}
+
 export default function ResultsPage() {
   const {
     events,
@@ -47,6 +59,7 @@ export default function ResultsPage() {
     refreshSchedule,
     syncNext,
     syncEvent,
+    drawRandomPosition,
     refresh,
     loading,
     hasLoaded,
@@ -209,8 +222,19 @@ export default function ResultsPage() {
                       <div className="muted small">
                         {eventTypeLabel(event.type)} • {event.status} • {formatEventTime(event.starts_at)} • payout {fmtCents(event.total_payout_cents || 0)}
                       </div>
+                      <div className="muted small">
+                        Random bonus: {event.random_bonus_position ? ordinal(event.random_bonus_position) : 'Not drawn yet'}
+                      </div>
                     </div>
                     <div className="row wrap gap-sm">
+                      <button
+                        className="btn btn-outline"
+                        onClick={() => runAndReload(() => drawRandomPosition(event.id))}
+                        disabled={Boolean(event.random_bonus_position)}
+                        title={event.random_bonus_position ? `Random bonus already drawn at ${ordinal(event.random_bonus_position)}.` : 'Draw and persist the random bonus position before the race starts'}
+                      >
+                        {event.random_bonus_position ? `Random ${ordinal(event.random_bonus_position)}` : 'Draw Random'}
+                      </button>
                       <button
                         className="btn btn-outline"
                         onClick={() => runAndReload(() => syncEvent(event.id))}

--- a/apps/f1/client/src/pages/admin/adminApi.js
+++ b/apps/f1/client/src/pages/admin/adminApi.js
@@ -156,6 +156,14 @@ export async function syncEvent(eventId, { force = false } = {}) {
   return parseApiResponse(response, 'Event sync failed');
 }
 
+export async function drawRandomPosition(eventId) {
+  const response = await api(`/admin/results/draw-random-position/${eventId}`, {
+    method: 'POST',
+    body: '{}',
+  });
+  return parseApiResponse(response, 'Random position draw failed');
+}
+
 export async function recalcSeasonBonuses() {
   const response = await api('/admin/results/recalc-season-bonuses', {
     method: 'POST',

--- a/apps/f1/client/src/pages/admin/useAdminData.js
+++ b/apps/f1/client/src/pages/admin/useAdminData.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   clearAllTestData as clearAllTestDataApi,
+  drawRandomPosition as drawRandomPositionApi,
   loadHistoricalSeasonData as loadHistoricalSeasonDataApi,
   normalizeRulesPayload,
   normalizeSettingsPayload,
@@ -110,6 +111,16 @@ export default function useAdminData() {
       await loadAll({ silent: true });
     } catch (error) {
       setMessage(error.message || 'Event sync failed.');
+    }
+  }, [loadAll]);
+
+  const drawRandomPosition = useCallback(async (eventId) => {
+    try {
+      const result = await drawRandomPositionApi(eventId);
+      setMessage(result.message || `Random bonus position set to P${result.randomBonusPosition}.`);
+      await loadAll({ silent: true });
+    } catch (error) {
+      setMessage(error.message || 'Random position draw failed.');
     }
   }, [loadAll]);
 
@@ -249,6 +260,7 @@ export default function useAdminData() {
     restoreSeeded2026Data,
     syncNext,
     syncEvent,
+    drawRandomPosition,
     recalcSeasonBonuses,
     rescoreSeasonEvents,
     updateRules,
@@ -276,6 +288,7 @@ export default function useAdminData() {
     restoreSeeded2026Data,
     syncNext,
     syncEvent,
+    drawRandomPosition,
     recalcSeasonBonuses,
     rescoreSeasonEvents,
     updateRules,

--- a/apps/f1/client/src/pages/admin/useAdminOutletContext.js
+++ b/apps/f1/client/src/pages/admin/useAdminOutletContext.js
@@ -24,6 +24,7 @@ import { useOutletContext } from 'react-router-dom';
  * @property {() => Promise<void>} restoreSeeded2026Data
  * @property {(options?: {force?: boolean}) => Promise<void>} syncNext
  * @property {(eventId: number, options?: {force?: boolean}) => Promise<void>} syncEvent
+ * @property {(eventId: number) => Promise<void>} drawRandomPosition
  * @property {() => Promise<void>} recalcSeasonBonuses
  * @property {() => Promise<void>} rescoreSeasonEvents
  * @property {(group: string, id: number, field: string, value: unknown) => void} updateRules

--- a/apps/f1/server/ai.js
+++ b/apps/f1/server/ai.js
@@ -10,6 +10,139 @@ function getClient() {
   return client;
 }
 
+function dollars(cents) {
+  return Math.round(Number(cents || 0) / 100);
+}
+
+function formatSigned(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 'N/A';
+  return `${num > 0 ? '+' : ''}${num}`;
+}
+
+function determineBriefingPhase({ primaryEvent, liveSession }) {
+  if (liveSession?.isLive || primaryEvent?.isLive) return 'live';
+  if (primaryEvent?.dashboardStatus === 'Next up') return 'pre_race';
+  return 'post_race';
+}
+
+function describeStandingsWindow({ standings, viewerId }) {
+  const rows = Array.isArray(standings) ? standings : [];
+  const index = rows.findIndex((row) => Number(row.id) === Number(viewerId));
+  if (index < 0) return 'Viewer is not currently in the standings table.';
+
+  return rows
+    .slice(Math.max(0, index - 1), Math.min(rows.length, index + 2))
+    .map((row, offset) => {
+      const rank = Math.max(1, index + offset);
+      const net = Number(row.total_earned_cents || 0) - Number(row.total_spent_cents || 0);
+      return `P${rank} ${row.name}: earned ${dollars(row.total_earned_cents)} dollars, spent ${dollars(row.total_spent_cents)} dollars, net ${dollars(net)} dollars, drivers ${Number(row.drivers_owned || 0)}`;
+    })
+    .join('\n');
+}
+
+function describeOwnedDrivers(portfolio) {
+  const drivers = Array.isArray(portfolio?.drivers) ? portfolio.drivers : [];
+  if (!drivers.length) return 'No owned drivers.';
+
+  return drivers
+    .slice(0, 8)
+    .map((driver) => {
+      const live = driver.live || {};
+      const liveParts = [];
+      if (live.position != null) liveParts.push(`P${live.position}`);
+      if (live.positionsGained != null) liveParts.push(`${formatSigned(live.positionsGained)} from grid`);
+      if (live.maxPitStopSeconds != null) liveParts.push(`slowest pit ${Number(live.maxPitStopSeconds).toFixed(2)}s`);
+      return `${driver.driver_name} (${driver.driver_code}) - purchase ${dollars(driver.purchase_price_cents)} dollars, earned ${dollars(driver.total_earnings_cents)} dollars${liveParts.length ? `, live ${liveParts.join(', ')}` : ''}`;
+    })
+    .join('\n');
+}
+
+function describePayoutBoard(payoutBoard) {
+  const rules = Array.isArray(payoutBoard?.rules) ? payoutBoard.rules : [];
+  if (!rules.length) return 'No active payout categories.';
+
+  return rules
+    .slice(0, 10)
+    .map((rule) => {
+      const holders = (rule.holders || []).map((holder) => {
+        const owner = holder.participantName || 'Unowned';
+        const yours = holder.isViewerOwner ? ', viewer-owned' : '';
+        const value = holder.displayValue ? ` (${holder.displayValue})` : '';
+        return `${holder.driverName || holder.driverCode || 'Driver'} for ${owner}${yours}${value}`;
+      });
+      return `${rule.label}: ${rule.status}${holders.length ? ` -> ${holders.join('; ')}` : ''}`;
+    })
+    .join('\n');
+}
+
+function extractJsonBlock(text) {
+  const raw = String(text || '').trim();
+  if (!raw) return null;
+  const match = raw.match(/\{[\s\S]*\}/);
+  return match ? match[0] : raw;
+}
+
+function normalizeSections(sections) {
+  if (!Array.isArray(sections)) return [];
+  return sections
+    .map((section) => ({
+      heading: String(section?.heading || '').trim(),
+      bullets: Array.isArray(section?.bullets)
+        ? section.bullets.map((bullet) => String(bullet || '').trim()).filter(Boolean).slice(0, 4)
+        : [],
+    }))
+    .filter((section) => section.heading || section.bullets.length);
+}
+
+function composeText(summary, sections) {
+  const lines = [String(summary || '').trim()];
+  normalizeSections(sections).forEach((section) => {
+    if (section.heading) lines.push(`${section.heading}:`);
+    section.bullets.forEach((bullet) => lines.push(`- ${bullet}`));
+  });
+  return lines.filter(Boolean).join('\n');
+}
+
+function normalizeBriefingPayload(payload, phase) {
+  const normalizedPhase = String(payload?.phase || phase || 'unknown').trim() || 'unknown';
+  const title = String(payload?.title || '').trim()
+    || (normalizedPhase === 'pre_race' ? 'Pre-race Outlook' : normalizedPhase === 'live' ? 'Live Race Readout' : 'Post-race Recap');
+  const summary = String(payload?.summary || '').trim();
+  const sections = normalizeSections(payload?.sections);
+
+  return {
+    phase: normalizedPhase,
+    title,
+    summary,
+    sections,
+    text: composeText(summary, sections),
+  };
+}
+
+function fallbackBriefingFromText(rawText, phase) {
+  const cleaned = String(rawText || '').trim();
+  return normalizeBriefingPayload({
+    phase,
+    title: phase === 'pre_race' ? 'Pre-race Outlook' : phase === 'live' ? 'Live Race Readout' : 'Post-race Recap',
+    summary: cleaned.split('\n').find(Boolean) || 'Structured briefing unavailable.',
+    sections: [
+      {
+        heading: 'Your Position',
+        bullets: cleaned ? [cleaned] : ['Structured briefing unavailable.'],
+      },
+      {
+        heading: 'Scenarios',
+        bullets: ['If the briefing format is incomplete, use the live payout board and standings to confirm the current swing points.'],
+      },
+      {
+        heading: 'What To Watch',
+        bullets: ['Refresh the briefing again after a meaningful race-state change if you need a cleaner structured readout.'],
+      },
+    ],
+  }, phase);
+}
+
 async function generateDashboardBriefing({
   viewer,
   summary,
@@ -17,6 +150,7 @@ async function generateDashboardBriefing({
   liveSession,
   standings,
   portfolio,
+  payoutBoard,
 }) {
   const anthropic = getClient();
   if (!anthropic) {
@@ -29,59 +163,87 @@ async function generateDashboardBriefing({
     };
   }
 
-  const topStandings = (standings || [])
-    .slice(0, 5)
-    .map((row, index) => {
-      const net = Number(row.total_earned_cents || 0) - Number(row.total_spent_cents || 0);
-      return `${index + 1}. ${row.name}: earned ${Math.round(Number(row.total_earned_cents || 0) / 100)} dollars, net ${Math.round(net / 100)} dollars`;
-    })
-    .join('\n');
+  const phase = determineBriefingPhase({ primaryEvent, liveSession });
+  const phaseTone = phase === 'pre_race'
+    ? 'Sound anticipatory and tactical. Focus on setup, exposure, and what could move during the upcoming race.'
+    : phase === 'live'
+      ? 'Sound urgent and tactical. Focus on live swings, immediate threats, and current leverage.'
+      : 'Sound reflective and outcome-focused. Explain what happened and how it affected the participant.';
 
-  const ownedDrivers = (portfolio?.drivers || [])
-    .slice(0, 6)
-    .map((driver) => {
-      const live = driver.live || {};
-      const liveNote = live.position
-        ? ` currently P${live.position}${live.positionsGained == null ? '' : `, ${live.positionsGained >= 0 ? '+' : ''}${live.positionsGained} from grid`}`
-        : ' not currently classified live';
-      return `${driver.driver_name} (${driver.driver_code})${liveNote}`;
-    })
-    .join('\n');
+  const prompt = `You are writing a structured F1 Calcutta dashboard briefing for one participant in a private pool.
+Return JSON only. No markdown fences.
 
-  const prompt = `You are writing a concise F1 Calcutta dashboard briefing for a participant in a friends-and-family pool.
-Write exactly 3 short sentences.
-Be specific, data-grounded, and useful. No hype, no bullet points, no markdown, no quotes.
+The JSON schema:
+{
+  "phase": "pre_race" | "live" | "post_race",
+  "title": "short heading",
+  "summary": "one short sentence",
+  "sections": [
+    { "heading": "Your Position", "bullets": ["...", "..."] },
+    { "heading": "Scenarios", "bullets": ["If ...", "If ..."] },
+    { "heading": "What To Watch", "bullets": ["...", "..."] }
+  ]
+}
 
-Viewer: ${viewer?.name || 'Participant'}
-Viewer rank: ${summary?.rank ?? 'N/A'}
-Viewer earned: ${Math.round(Number(summary?.totalEarnedCents || 0) / 100)} dollars
-Viewer spent: ${Math.round(Number(summary?.totalSpentCents || 0) / 100)} dollars
-Viewer net: ${Math.round(Number(summary?.netCents || 0) / 100)} dollars
+Requirements:
+- Keep it readable and compact.
+- Use exactly 3 sections in this order: Your Position, Scenarios, What To Watch.
+- Each section must have 2 bullets maximum.
+- Every bullet must be one sentence.
+- The Scenarios section must use explicit scenario language starting with "If".
+- Personalize it to the viewer and connect live/payout context to standings impact.
+- ${phaseTone}
 
-Primary event: ${primaryEvent?.name || 'No event selected'}
-Event state: ${primaryEvent?.dashboardStatus || 'unknown'}
-Event start: ${primaryEvent?.starts_at || 'TBD'}
-Live session: ${liveSession?.isLive ? 'live' : 'not live'}
-Track status: ${liveSession?.trackStatus?.label || liveSession?.statusText || 'N/A'}
+Viewer:
+- Name: ${viewer?.name || 'Participant'}
+- Rank: ${summary?.rank ?? 'N/A'}
+- Earned: ${dollars(summary?.totalEarnedCents)} dollars
+- Spent: ${dollars(summary?.totalSpentCents)} dollars
+- Net: ${dollars(summary?.netCents)} dollars
+
+Primary event:
+- Name: ${primaryEvent?.name || 'No event selected'}
+- Type: ${primaryEvent?.type || 'unknown'}
+- Dashboard status: ${primaryEvent?.dashboardStatus || 'unknown'}
+- Event start: ${primaryEvent?.starts_at || 'TBD'}
+- Briefing phase to use: ${phase}
+
+Live session:
+- Is live: ${liveSession?.isLive ? 'yes' : 'no'}
+- Track status: ${liveSession?.trackStatus?.label || liveSession?.statusText || 'N/A'}
+- Headline: ${liveSession?.headline || 'N/A'}
+
+Standings around viewer:
+${describeStandingsWindow({ standings, viewerId: viewer?.id })}
 
 Owned drivers:
-${ownedDrivers || 'No owned drivers'}
+${describeOwnedDrivers(portfolio)}
 
-Top standings:
-${topStandings || 'No standings available'}
-
-Respond with only the 3-sentence briefing.`;
+Current payout board:
+${describePayoutBoard(payoutBoard)}
+`;
 
   try {
     const message = await anthropic.messages.create({
       model: 'claude-sonnet-4-5-20250929',
-      max_tokens: 220,
+      max_tokens: 500,
       messages: [{ role: 'user', content: prompt }],
     });
 
+    const rawText = String(message.content?.[0]?.text || '').trim();
+    let normalized = null;
+
+    try {
+      const jsonText = extractJsonBlock(rawText);
+      const parsed = jsonText ? JSON.parse(jsonText) : null;
+      normalized = normalizeBriefingPayload(parsed, phase);
+    } catch {
+      normalized = fallbackBriefingFromText(rawText, phase);
+    }
+
     return {
       available: true,
-      text: String(message.content?.[0]?.text || '').trim(),
+      ...normalized,
       generatedAt: new Date().toISOString(),
       source: 'anthropic',
       error: null,
@@ -100,4 +262,6 @@ Respond with only the 3-sentence briefing.`;
 module.exports = {
   getClient,
   generateDashboardBriefing,
+  determineBriefingPhase,
+  normalizeBriefingPayload,
 };

--- a/apps/f1/server/db.js
+++ b/apps/f1/server/db.js
@@ -144,6 +144,10 @@ function getLatestDashboardBriefing(seasonId, participantId) {
   return dashboardBriefingRepo.getLatestDashboardBriefing(db, seasonId, participantId);
 }
 
+function getDashboardBriefingHistory(seasonId, participantId, options) {
+  return dashboardBriefingRepo.getDashboardBriefingHistory(db, seasonId, participantId, options);
+}
+
 function saveDashboardBriefing(seasonId, participantId, payload) {
   return dashboardBriefingRepo.saveDashboardBriefing(db, seasonId, participantId, payload);
 }
@@ -181,6 +185,7 @@ module.exports = {
   getEventPayouts,
   getProviderSyncStates,
   upsertProviderSyncState,
+  getDashboardBriefingHistory,
   getLatestDashboardBriefing,
   saveDashboardBriefing,
 };

--- a/apps/f1/server/persistence/repositories/dashboardBriefingRepo.js
+++ b/apps/f1/server/persistence/repositories/dashboardBriefingRepo.js
@@ -1,29 +1,59 @@
-function getLatestDashboardBriefing(db, seasonId, participantId) {
+function getDashboardBriefingHistory(db, seasonId, participantId, { limit = 12 } = {}) {
   return db.prepare(`
-    SELECT season_id, participant_id, event_id, snapshot_hash, briefing_text, source, generated_at, updated_at
-    FROM dashboard_briefings
-    WHERE season_id = ? AND participant_id = ?
-  `).get(seasonId, participantId) || null;
+    SELECT
+      entry.id,
+      entry.season_id,
+      entry.participant_id,
+      entry.event_id,
+      entry.snapshot_hash,
+      entry.briefing_phase,
+      entry.briefing_title,
+      entry.briefing_summary,
+      entry.briefing_json,
+      entry.source,
+      entry.generated_at,
+      entry.updated_at,
+      event.name AS event_name,
+      event.type AS event_type,
+      event.starts_at AS event_starts_at
+    FROM dashboard_briefing_entries entry
+    LEFT JOIN events event ON event.id = entry.event_id
+    WHERE entry.season_id = ? AND entry.participant_id = ?
+    ORDER BY COALESCE(entry.generated_at, '') DESC, entry.updated_at DESC, entry.id DESC
+    LIMIT ?
+  `).all(seasonId, participantId, Number(limit) || 12);
+}
+
+function getLatestDashboardBriefing(db, seasonId, participantId) {
+  return getDashboardBriefingHistory(db, seasonId, participantId, { limit: 1 })[0] || null;
 }
 
 function saveDashboardBriefing(db, seasonId, participantId, payload) {
   db.prepare(`
-    INSERT INTO dashboard_briefings
-      (season_id, participant_id, event_id, snapshot_hash, briefing_text, source, generated_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(season_id, participant_id) DO UPDATE SET
-      event_id = excluded.event_id,
-      snapshot_hash = excluded.snapshot_hash,
-      briefing_text = excluded.briefing_text,
-      source = excluded.source,
-      generated_at = excluded.generated_at,
-      updated_at = excluded.updated_at
+    INSERT INTO dashboard_briefing_entries
+      (
+        season_id,
+        participant_id,
+        event_id,
+        snapshot_hash,
+        briefing_phase,
+        briefing_title,
+        briefing_summary,
+        briefing_json,
+        source,
+        generated_at,
+        updated_at
+      )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     seasonId,
     participantId,
     payload?.eventId || null,
     String(payload?.snapshotHash || ''),
-    String(payload?.text || ''),
+    String(payload?.phase || 'unknown'),
+    String(payload?.title || ''),
+    String(payload?.summary || ''),
+    JSON.stringify(payload?.content || null),
     String(payload?.source || 'unknown'),
     payload?.generatedAt || null,
     Number(payload?.updatedAt) || Date.now(),
@@ -33,6 +63,7 @@ function saveDashboardBriefing(db, seasonId, participantId, payload) {
 }
 
 module.exports = {
+  getDashboardBriefingHistory,
   getLatestDashboardBriefing,
   saveDashboardBriefing,
 };

--- a/apps/f1/server/persistence/schema.js
+++ b/apps/f1/server/persistence/schema.js
@@ -3,6 +3,113 @@ function columnExists(db, tableName, columnName) {
   return rows.some((row) => row.name === columnName);
 }
 
+function tableExists(db, tableName) {
+  const row = db.prepare(`
+    SELECT name
+    FROM sqlite_master
+    WHERE type = 'table' AND name = ?
+  `).get(tableName);
+  return !!row;
+}
+
+function deriveLegacyBriefingPhase(eventRow, generatedAt) {
+  const generatedMs = Date.parse(generatedAt || '');
+  const startsAtMs = Date.parse(eventRow?.starts_at || '');
+
+  if (Number.isFinite(startsAtMs) && Number.isFinite(generatedMs) && generatedMs < startsAtMs) {
+    return 'pre_race';
+  }
+  if (String(eventRow?.status || '').toLowerCase() === 'scored') {
+    return 'post_race';
+  }
+  return 'live';
+}
+
+function migrateLegacyDashboardBriefings(db) {
+  if (!tableExists(db, 'dashboard_briefings') || !tableExists(db, 'dashboard_briefing_entries')) {
+    return;
+  }
+
+  const legacyRows = db.prepare(`
+    SELECT season_id, participant_id, event_id, snapshot_hash, briefing_text, source, generated_at, updated_at
+    FROM dashboard_briefings
+  `).all();
+
+  if (!legacyRows.length) return;
+
+  const findEvent = db.prepare(`
+    SELECT id, name, status, starts_at
+    FROM events
+    WHERE id = ?
+  `);
+  const insertEntry = db.prepare(`
+    INSERT INTO dashboard_briefing_entries
+      (
+        season_id,
+        participant_id,
+        event_id,
+        snapshot_hash,
+        briefing_phase,
+        briefing_title,
+        briefing_summary,
+        briefing_json,
+        source,
+        generated_at,
+        updated_at
+      )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const findDuplicate = db.prepare(`
+    SELECT id
+    FROM dashboard_briefing_entries
+    WHERE season_id = ?
+      AND participant_id = ?
+      AND COALESCE(event_id, 0) = COALESCE(?, 0)
+      AND snapshot_hash = ?
+      AND COALESCE(generated_at, '') = COALESCE(?, '')
+    LIMIT 1
+  `);
+
+  const transaction = db.transaction((rows) => {
+    rows.forEach((row) => {
+      if (findDuplicate.get(
+        row.season_id,
+        row.participant_id,
+        row.event_id || null,
+        String(row.snapshot_hash || ''),
+        row.generated_at || null,
+      )) {
+        return;
+      }
+
+      const eventRow = row.event_id ? findEvent.get(row.event_id) : null;
+      const phase = deriveLegacyBriefingPhase(eventRow, row.generated_at);
+      const title = eventRow?.name ? `${eventRow.name} Briefing` : 'Saved Dashboard Briefing';
+      const summary = String(row.briefing_text || '').trim();
+      const content = {
+        summary,
+        sections: summary ? [{ heading: 'Saved Briefing', bullets: [summary] }] : [],
+      };
+
+      insertEntry.run(
+        row.season_id,
+        row.participant_id,
+        row.event_id || null,
+        String(row.snapshot_hash || ''),
+        phase,
+        title,
+        summary,
+        JSON.stringify(content),
+        String(row.source || 'legacy'),
+        row.generated_at || null,
+        Number(row.updated_at) || Date.now(),
+      );
+    });
+  });
+
+  transaction(legacyRows);
+}
+
 function ensureSchema(db) {
   db.exec(`
     CREATE TABLE IF NOT EXISTS settings (
@@ -185,6 +292,21 @@ function ensureSchema(db) {
       updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
       PRIMARY KEY (season_id, participant_id)
     );
+
+    CREATE TABLE IF NOT EXISTS dashboard_briefing_entries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      season_id INTEGER NOT NULL REFERENCES seasons(id),
+      participant_id INTEGER NOT NULL REFERENCES participants(id),
+      event_id INTEGER REFERENCES events(id),
+      snapshot_hash TEXT NOT NULL,
+      briefing_phase TEXT NOT NULL,
+      briefing_title TEXT NOT NULL,
+      briefing_summary TEXT NOT NULL,
+      briefing_json TEXT NOT NULL,
+      source TEXT NOT NULL,
+      generated_at TEXT,
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
   `);
 
   if (!columnExists(db, 'seasons', 'payout_model_version')) {
@@ -205,6 +327,8 @@ function ensureSchema(db) {
   if (!columnExists(db, 'event_results', 'slowest_pit_stop_seconds')) {
     db.exec('ALTER TABLE event_results ADD COLUMN slowest_pit_stop_seconds REAL');
   }
+
+  migrateLegacyDashboardBriefings(db);
 }
 
 module.exports = {

--- a/apps/f1/server/routes/admin.js
+++ b/apps/f1/server/routes/admin.js
@@ -158,6 +158,18 @@ router.post('/results/sync-next', withAdmin, async (req, res) => {
   return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
 });
 
+router.post('/results/draw-random-position/:id', withAdmin, (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const eventId = parseIdFromParams(res, req.params.id);
+  if (eventId == null) return undefined;
+
+  const result = resultsAdminService.drawRandomPositionForEvent({
+    seasonId,
+    eventId,
+  });
+  return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
+});
+
 router.get('/results/provider-status', withAdmin, (req, res) => {
   const seasonId = getActiveSeasonId();
   const provider = req.app.get('resultsProvider');

--- a/apps/f1/server/routes/standings.js
+++ b/apps/f1/server/routes/standings.js
@@ -38,6 +38,10 @@ router.get('/dashboard', requireAuth, async (req, res) => {
       seasonId,
       participantId: req.participant.id,
     });
+    payload.briefingHistory = dashboardBriefingService.getBriefingHistory({
+      seasonId,
+      participantId: req.participant.id,
+    });
     return res.json(payload);
   } catch (error) {
     return res.status(502).json({ error: error.message || 'Dashboard data failed to load.' });
@@ -57,9 +61,14 @@ router.post('/dashboard/briefing', requireAuth, async (req, res) => {
       dashboardPayload,
       force: !!req.body?.force,
     });
+    const briefingHistory = dashboardBriefingService.getBriefingHistory({
+      seasonId,
+      participantId: req.participant.id,
+    });
 
     return res.json({
       briefing,
+      briefingHistory,
       briefingMeta: {
         ...dashboardPayload.briefingMeta,
         snapshotHash: briefing.snapshotHash,

--- a/apps/f1/server/services/admin/resultsAdminService.js
+++ b/apps/f1/server/services/admin/resultsAdminService.js
@@ -9,6 +9,7 @@ const {
   upsertProviderSyncState,
 } = require('../../db');
 const {
+  drawEventRandomBonusPosition,
   scoreEvent,
   recalcSeasonBonuses,
   rescoreSeasonEvents,
@@ -163,6 +164,22 @@ function syncEventResults({ seasonId, eventId, provider, io, force = false }) {
     io,
     ignoreLock: force,
   });
+}
+
+function drawRandomPositionForEvent({ seasonId, eventId }) {
+  const result = drawEventRandomBonusPosition({ seasonId, eventId });
+  if (!result.ok) return result;
+
+  const position = Number(result.randomBonusPosition);
+  const message = `Drew random bonus position P${position}.`;
+
+  return {
+    ok: true,
+    randomBonusPosition: position,
+    randomBonusDrawnAt: result.randomBonusDrawnAt,
+    event: result.event,
+    message,
+  };
 }
 
 async function refreshDriversFromProvider({ seasonId, provider }) {
@@ -841,6 +858,7 @@ function getSeasonBonusPayouts({ seasonId }) {
 }
 
 module.exports = {
+  drawRandomPositionForEvent,
   syncNextResults,
   syncEventResults,
   refreshDriversFromProvider,

--- a/apps/f1/server/services/dashboardBriefingService.js
+++ b/apps/f1/server/services/dashboardBriefingService.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const { generateDashboardBriefing } = require('../ai');
 const {
+  getDashboardBriefingHistory,
   getLatestDashboardBriefing,
   saveDashboardBriefing,
 } = require('../db');
@@ -11,10 +12,42 @@ function hashPayload(payload) {
   return crypto.createHash('sha256').update(JSON.stringify(payload || {})).digest('hex');
 }
 
+function phaseLabel(phase) {
+  if (phase === 'pre_race') return 'Pre-race';
+  if (phase === 'live') return 'Live';
+  if (phase === 'post_race') return 'Post-race';
+  return 'Saved';
+}
+
+function normalizeSections(sections) {
+  if (!Array.isArray(sections)) return [];
+  return sections
+    .map((section) => ({
+      heading: String(section?.heading || '').trim(),
+      bullets: Array.isArray(section?.bullets)
+        ? section.bullets.map((bullet) => String(bullet || '').trim()).filter(Boolean).slice(0, 4)
+        : [],
+    }))
+    .filter((section) => section.heading || section.bullets.length);
+}
+
+function composeBriefingText(content) {
+  const summary = String(content?.summary || '').trim();
+  const sectionLines = normalizeSections(content?.sections)
+    .flatMap((section) => [
+      section.heading ? `${section.heading}:` : null,
+      ...section.bullets.map((bullet) => `- ${bullet}`),
+    ])
+    .filter(Boolean);
+
+  return [summary, ...sectionLines].filter(Boolean).join('\n').trim();
+}
+
 function createDashboardBriefingService({
   generator = generateDashboardBriefing,
   ttlMs = DEFAULT_TTL_MS,
   nowImpl = Date.now,
+  loadSavedHistory = getDashboardBriefingHistory,
   loadSavedBriefing = getLatestDashboardBriefing,
   persistBriefing = saveDashboardBriefing,
 } = {}) {
@@ -57,11 +90,26 @@ function createDashboardBriefingService({
               position: driver.position ?? null,
               positionsGained: driver.positionsGained ?? null,
               lastPitStopSeconds: driver.lastPitStopSeconds ?? null,
+              maxPitStopSeconds: driver.maxPitStopSeconds ?? null,
             })),
           }
         : null,
+      payoutBoard: {
+        eventType: dashboardPayload?.payoutBoard?.eventType || null,
+        rules: (dashboardPayload?.payoutBoard?.rules || []).slice(0, 8).map((rule) => ({
+          category: rule.category,
+          status: rule.status,
+          holders: (rule.holders || []).slice(0, 4).map((holder) => ({
+            driverId: holder.driverId ?? null,
+            participantId: holder.participantId ?? null,
+            isViewerOwner: !!holder.isViewerOwner,
+            displayValue: holder.displayValue || null,
+          })),
+        })),
+      },
       standings: (dashboardPayload?.standings || []).slice(0, 8).map((row) => ({
         id: row.id,
+        name: row.name,
         total_earned_cents: row.total_earned_cents,
         total_spent_cents: row.total_spent_cents,
         drivers_owned: row.drivers_owned,
@@ -79,6 +127,7 @@ function createDashboardBriefingService({
                     position: driver.live.position ?? null,
                     positionsGained: driver.live.positionsGained ?? null,
                     lastPitStopSeconds: driver.live.lastPitStopSeconds ?? null,
+                    maxPitStopSeconds: driver.live.maxPitStopSeconds ?? null,
                   }
                 : null,
             })),
@@ -88,10 +137,35 @@ function createDashboardBriefingService({
   }
 
   function normalizeSavedBriefing(row) {
-    if (!row?.briefing_text) return null;
+    if (!row?.briefing_json && !row?.briefing_text) return null;
+    let content = null;
+    try {
+      content = row?.briefing_json ? JSON.parse(row.briefing_json) : null;
+    } catch {
+      content = null;
+    }
+
+    if (!content) {
+      const legacyText = String(row?.briefing_text || '').trim();
+      content = {
+        summary: legacyText,
+        sections: legacyText ? [{ heading: 'Saved Briefing', bullets: [legacyText] }] : [],
+      };
+    }
+
+    const sections = normalizeSections(content.sections);
+    const summary = String(content.summary || row?.briefing_summary || '').trim();
+    const title = String(row?.briefing_title || '').trim() || (row?.event_name ? `${row.event_name} Briefing` : 'Dashboard Briefing');
+
     return {
+      id: row.id || null,
       available: true,
-      text: row.briefing_text,
+      text: composeBriefingText({ summary, sections }),
+      title,
+      summary,
+      sections,
+      phase: row.briefing_phase || 'unknown',
+      phaseLabel: phaseLabel(row.briefing_phase),
       generatedAt: row.generated_at || null,
       source: row.source || 'persisted',
       error: null,
@@ -99,6 +173,9 @@ function createDashboardBriefingService({
       snapshotHash: row.snapshot_hash || '',
       persisted: true,
       eventId: row.event_id || null,
+      eventName: row.event_name || null,
+      eventType: row.event_type || null,
+      eventStartsAt: row.event_starts_at || null,
     };
   }
 
@@ -108,6 +185,12 @@ function createDashboardBriefingService({
 
   function getSavedBriefing({ seasonId, participantId }) {
     return normalizeSavedBriefing(loadSavedBriefing(seasonId, participantId));
+  }
+
+  function getBriefingHistory({ seasonId, participantId, limit = 12 }) {
+    return (loadSavedHistory(seasonId, participantId, { limit }) || [])
+      .map(normalizeSavedBriefing)
+      .filter(Boolean);
   }
 
   async function getBriefing({ dashboardPayload, force = false }) {
@@ -156,14 +239,28 @@ function createDashboardBriefingService({
       liveSession: dashboardPayload?.liveSession || null,
       standings: dashboardPayload?.standings || [],
       portfolio: dashboardPayload?.portfolio || null,
+      payoutBoard: dashboardPayload?.payoutBoard || null,
     });
 
     const value = {
       available: !!briefing?.available,
-      text: briefing?.text || '',
+      id: briefing?.id || null,
+      title: briefing?.title || '',
+      summary: briefing?.summary || '',
+      sections: normalizeSections(briefing?.sections),
+      phase: briefing?.phase || 'unknown',
+      phaseLabel: phaseLabel(briefing?.phase),
+      text: briefing?.text || composeBriefingText({
+        summary: briefing?.summary || '',
+        sections: briefing?.sections || [],
+      }),
       generatedAt: briefing?.generatedAt || null,
       source: briefing?.source || 'unknown',
       error: briefing?.error || null,
+      eventId: dashboardPayload?.primaryEvent?.id || null,
+      eventName: dashboardPayload?.primaryEvent?.name || null,
+      eventType: dashboardPayload?.primaryEvent?.type || null,
+      eventStartsAt: dashboardPayload?.primaryEvent?.starts_at || null,
     };
 
     cache.set(cacheKey, {
@@ -175,7 +272,13 @@ function createDashboardBriefingService({
       persistBriefing(dashboardPayload?.seasonId, dashboardPayload?.viewer?.id, {
         eventId: dashboardPayload?.primaryEvent?.id || null,
         snapshotHash,
-        text: value.text,
+        phase: value.phase,
+        title: value.title,
+        summary: value.summary,
+        content: {
+          summary: value.summary,
+          sections: value.sections,
+        },
         source: value.source,
         generatedAt: value.generatedAt,
         updatedAt: now,
@@ -204,6 +307,7 @@ function createDashboardBriefingService({
   return {
     buildSnapshot,
     getSavedBriefing,
+    getBriefingHistory,
     getBriefing,
     getMeta,
   };

--- a/apps/f1/server/services/dashboardService.js
+++ b/apps/f1/server/services/dashboardService.js
@@ -331,8 +331,13 @@ function buildRuleStatus({ selectionState, liveSession, category, event }) {
 }
 
 function buildRuleNote({ selectionState, liveSession, status, evaluation }) {
+  const targetDisplay = evaluation?.resolution?.metric === 'finish_position'
+    && evaluation?.resolution?.target_value != null
+    ? `Target position: P${evaluation.resolution.target_value}.`
+    : null;
+
   if (status === 'pending') {
-    return 'TBD until live timing data is available.';
+    return targetDisplay || 'TBD until live timing data is available.';
   }
   if (status === 'draw_pending') {
     return 'Random finish target has not been drawn yet.';
@@ -344,9 +349,9 @@ function buildRuleNote({ selectionState, liveSession, status, evaluation }) {
     return 'No active live scoring session.';
   }
   if (!evaluation?.winnerDriverIds?.length) {
-    return 'No current holder yet.';
+    return targetDisplay || 'No current holder yet.';
   }
-  return evaluation?.resolution?.note || null;
+  return evaluation?.resolution?.note || targetDisplay || null;
 }
 
 function buildPayoutBoard({
@@ -392,6 +397,9 @@ function buildPayoutBoard({
       });
 
       if (status !== 'live') {
+        const pendingRandomPosition = rule.category === 'random_finish_bonus'
+          ? getRandomBonusPosition(event)
+          : null;
         return {
           category: rule.category,
           label: rule.label,
@@ -404,8 +412,27 @@ function buildPayoutBoard({
                 value: null,
                 display: 'Pending',
               }
-            : null,
-          note: buildRuleNote({ selectionState, liveSession, status, evaluation: null }),
+            : pendingRandomPosition != null
+              ? {
+                  key: 'finish_position',
+                  value: pendingRandomPosition,
+                  display: `P${pendingRandomPosition}`,
+                }
+              : null,
+          note: buildRuleNote({
+            selectionState,
+            liveSession,
+            status,
+            evaluation: pendingRandomPosition != null
+              ? {
+                  resolution: {
+                    metric: 'finish_position',
+                    target_value: pendingRandomPosition,
+                  },
+                  winnerDriverIds: [],
+                }
+              : null,
+          }),
         };
       }
 

--- a/apps/f1/server/services/scoringService.js
+++ b/apps/f1/server/services/scoringService.js
@@ -36,6 +36,33 @@ function ensureRandomBonusPosition(event) {
   return drawn;
 }
 
+function drawEventRandomBonusPosition({ seasonId, eventId }) {
+  const event = getEventById(seasonId, eventId);
+  if (!event) return { ok: false, status: 404, error: 'Event not found' };
+
+  const existing = Number(event.random_bonus_position);
+  if (existing >= 4 && existing <= 20) {
+    return {
+      ok: false,
+      status: 409,
+      error: `Random bonus position already set to P${existing}.`,
+      randomBonusPosition: existing,
+      randomBonusDrawnAt: event.random_bonus_drawn_at || null,
+      event,
+    };
+  }
+
+  const drawnPosition = ensureRandomBonusPosition(event);
+  const updatedEvent = getEventById(seasonId, eventId);
+
+  return {
+    ok: true,
+    randomBonusPosition: drawnPosition,
+    randomBonusDrawnAt: updatedEvent?.random_bonus_drawn_at || null,
+    event: updatedEvent,
+  };
+}
+
 function scoreEvent({ seasonId, eventId, skipSeasonBonuses = false, ignoreLock = false }) {
   const event = getEventById(seasonId, eventId);
   if (!event) return { ok: false, status: 404, error: 'Event not found' };
@@ -436,6 +463,7 @@ async function syncNextEventFromProvider({
 }
 
 module.exports = {
+  drawEventRandomBonusPosition,
   scoreEvent,
   recalcSeasonBonuses,
   rescoreSeasonEvents,

--- a/apps/f1/server/tests/adminServices.test.js
+++ b/apps/f1/server/tests/adminServices.test.js
@@ -178,6 +178,46 @@ test('results admin refreshDrivers updates seeded drivers without changing ident
   });
 });
 
+test('results admin can pre-draw and preserve an event random bonus position', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const event = db.prepare(`
+    SELECT id, random_bonus_position, random_bonus_drawn_at
+    FROM events
+    WHERE season_id = ?
+    ORDER BY round_number ASC
+    LIMIT 1
+  `).get(seasonId);
+
+  assert.equal(event.random_bonus_position, null);
+  assert.equal(event.random_bonus_drawn_at, null);
+
+  const first = resultsAdminService.drawRandomPositionForEvent({ seasonId, eventId: event.id });
+  assert.equal(first.ok, true);
+  assert.ok(first.randomBonusPosition >= 4 && first.randomBonusPosition <= 20);
+  assert.ok(Number(first.randomBonusDrawnAt) > 0);
+
+  const second = resultsAdminService.drawRandomPositionForEvent({ seasonId, eventId: event.id });
+  assert.equal(second.ok, false);
+  assert.equal(second.status, 409);
+  assert.equal(second.randomBonusPosition, first.randomBonusPosition);
+  assert.equal(second.randomBonusDrawnAt, first.randomBonusDrawnAt);
+  assert.match(second.error, /already set to P/i);
+
+  const stored = db.prepare(`
+    SELECT random_bonus_position, random_bonus_drawn_at
+    FROM events
+    WHERE id = ?
+  `).get(event.id);
+  assert.equal(stored.random_bonus_position, first.randomBonusPosition);
+  assert.equal(stored.random_bonus_drawn_at, first.randomBonusDrawnAt);
+});
+
 test('results admin refreshDrivers rebuilds clean season roster when provider lineup drifts from the seed', async () => {
   const {
     db,

--- a/apps/f1/server/tests/dashboardService.test.js
+++ b/apps/f1/server/tests/dashboardService.test.js
@@ -149,7 +149,18 @@ test('GET /api/standings/dashboard returns participant summary, portfolio, and f
   saveDashboardBriefing(seasonId, alphaId, {
     eventId: event.id,
     snapshotHash: 'persisted-snapshot',
-    text: 'Persistent participant briefing.',
+    phase: 'pre_race',
+    title: 'Pre-race Outlook',
+    summary: 'Persistent participant briefing.',
+    content: {
+      summary: 'Persistent participant briefing.',
+      sections: [
+        {
+          heading: 'Your Position',
+          bullets: ['You enter the weekend with the strongest net in the pool.'],
+        },
+      ],
+    },
     source: 'anthropic',
     generatedAt: '2026-03-07T12:00:00Z',
     updatedAt: Date.parse('2026-03-07T12:00:00Z'),
@@ -176,11 +187,68 @@ test('GET /api/standings/dashboard returns participant summary, portfolio, and f
   assert.equal(payload.liveSession.available, false);
   assert.match(payload.liveSession.degradedReason, /openf1 provider/i);
   assert.equal(payload.briefingMeta.mode, 'on_demand');
-  assert.equal(payload.briefing.text, 'Persistent participant briefing.');
+  assert.equal(payload.briefing.summary, 'Persistent participant briefing.');
+  assert.equal(payload.briefing.phase, 'pre_race');
+  assert.equal(payload.briefingHistory.length, 1);
   assert.ok(payload.primaryEvent);
   assert.ok(Array.isArray(payload.payoutBoard.rules));
   assert.ok(payload.payoutBoard.rules.length > 0);
   assert.equal(Array.isArray(payload.standings), true);
+});
+
+test('GET /api/standings/dashboard returns briefing history most recent first', async () => {
+  const { db, getActiveSeasonId, standingsRoutes, saveDashboardBriefing } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const participantId = createParticipant(db, seasonId, {
+    name: 'History Tester',
+    token: 'history-session',
+    color: '#aa5500',
+  });
+
+  const events = db.prepare('SELECT id FROM events WHERE season_id = ? ORDER BY round_number ASC LIMIT 2').all(seasonId);
+
+  saveDashboardBriefing(seasonId, participantId, {
+    eventId: events[0].id,
+    snapshotHash: 'old-snapshot',
+    phase: 'pre_race',
+    title: 'Older Brief',
+    summary: 'Older saved briefing.',
+    content: {
+      summary: 'Older saved briefing.',
+      sections: [{ heading: 'Your Position', bullets: ['Older item.'] }],
+    },
+    source: 'anthropic',
+    generatedAt: '2026-03-06T10:00:00Z',
+    updatedAt: Date.parse('2026-03-06T10:00:00Z'),
+  });
+  saveDashboardBriefing(seasonId, participantId, {
+    eventId: events[1].id,
+    snapshotHash: 'new-snapshot',
+    phase: 'live',
+    title: 'Newer Brief',
+    summary: 'Newer saved briefing.',
+    content: {
+      summary: 'Newer saved briefing.',
+      sections: [{ heading: 'Your Position', bullets: ['Newer item.'] }],
+    },
+    source: 'anthropic',
+    generatedAt: '2026-03-07T10:00:00Z',
+    updatedAt: Date.parse('2026-03-07T10:00:00Z'),
+  });
+
+  const response = await invokeRoute({
+    router: standingsRoutes,
+    method: 'get',
+    path: '/dashboard',
+    provider: { name: 'mock' },
+    cookies: { session: 'history-session' },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.briefingHistory.length, 2);
+  assert.equal(response.body.briefingHistory[0].summary, 'Newer saved briefing.');
+  assert.equal(response.body.briefingHistory[0].phase, 'live');
+  assert.equal(response.body.briefingHistory[1].summary, 'Older saved briefing.');
 });
 
 test('GET /api/standings/dashboard returns admin summary without portfolio', async () => {
@@ -544,6 +612,39 @@ test('buildDashboardPayload returns pending payout board for upcoming events', a
   assert.ok(payload.payoutBoard.rules.every((rule) => rule.note === 'TBD until live timing data is available.'));
 });
 
+test('buildDashboardPayload shows the pre-drawn random target for upcoming events', async () => {
+  const { db, getActiveSeasonId, dashboardService } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const viewerId = createParticipant(db, seasonId, {
+    name: 'Random Viewer',
+    token: 'random-viewer',
+    color: '#334455',
+  });
+
+  db.prepare(`
+    UPDATE events
+    SET random_bonus_position = 9
+    WHERE season_id = ? AND round_number = 1 AND type = 'grand_prix'
+  `).run(seasonId);
+
+  const payload = await dashboardService.buildDashboardPayload({
+    seasonId,
+    viewer: {
+      id: viewerId,
+      name: 'Random Viewer',
+      color: '#334455',
+      is_admin: 0,
+    },
+    nowImpl: () => Date.parse('2026-03-07T12:00:00Z'),
+    provider: { name: 'mock' },
+  });
+
+  const randomRule = payload.payoutBoard.rules.find((rule) => rule.category === 'random_finish_bonus');
+  assert.equal(randomRule.status, 'pending');
+  assert.equal(randomRule.metric?.display, 'P9');
+  assert.equal(randomRule.note, 'Target position: P9.');
+});
+
 test('buildDashboardPayload marks payout board unavailable when live session load fails', async () => {
   const { db, getActiveSeasonId, dashboardService } = setupDb();
   const seasonId = getActiveSeasonId();
@@ -592,13 +693,21 @@ test('dashboard briefing service caches and refreshes on force', async () => {
   let callCount = 0;
   const service = briefingService.createDashboardBriefingService({
     nowImpl: () => 1000,
+    loadSavedHistory: () => [],
     loadSavedBriefing: () => null,
     persistBriefing: () => null,
     generator: async () => {
       callCount += 1;
       return {
         available: true,
-        text: `briefing-${callCount}`,
+        phase: 'live',
+        title: `Briefing ${callCount}`,
+        summary: `briefing-${callCount}`,
+        sections: [
+          { heading: 'Your Position', bullets: [`Bullet ${callCount}`] },
+          { heading: 'Scenarios', bullets: [`If item ${callCount}`] },
+          { heading: 'What To Watch', bullets: [`Watch ${callCount}`] },
+        ],
         generatedAt: '2026-03-07T00:00:00Z',
         source: 'test',
       };
@@ -619,9 +728,10 @@ test('dashboard briefing service caches and refreshes on force', async () => {
   const second = await service.getBriefing({ dashboardPayload, force: false });
   const third = await service.getBriefing({ dashboardPayload, force: true });
 
-  assert.equal(first.text, 'briefing-1');
-  assert.equal(second.text, 'briefing-1');
+  assert.match(first.text, /briefing-1/);
+  assert.match(second.text, /briefing-1/);
   assert.equal(second.cached, true);
-  assert.equal(third.text, 'briefing-2');
+  assert.match(third.text, /briefing-2/);
+  assert.equal(third.phase, 'live');
   assert.equal(callCount, 2);
 });

--- a/docs/adr/0012-f1-dashboard-briefing-history-and-structured-content.md
+++ b/docs/adr/0012-f1-dashboard-briefing-history-and-structured-content.md
@@ -1,0 +1,76 @@
+# ADR 0012: F1 Dashboard Briefing History And Structured Content
+
+Date: 2026-03-07
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0010 persisted only the latest dashboard briefing per participant. That fixed refresh and login durability, but it left several product gaps:
+
+- participants could not revisit older race-weekend briefings
+- the UI only had a single text blob, which limited readability
+- the system could not label a briefing with race context like pre-race, live, or post-race
+- future briefing modes such as qualifying would have required another persistence redesign
+
+The dashboard briefing is now becoming a reusable participant feature rather than a one-off generated paragraph.
+
+## Decision
+
+Store dashboard briefings as append-only history entries with structured content.
+
+Implementation:
+
+1. Add `dashboard_briefing_entries` as the source-of-truth table
+2. Persist one row per generated briefing instead of overwriting one latest row
+3. Store:
+   - `event_id`
+   - `snapshot_hash`
+   - `briefing_phase`
+   - `briefing_title`
+   - `briefing_summary`
+   - `briefing_json`
+   - `source`
+   - `generated_at`
+   - `updated_at`
+4. Continue returning the latest saved briefing for convenience, but also return briefing history ordered newest-first
+5. Render saved briefings from structured sections in the dashboard UI instead of a single large paragraph
+6. Migrate legacy rows from `dashboard_briefings` into the new history table during schema initialization
+
+## Consequences
+
+Positive:
+
+- participants can navigate prior weekend briefings
+- briefings carry explicit race context like pre-race, live, and post-race
+- the UI can stay readable because the content is sectioned and bullet-based
+- future briefing phases such as qualifying can be added without replacing the storage model
+
+Tradeoffs:
+
+- persistence is more complex than the original single-row model
+- the database now stores more generated content over time
+- prompt design matters more because malformed structured output affects both persistence and rendering
+
+## Rollback / Alternatives
+
+Alternative considered:
+
+- keep one latest briefing row and add a second archive blob column
+
+Rejected because it still couples history shape to one row and does not scale cleanly to multiple weekend entries or future briefing phases.
+
+Rollback:
+
+- stop writing `dashboard_briefing_entries`
+- continue reading only the latest row model
+- collapse the UI back to one saved briefing card
+
+## References
+
+- [dashboardBriefingService.js](/Users/rmilton/Code/Calcutta-App/apps/f1/server/services/dashboardBriefingService.js)
+- [dashboardBriefingRepo.js](/Users/rmilton/Code/Calcutta-App/apps/f1/server/persistence/repositories/dashboardBriefingRepo.js)
+- [schema.js](/Users/rmilton/Code/Calcutta-App/apps/f1/server/persistence/schema.js)
+- [Dashboard.jsx](/Users/rmilton/Code/Calcutta-App/apps/f1/client/src/pages/Dashboard.jsx)


### PR DESCRIPTION
## Summary
- add structured F1 dashboard briefing history with persisted per-event entries and richer AI output
- improve the participant dashboard and payout board with mobile-friendly briefing/history rendering
- add admin pre-draw controls for event random bonus positions and reuse the stored draw during scoring
- update docs and ADRs for the new dashboard briefing storage and admin random-draw workflow

## Verification
- npm run test:f1
- npm run build:f1