### PR TITLE
Rank F1 standings by net return

### DIFF
--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -13,7 +13,7 @@ A dedicated Formula 1 Calcutta app for a full season pool.
 - Auto-drawn random finishing position bonus per event
 - Grand Prix novelty rule for slowest recorded pit stop via OpenF1 `stop_duration`
 - Season bonus payouts from remaining pool
-- Participant dashboard at `/dashboard` with personal KPIs, full standings, current-or-next race focus, and a live payout-category board driven by OpenF1 timing
+- Participant dashboard at `/dashboard` with personal KPIs, full standings ranked by net return, current-or-next race focus, and a live payout-category board driven by OpenF1 timing
 - On-demand Anthropic briefing on the dashboard with saved per-event history, contextual pre-race/live/post-race labels, and compact structured sections for faster reading
 - Participant mobile UX now uses a compact nav shell, join-first login layout, card-based dashboard/portfolio views, and a list-to-detail event flow instead of relying on wide desktop tables
 - Results sync via provider adapter (`openf1` for real data, `mock` for local/dev/test)

--- a/apps/f1/server/persistence/repositories/standingsRepo.js
+++ b/apps/f1/server/persistence/repositories/standingsRepo.js
@@ -30,7 +30,10 @@ function getStandings(db, seasonId) {
       GROUP BY participant_id
     ) sb_agg ON sb_agg.participant_id = p.id
     WHERE p.is_admin = 0
-    ORDER BY total_earned_cents DESC, total_spent_cents ASC, p.name ASC
+    ORDER BY
+      ((COALESCE(e_agg.total_event_cents, 0) + COALESCE(sb_agg.total_bonus_cents, 0)) - COALESCE(o_agg.total_spent_cents, 0)) DESC,
+      total_earned_cents DESC,
+      p.name ASC
   `).all(seasonId, seasonId, seasonId, seasonId);
 }
 

--- a/apps/f1/server/tests/dashboardService.test.js
+++ b/apps/f1/server/tests/dashboardService.test.js
@@ -283,6 +283,55 @@ test('GET /api/standings/dashboard returns admin summary without portfolio', asy
   assert.equal(typeof payload.summary.totalPotCents, 'number');
 });
 
+test('GET /api/standings/dashboard ranks participants by net return first', async () => {
+  const { db, getActiveSeasonId, standingsRoutes } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const alphaId = createParticipant(db, seasonId, {
+    name: 'Alpha',
+    token: 'alpha-net-session',
+    color: '#ff0000',
+  });
+  const bravoId = createParticipant(db, seasonId, {
+    name: 'Bravo',
+    token: 'bravo-net-session',
+    color: '#00ff00',
+  });
+
+  const drivers = db.prepare('SELECT id FROM drivers WHERE season_id = ? ORDER BY id ASC LIMIT 2').all(seasonId);
+  const event = db.prepare('SELECT id FROM events WHERE season_id = ? ORDER BY round_number ASC LIMIT 1').get(seasonId);
+
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, drivers[0].id, alphaId, 2000);
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, drivers[1].id, bravoId, 500);
+
+  db.prepare(`
+    INSERT INTO event_payouts (season_id, event_id, participant_id, driver_id, category, amount_cents)
+    VALUES (?, ?, ?, ?, 'race_winner', ?)
+  `).run(seasonId, event.id, alphaId, drivers[0].id, 1500);
+  db.prepare(`
+    INSERT INTO event_payouts (season_id, event_id, participant_id, driver_id, category, amount_cents)
+    VALUES (?, ?, ?, ?, 'second_place', ?)
+  `).run(seasonId, event.id, bravoId, drivers[1].id, 1000);
+
+  const response = await invokeRoute({
+    router: standingsRoutes,
+    method: 'get',
+    path: '/dashboard',
+    provider: { name: 'mock' },
+    cookies: { session: 'alpha-net-session' },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.standings[0].name, 'Bravo');
+  assert.equal(response.body.standings[1].name, 'Alpha');
+  assert.equal(response.body.summary.rank, 2);
+});
+
 test('POST /api/standings/dashboard/briefing degrades cleanly when Anthropic is unavailable', async () => {
   const previousAnthropicKey = process.env.ANTHROPIC_API_KEY;
   delete process.env.ANTHROPIC_API_KEY;


### PR DESCRIPTION
## Summary
- change F1 participant standings to rank by net return instead of gross earnings
- keep total earnings as the first tie-breaker and name as the final tie-breaker
- add a dashboard regression test covering the net-first ranking behavior
- update the F1 README to describe the standings rule

## Verification
- npm run test:f1
- npm run build:f1