### PR TITLE
Update F1 mobile UI and admin flows

### DIFF
--- a/apps/f1/server/providers/openF1ResultsProvider.js
+++ b/apps/f1/server/providers/openF1ResultsProvider.js
@@ -180,6 +180,31 @@ function pickMostRecentRow(rows, fields = ['date', 'date_start', 'date_end']) {
   }, null);
 }
 
+function deriveStartingGridFromPositions(positionRows) {
+  const earliestByDriver = new Map();
+
+  (positionRows || []).forEach((row) => {
+    const driverNumber = Number(row.driver_number);
+    const position = Number(row.position);
+    const rowMs = toTimestampMs(row.date);
+    if (!Number.isFinite(driverNumber) || !Number.isFinite(position) || !Number.isFinite(rowMs)) return;
+
+    const current = earliestByDriver.get(driverNumber);
+    const currentMs = current ? toTimestampMs(current.date) : null;
+    if (!current || !Number.isFinite(currentMs) || rowMs < currentMs) {
+      earliestByDriver.set(driverNumber, row);
+    }
+  });
+
+  return [...earliestByDriver.values()]
+    .map((row) => ({
+      driver_number: Number(row.driver_number),
+      position: Number(row.position),
+    }))
+    .filter((row) => Number.isFinite(row.driver_number) && Number.isFinite(row.position))
+    .sort((a, b) => a.position - b.position);
+}
+
 function normalizeTrackStatus(row) {
   if (!row) return null;
 
@@ -527,9 +552,14 @@ class OpenF1ResultsProvider {
     }
 
     const session = await this.fetchSessionMetadata(sessionKey);
+    const startingGridPromise = this.request('/starting_grid', { session_key: sessionKey }).catch(async (error) => {
+      if (!isNoResultsFoundError(error)) throw error;
+      const positionRows = await this.request('/position', { session_key: sessionKey });
+      return deriveStartingGridFromPositions(positionRows);
+    });
     const [sessionResults, startingGrid, pitStops, roster] = await Promise.all([
       this.request('/session_result', { session_key: sessionKey }),
-      this.request('/starting_grid', { session_key: sessionKey }),
+      startingGridPromise,
       this.request('/pit', { session_key: sessionKey }),
       this.fetchNormalizedDriverRoster(session || { session_key: sessionKey }),
     ]);

--- a/apps/f1/server/tests/openF1ResultsProvider.test.js
+++ b/apps/f1/server/tests/openF1ResultsProvider.test.js
@@ -159,6 +159,85 @@ test('OpenF1ResultsProvider normalizes season schedule and event results', async
   ]);
 });
 
+test('OpenF1ResultsProvider fetchEventResults falls back to earliest position snapshot when starting_grid is unavailable', async () => {
+  const responses = {
+    '/v1/session_result?session_key=9001': [
+      { driver_number: 1, position: 2 },
+      { driver_number: 16, position: 1 },
+    ],
+    '/v1/position?session_key=9001': [
+      { driver_number: 1, position: 4, date: '2026-03-08T03:01:19.220000+00:00' },
+      { driver_number: 16, position: 2, date: '2026-03-08T03:01:19.220000+00:00' },
+      { driver_number: 1, position: 2, date: '2026-03-08T05:01:19.220000+00:00' },
+      { driver_number: 16, position: 1, date: '2026-03-08T05:01:19.220000+00:00' },
+    ],
+    '/v1/pit?session_key=9001': [],
+    '/v1/drivers?session_key=9001': [
+      {
+        driver_number: 1,
+        name_acronym: 'VER',
+        full_name: 'Max Verstappen',
+        team_name: 'Red Bull Racing',
+      },
+      {
+        driver_number: 16,
+        name_acronym: 'LEC',
+        full_name: 'Charles Leclerc',
+        team_name: 'Ferrari',
+      },
+    ],
+  };
+
+  const provider = createNoAuthProvider({
+    fetchImpl: async (url) => {
+      const key = `${url.pathname}${url.search}`;
+      if (key === '/v1/starting_grid?session_key=9001') {
+        return {
+          ok: false,
+          status: 404,
+          async json() {
+            return { detail: 'No results found.' };
+          },
+          headers: { get() { return 'application/json'; } },
+        };
+      }
+
+      return {
+        ok: true,
+        async json() {
+          return responses[key] || [];
+        },
+        headers: { get() { return 'application/json'; } },
+      };
+    },
+  });
+
+  const results = await provider.fetchEventResults({
+    event: { external_event_id: '9001' },
+  });
+
+  assert.deepEqual(results, [
+    {
+      external_driver_id: 16,
+      driver_code: 'LEC',
+      driver_name: 'Charles Leclerc',
+      team_name: 'Ferrari',
+      finish_position: 1,
+      start_position: 2,
+      slowest_pit_stop_seconds: null,
+    },
+    {
+      external_driver_id: 1,
+      driver_code: 'VER',
+      driver_name: 'Max Verstappen',
+      team_name: 'Red Bull Racing',
+      finish_position: 2,
+      start_position: 4,
+      slowest_pit_stop_seconds: null,
+    },
+  ]);
+});
+
 test('OpenF1ResultsProvider fetchDrivers uses the latest started non-testing session, including practice', async () => {
   const responses = {
     '/v1/sessions?year=2026': [


### PR DESCRIPTION
## Summary
- refresh the F1 client site (styles, nav, pages) to align with the new mobile experience
- strengthen admin services (auction, dashboard, auth) plus openF1 results provider and persistence layers
- add documentation updates in HEARTBEAT.md, RUNBOOK.md, and `apps/f1/README.md`

## Testing
- Not run (not requested)