### PR TITLE
Adjust F1 standings and bonus controls

### DIFF
--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -13,6 +13,7 @@ A dedicated Formula 1 Calcutta app for a full season pool.
 - Auto-drawn random finishing position bonus per event
 - Grand Prix novelty rule for slowest recorded pit stop via OpenF1 `stop_duration`
 - Season bonus payouts from remaining pool
+- Season bonus payouts are withheld until all scoring events in the season are complete, then calculated from full-season data
 - Participant dashboard at `/dashboard` with personal KPIs, full standings ranked by net return, current-or-next race focus, and a live payout-category board driven by OpenF1 timing
 - On-demand Anthropic briefing on the dashboard with saved per-event history, contextual pre-race/live/post-race labels, and compact structured sections for faster reading
 - Participant mobile UX now uses a compact nav shell, join-first login layout, card-based dashboard/portfolio views, and a list-to-detail event flow instead of relying on wide desktop tables

--- a/apps/f1/client/src/pages/admin/TestDataPage.jsx
+++ b/apps/f1/client/src/pages/admin/TestDataPage.jsx
@@ -41,6 +41,7 @@ export default function TestDataPage() {
   const {
     events,
     recalcSeasonBonuses,
+    clearSeasonBonuses,
     rescoreSeasonEvents,
     clearAllTestData,
     resetAuctionOnly,
@@ -445,16 +446,29 @@ export default function TestDataPage() {
       <section className="panel stack">
         <div className="row between wrap gap-sm">
           <h2>Season Bonus Payouts</h2>
-          <button
-            className="btn btn-outline"
-            onClick={async () => {
-              await recalcSeasonBonuses();
-              await refresh();
-              await loadSeasonBonusBreakdown();
-            }}
-          >
-            Recalculate Season Bonuses
-          </button>
+          <div className="row wrap gap-sm">
+            <button
+              className="btn btn-outline"
+              onClick={async () => {
+                if (!window.confirm('Clear all saved season bonus payouts for the active season?')) return;
+                await clearSeasonBonuses();
+                await refresh();
+                await loadSeasonBonusBreakdown();
+              }}
+            >
+              Clear Season Bonuses
+            </button>
+            <button
+              className="btn btn-outline"
+              onClick={async () => {
+                await recalcSeasonBonuses();
+                await refresh();
+                await loadSeasonBonusBreakdown();
+              }}
+            >
+              Recalculate Season Bonuses
+            </button>
+          </div>
         </div>
         {bonusLoading ? <p className="muted">Loading season bonus payouts...</p> : null}
         {!bonusLoading && bonusTotals.length ? (

--- a/apps/f1/client/src/pages/admin/adminApi.js
+++ b/apps/f1/client/src/pages/admin/adminApi.js
@@ -172,6 +172,14 @@ export async function recalcSeasonBonuses() {
   return parseApiResponse(response, 'Recalculation failed');
 }
 
+export async function clearSeasonBonuses() {
+  const response = await api('/admin/results/clear-season-bonuses', {
+    method: 'POST',
+    body: '{}',
+  });
+  return parseApiResponse(response, 'Clear season bonuses failed');
+}
+
 export async function rescoreSeasonEvents() {
   const response = await api('/admin/results/rescore-season-events', {
     method: 'POST',

--- a/apps/f1/client/src/pages/admin/useAdminData.js
+++ b/apps/f1/client/src/pages/admin/useAdminData.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  clearSeasonBonuses as clearSeasonBonusesApi,
   clearAllTestData as clearAllTestDataApi,
   drawRandomPosition as drawRandomPositionApi,
   loadHistoricalSeasonData as loadHistoricalSeasonDataApi,
@@ -157,11 +158,21 @@ export default function useAdminData() {
 
   const recalcSeasonBonuses = useCallback(async () => {
     try {
-      await recalcSeasonBonusesApi();
-      setMessage('Season bonuses recalculated.');
+      const result = await recalcSeasonBonusesApi();
+      setMessage(result.message || 'Season bonuses recalculated.');
       await loadAll({ silent: true });
     } catch (error) {
       setMessage(error.message || 'Recalculation failed.');
+    }
+  }, [loadAll]);
+
+  const clearSeasonBonuses = useCallback(async () => {
+    try {
+      const result = await clearSeasonBonusesApi();
+      setMessage(result.message || 'Season bonuses cleared.');
+      await loadAll({ silent: true });
+    } catch (error) {
+      setMessage(error.message || 'Failed to clear season bonuses.');
     }
   }, [loadAll]);
 
@@ -262,6 +273,7 @@ export default function useAdminData() {
     syncEvent,
     drawRandomPosition,
     recalcSeasonBonuses,
+    clearSeasonBonuses,
     rescoreSeasonEvents,
     updateRules,
     saveRules,
@@ -290,6 +302,7 @@ export default function useAdminData() {
     syncEvent,
     drawRandomPosition,
     recalcSeasonBonuses,
+    clearSeasonBonuses,
     rescoreSeasonEvents,
     updateRules,
     saveRules,

--- a/apps/f1/server/routes/admin.js
+++ b/apps/f1/server/routes/admin.js
@@ -361,6 +361,15 @@ router.post('/results/recalc-season-bonuses', withAdmin, (req, res) => {
   return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
 });
 
+router.post('/results/clear-season-bonuses', withAdmin, (req, res) => {
+  const seasonId = getActiveSeasonId();
+  const result = resultsAdminService.clearSeasonBonusesForSeason({
+    seasonId,
+    io: req.app.get('io'),
+  });
+  return runAndRespond(res, result, (payload) => ({ ok: true, ...payload }));
+});
+
 router.post('/results/rescore-season-events', withAdmin, (req, res) => {
   const seasonId = getActiveSeasonId();
   const result = resultsAdminService.rescoreSeasonEventsForSeason({

--- a/apps/f1/server/services/admin/resultsAdminService.js
+++ b/apps/f1/server/services/admin/resultsAdminService.js
@@ -826,6 +826,22 @@ function recalcSeasonBonusesForSeason({ seasonId, io }) {
   return { ok: true, ...result };
 }
 
+function clearSeasonBonusesForSeason({ seasonId, io }) {
+  const deletedCount = db.prepare(`
+    DELETE FROM season_bonus_payouts
+    WHERE season_id = ?
+  `).run(seasonId).changes;
+
+  io?.emit('standings:update');
+  return {
+    ok: true,
+    deletedCount,
+    message: deletedCount
+      ? `Cleared ${deletedCount} season bonus payout${deletedCount === 1 ? '' : 's'}.`
+      : 'No season bonus payouts were present to clear.',
+  };
+}
+
 function rescoreSeasonEventsForSeason({ seasonId, io }) {
   const result = rescoreSeasonEvents({ seasonId });
   if (!result.ok) return result;
@@ -872,6 +888,7 @@ module.exports = {
   getEventEditorData,
   saveManualResultsAndScore,
   recalcSeasonBonusesForSeason,
+  clearSeasonBonusesForSeason,
   rescoreSeasonEventsForSeason,
   getSeasonBonusPayouts,
 };

--- a/apps/f1/server/services/scoringService.js
+++ b/apps/f1/server/services/scoringService.js
@@ -186,6 +186,21 @@ function getSeasonRandomBonusPosition(seasonId, standingsCount) {
   return drawn;
 }
 
+function isSeasonBonusReady(seasonId) {
+  const scoringEventCounts = db.prepare(`
+    SELECT
+      COUNT(*) as scoring_event_count,
+      SUM(CASE WHEN status = 'scored' THEN 1 ELSE 0 END) as scored_event_count
+    FROM events
+    WHERE season_id = ?
+      AND type IN ('grand_prix', 'sprint')
+  `).get(seasonId);
+
+  const total = Number(scoringEventCounts?.scoring_event_count || 0);
+  const scored = Number(scoringEventCounts?.scored_event_count || 0);
+  return total > 0 && total === scored;
+}
+
 function resolveSeasonBonusWinners(category, seasonId, context) {
   const { rows, standings } = context;
 
@@ -237,6 +252,9 @@ function recalcSeasonBonuses({ seasonId }) {
 
   db.prepare('DELETE FROM season_bonus_payouts WHERE season_id = ?').run(seasonId);
   if (!rules.length) return { ok: true, distributedCents: 0 };
+  if (!isSeasonBonusReady(seasonId)) {
+    return { ok: true, distributedCents: 0, skippedUntilSeasonEnd: true };
+  }
 
   const totalPot = getTotalPotCents(seasonId);
   if (totalPot <= 0) return { ok: true, distributedCents: 0 };
@@ -470,4 +488,5 @@ module.exports = {
   upsertEventResults,
   syncEventFromProvider,
   syncNextEventFromProvider,
+  isSeasonBonusReady,
 };

--- a/apps/f1/server/tests/adminServices.test.js
+++ b/apps/f1/server/tests/adminServices.test.js
@@ -1114,6 +1114,46 @@ test('results admin rescoreSeasonEventsForSeason rewrites scored event payouts u
   assert.equal(newPayout.amount_cents, 3);
 });
 
+test('results admin clearSeasonBonusesForSeason removes only season bonus payouts', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    resultsAdminService,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const participantId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('Season Bonus Clear Tester', '#ffaa00', 'season-bonus-clear-token')
+  `).run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+  const driver = db.prepare('SELECT id FROM drivers WHERE season_id = ? ORDER BY id ASC LIMIT 1').get(seasonId);
+  const event = db.prepare('SELECT id FROM events WHERE season_id = ? ORDER BY round_number ASC LIMIT 1').get(seasonId);
+
+  db.prepare(`
+    INSERT INTO event_payouts
+      (season_id, event_id, participant_id, driver_id, category, amount_cents, tie_count)
+    VALUES (?, ?, ?, ?, 'race_winner', 321, 1)
+  `).run(seasonId, event.id, participantId, driver.id);
+  db.prepare(`
+    INSERT INTO season_bonus_payouts
+      (season_id, participant_id, driver_id, category, amount_cents, tie_count)
+    VALUES (?, ?, ?, 'drivers_champion', 654, 1)
+  `).run(seasonId, participantId, driver.id);
+
+  const emitted = [];
+  const result = resultsAdminService.clearSeasonBonusesForSeason({
+    seasonId,
+    io: { emit: (eventName) => emitted.push(eventName) },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.deletedCount, 1);
+  assert.ok(emitted.includes('standings:update'));
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM season_bonus_payouts WHERE season_id = ?').get(seasonId).c, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) as c FROM event_payouts WHERE season_id = ?').get(seasonId).c, 1);
+});
+
 test('payout rules admin save triggers bonus recalc path and standings update emit', () => {
   const {
     db,

--- a/apps/f1/server/tests/scoringService.test.js
+++ b/apps/f1/server/tests/scoringService.test.js
@@ -567,6 +567,14 @@ test('season bonus winners and allocations follow payout model v2', () => {
   assert.equal(scoreEvent({ seasonId, eventId: gp2.id }).ok, true);
 
   db.prepare(`
+    UPDATE events
+    SET status = 'scored'
+    WHERE season_id = ?
+      AND type IN ('grand_prix', 'sprint')
+      AND id NOT IN (?, ?, ?)
+  `).run(seasonId, gp1.id, sprint1.id, gp2.id);
+
+  db.prepare(`
     UPDATE seasons
     SET season_random_bonus_position = ?, season_random_bonus_drawn_at = ?
     WHERE id = ?
@@ -601,6 +609,58 @@ test('season bonus winners and allocations follow payout model v2', () => {
   `).get(seasonId);
   assert.equal(season.season_random_bonus_position, 5);
   assert.equal(season.season_random_bonus_drawn_at, 1234567890);
+});
+
+test('season bonuses stay empty until every scoring event in the season is scored', () => {
+  const {
+    db,
+    getActiveSeasonId,
+    upsertEventResults,
+    scoreEvent,
+  } = setupDb();
+
+  const seasonId = getActiveSeasonId();
+  const [driver] = db.prepare(`
+    SELECT id, external_id
+    FROM drivers
+    WHERE season_id = ?
+    ORDER BY external_id ASC
+    LIMIT 1
+  `).all(seasonId);
+  const participantId = db.prepare(`
+    INSERT INTO participants (name, color, session_token)
+    VALUES ('Season Bonus Gate Tester', '#112233', 'season-bonus-gate-token')
+  `).run().lastInsertRowid;
+  db.prepare('INSERT INTO season_participants (season_id, participant_id) VALUES (?, ?)').run(seasonId, participantId);
+  db.prepare(`
+    INSERT INTO ownership (season_id, driver_id, participant_id, purchase_price_cents)
+    VALUES (?, ?, ?, ?)
+  `).run(seasonId, driver.id, participantId, 10000);
+
+  const gpEvent = db.prepare(`
+    SELECT id
+    FROM events
+    WHERE season_id = ? AND type = 'grand_prix'
+    ORDER BY round_number ASC
+    LIMIT 1
+  `).get(seasonId);
+  db.prepare('UPDATE events SET lock_at = ? WHERE id = ?').run('2000-01-01T00:00:00Z', gpEvent.id);
+
+  upsertEventResults({
+    seasonId,
+    eventId: gpEvent.id,
+    rows: [{ external_driver_id: driver.external_id, finish_position: 1, start_position: 3 }],
+  });
+
+  const score = scoreEvent({ seasonId, eventId: gpEvent.id });
+  assert.equal(score.ok, true);
+
+  const bonusCount = db.prepare(`
+    SELECT COUNT(*) as c
+    FROM season_bonus_payouts
+    WHERE season_id = ?
+  `).get(seasonId).c;
+  assert.equal(bonusCount, 0);
 });
 
 test('v2 migration normalizes rules and gp random draws for active season', () => {

--- a/docs/adr/0013-f1-season-bonuses-score-only-after-season-complete.md
+++ b/docs/adr/0013-f1-season-bonuses-score-only-after-season-complete.md
@@ -1,0 +1,62 @@
+# ADR 0013: F1 Season Bonuses Score Only After Season Complete
+
+Date: 2026-03-08
+
+## Status
+
+Accepted
+
+## Context
+
+The F1 scoring service recalculated `season_bonus_payouts` every time any event was scored. That made season bonus money appear in participant standings mid-season even though the categories are defined as full-season awards such as:
+
+- Drivers Champion
+- Most Race Wins
+- Most Top-10 Finishes Outside Top 4
+- Random Finishing Position Bonus
+- Biggest Single-Race Climb
+
+Those categories should reflect the complete season, not an in-progress partial season snapshot.
+
+## Decision
+
+Gate season bonus payout calculation behind full scoring completion for the season.
+
+Implementation:
+
+1. Keep event payout scoring unchanged
+2. Delete and recompute `season_bonus_payouts` only when every scoring event in the active season is marked `scored`
+3. If the season is not complete, keep `season_bonus_payouts` empty
+4. Continue using the same full-season metric logic once the season is complete
+
+## Consequences
+
+Positive:
+
+- standings no longer overstate participant earnings mid-season
+- season bonus categories now match their intended semantics
+- payout timing is easier to explain to participants
+
+Tradeoffs:
+
+- admin/test flows that previously showed provisional season bonus payouts no longer do so
+- local/dev databases with old bonus payouts may need cleanup or rescoring to match the new rule
+
+## Rollback / Alternatives
+
+Alternative considered:
+
+- keep mid-season provisional season bonus payouts and label them as provisional
+
+Rejected because payouts are used directly in standings, and provisional payouts create misleading earnings totals during the season.
+
+Rollback:
+
+- remove the season-complete gate
+- return to recalculating `season_bonus_payouts` after every scored event
+
+## References
+
+- [scoringService.js](/Users/rmilton/Code/Calcutta-App/apps/f1/server/services/scoringService.js)
+- [standingsRepo.js](/Users/rmilton/Code/Calcutta-App/apps/f1/server/persistence/repositories/standingsRepo.js)
+- [scoringService.test.js](/Users/rmilton/Code/Calcutta-App/apps/f1/server/tests/scoringService.test.js)


### PR DESCRIPTION
Summary
- align F1 standings earned amounts with actual payouts by reworking backend calculations and ensuring season bonus logic waits for final race data
- refresh admin and client pages plus shared docs to expose a new clear season bonuses button and reflect the new scoring/bonus behavior
- update documentation and suite guidance (HEARTBEAT, RUNBOOK, README, ADR) to match the new operational details

Testing
- Not run (not requested)