### PR TITLE
Add live timing pit stop data integration for F1 standings

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -1,6 +1,6 @@
 # HEARTBEAT.md
 
-Last updated: 2026-03-07
+Last updated: 2026-03-08
 Owner: On-call engineer / active implementer
 
 ## Status At A Glance
@@ -28,6 +28,7 @@ Owner: On-call engineer / active implementer
 - F1 driver refresh now pulls the latest started non-testing session roster and falls back from `session_key` to `meeting_key` roster lookups when a live session weekend has started but the session-level roster is not populated yet.
 - F1 event sync now preserves unknown substitute/new race drivers as inactive, non-auction season drivers so event scoring can mark their payouts as unowned instead of dropping their result rows.
 - F1 OpenF1 access now rate-limits outbound provider calls against both short-burst and rolling minute windows to reduce `429` failures during admin refresh/sync operations.
+- F1 event sync now enriches slowest pit-stop scoring from Formula 1 LiveTiming `PitStopSeries.json`, using the season `Index.json` to resolve race/sprint session paths and falling back to OpenF1 `stop_duration` only when the static feed is unavailable.
 - F1 Results Sync now exposes a DB backup/export path and a visible driver-roster freeze guard once auction or scoring activity exists.
 - F1 now has an explicit season roster lock setting in admin so post-auction driver refresh policy is visible and deliberate.
 - F1 participant navigation now centers on `/dashboard`, which combines personal standings, full league standings, and current-or-next scoring-session race context.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -94,6 +94,7 @@ After deploy:
 5. If OpenF1 returns `429`, wait briefly and retry; the F1 provider now serializes requests, spaces them, retries boundedly, and enforces a rolling minute budget, but repeated manual clicks can still queue work and extend refresh latency.
 6. If provider responses are incomplete or unmapped, use manual results entry and do not force-score partial provider data.
 7. Schedule refresh is now durable across restart/deploy cycles; if dates drift again, inspect the stored event rows and provider sync state instead of assuming startup reseeding will correct them.
+8. Slowest pit stop scoring now prefers Formula 1 LiveTiming `PitStopSeries.json` resolved from the season `Index.json`; if that static feed is missing for a session, the app falls back to OpenF1 `stop_duration`, and manual override is still the last-resort recovery path.
 
 ### E) F1 Participant Login / Access Recovery
 

--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -11,7 +11,7 @@ A dedicated Formula 1 Calcutta app for a full season pool.
 - Event-by-event payouts using percentage-of-pool rules
 - Grand Prix and Sprint scoring categories
 - Auto-drawn random finishing position bonus per event
-- Grand Prix novelty rule for slowest recorded pit stop via OpenF1 `stop_duration`
+- Grand Prix novelty rule for slowest recorded pit stop via Formula 1 LiveTiming `PitStopTime`, with OpenF1 `stop_duration` as backup
 - Season bonus payouts from remaining pool
 - Season bonus payouts are withheld until all scoring events in the season are complete, then calculated from full-season data
 - Participant dashboard at `/dashboard` with personal KPIs, full standings ranked by net return, current-or-next race focus, and a live payout-category board driven by OpenF1 timing
@@ -54,6 +54,7 @@ Server: `http://localhost:3002`
   - `OPENF1_USERNAME`
 - `OPENF1_PASSWORD`
 - optional token override: `OPENF1_TOKEN_URL`
+- optional Formula 1 LiveTiming static base override: `F1_LIVETIMING_BASE_URL`
 - optional AI briefing key: `ANTHROPIC_API_KEY`
 - Driver refresh now uses the latest started non-testing OpenF1 session roster and falls back from session_key to meeting_key lookups when a live session roster is not yet populated; if 2026 weekend data is still unavailable, admin will see a clear "no populated driver roster yet" message instead of a raw provider 404
 - Event result sync now preserves unknown substitute/new race drivers by inserting them as inactive season drivers with no auction item; their results still score, but any resulting payouts remain unowned/undistributed unless an owner exists
@@ -61,6 +62,7 @@ Server: `http://localhost:3002`
 - If the active season has no bids, ownership, or scored race data yet, driver refresh can now rebuild the season roster directly from OpenF1 when the provider lineup has drifted from the seeded 2026 driver list
 - Startup seeding now treats the 2026 event list as bootstrap-only data: provider-refreshed schedule rows survive restart/deploy cycles, while still-mock rows can still be repaired from the canonical seed list
 - OpenF1 requests are now serialized, spaced, bounded-retried on `429`, and limited against a rolling per-minute budget to match the provider's published rate limits more closely
+- Event result sync now enriches stopped pit duration from Formula 1 LiveTiming `Index.json` + `PitStopSeries.json`; if that static feed is unavailable, the app falls back to OpenF1 `stop_duration`, and manual override remains available if both sources are missing
 - Optional auto-poll:
   - `F1_AUTO_POLL_ENABLED=1`
   - `F1_AUTO_POLL_INTERVAL_SECONDS=<seconds>`

--- a/apps/f1/server/providers/index.js
+++ b/apps/f1/server/providers/index.js
@@ -19,6 +19,7 @@ function createResultsProvider() {
   if (provider === 'openf1') {
     return new OpenF1ResultsProvider({
       baseUrl: process.env.OPENF1_BASE_URL,
+      liveTimingBaseUrl: process.env.F1_LIVETIMING_BASE_URL,
       tokenUrl: process.env.OPENF1_TOKEN_URL,
       username: process.env.OPENF1_USERNAME,
       password: process.env.OPENF1_PASSWORD,

--- a/apps/f1/server/providers/openF1ResultsProvider.js
+++ b/apps/f1/server/providers/openF1ResultsProvider.js
@@ -1,9 +1,11 @@
 const DEFAULT_BASE_URL = 'https://api.openf1.org/v1';
+const DEFAULT_LIVETIMING_BASE_URL = 'https://livetiming.formula1.com/static';
 const DEFAULT_TOKEN_PATH = '/token';
 const DEFAULT_MIN_REQUEST_INTERVAL_MS = 200;
 const DEFAULT_MINUTE_WINDOW_MS = 60_000;
 const DEFAULT_MAX_REQUESTS_PER_MINUTE = 60;
 const DEFAULT_MAX_RATE_LIMIT_RETRIES = 3;
+const DEFAULT_LIVETIMING_INDEX_CACHE_MS = 5 * 60_000;
 const EVENT_NAME_OVERRIDES = {
   melbourne: 'Australian Grand Prix',
   shanghai: 'Chinese Grand Prix',
@@ -38,6 +40,10 @@ const EVENT_NAME_OVERRIDES = {
 
 function normalizeBaseUrl(baseUrl) {
   return String(baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '');
+}
+
+function normalizeLiveTimingBaseUrl(baseUrl) {
+  return String(baseUrl || DEFAULT_LIVETIMING_BASE_URL).replace(/\/+$/, '');
 }
 
 function deriveTokenUrl(baseUrl, explicitTokenUrl) {
@@ -222,9 +228,35 @@ function normalizeTrackStatus(row) {
   };
 }
 
+function parseLiveTimingPitStopSeries(payload) {
+  const slowestPitByDriver = new Map();
+  const pitTimes = payload?.PitTimes;
+  if (!pitTimes || typeof pitTimes !== 'object') {
+    return slowestPitByDriver;
+  }
+
+  Object.values(pitTimes).forEach((entryGroup) => {
+    const entries = Array.isArray(entryGroup) ? entryGroup : [entryGroup].filter(Boolean);
+    entries.forEach((entry) => {
+      const pitStop = entry?.PitStop || entry || {};
+      const driverNumber = Number(pitStop.RacingNumber ?? pitStop.driver_number);
+      const pitStopTime = Number(pitStop.PitStopTime ?? pitStop.pit_stop_time);
+      if (!Number.isFinite(driverNumber) || !Number.isFinite(pitStopTime) || pitStopTime <= 0) return;
+
+      const current = slowestPitByDriver.get(driverNumber);
+      if (current == null || pitStopTime > current) {
+        slowestPitByDriver.set(driverNumber, pitStopTime);
+      }
+    });
+  });
+
+  return slowestPitByDriver;
+}
+
 class OpenF1ResultsProvider {
   constructor({
     baseUrl = DEFAULT_BASE_URL,
+    liveTimingBaseUrl = process.env.F1_LIVETIMING_BASE_URL,
     tokenUrl,
     username = process.env.OPENF1_USERNAME,
     password = process.env.OPENF1_PASSWORD,
@@ -235,9 +267,11 @@ class OpenF1ResultsProvider {
     minuteWindowMs = DEFAULT_MINUTE_WINDOW_MS,
     maxRequestsPerMinute = DEFAULT_MAX_REQUESTS_PER_MINUTE,
     maxRateLimitRetries = DEFAULT_MAX_RATE_LIMIT_RETRIES,
+    liveTimingIndexCacheMs = DEFAULT_LIVETIMING_INDEX_CACHE_MS,
   } = {}) {
     this.name = 'openf1';
     this.baseUrl = normalizeBaseUrl(baseUrl);
+    this.liveTimingBaseUrl = normalizeLiveTimingBaseUrl(liveTimingBaseUrl);
     this.tokenUrl = deriveTokenUrl(baseUrl, tokenUrl || process.env.OPENF1_TOKEN_URL);
     this.username = username;
     this.password = password;
@@ -248,12 +282,14 @@ class OpenF1ResultsProvider {
     this.minuteWindowMs = minuteWindowMs;
     this.maxRequestsPerMinute = maxRequestsPerMinute;
     this.maxRateLimitRetries = maxRateLimitRetries;
+    this.liveTimingIndexCacheMs = liveTimingIndexCacheMs;
     this.accessToken = null;
     this.accessTokenExpiresAt = 0;
     this.tokenPromise = null;
     this.nextRequestAt = 0;
     this.requestTimestamps = [];
     this.requestQueue = Promise.resolve();
+    this.liveTimingIndexCache = new Map();
   }
 
   get authConfigured() {
@@ -426,6 +462,88 @@ class OpenF1ResultsProvider {
     return this.enqueueRequest(() => this.performRequest(path, params, options));
   }
 
+  async requestJsonUrl(url) {
+    if (typeof this.fetchImpl !== 'function') {
+      throw new Error('Fetch is unavailable in this runtime');
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+    try {
+      const response = await this.fetchImpl(url, {
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const detail = await parseErrorDetail(response);
+        throw new Error(detail
+          ? `Formula 1 LiveTiming request failed (${response.status}): ${detail}`
+          : `Formula 1 LiveTiming request failed (${response.status})`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      if (error?.name === 'AbortError') {
+        throw new Error('Formula 1 LiveTiming request timed out');
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  async fetchLiveTimingIndex({ year }) {
+    const key = Number(year);
+    const now = this.nowImpl();
+    const cached = this.liveTimingIndexCache.get(key);
+    if (cached && (now - cached.fetchedAt) < this.liveTimingIndexCacheMs) {
+      return cached.data;
+    }
+
+    const url = `${this.liveTimingBaseUrl}/${key}/Index.json`;
+    const data = await this.requestJsonUrl(url);
+    this.liveTimingIndexCache.set(key, { fetchedAt: now, data });
+    return data;
+  }
+
+  async findLiveTimingSessionPath({ year, sessionKey }) {
+    const index = await this.fetchLiveTimingIndex({ year });
+    const meetings = Array.isArray(index?.Meetings) ? index.Meetings : [];
+
+    for (const meeting of meetings) {
+      const sessions = Array.isArray(meeting?.Sessions) ? meeting.Sessions : [];
+      for (const session of sessions) {
+        if (Number(session?.Key) === Number(sessionKey)) {
+          return String(session?.Path || '').trim() || null;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  async fetchLiveTimingPitStopDurations({ event, session }) {
+    const year = Number(String(session?.starts_at || event?.starts_at || '').slice(0, 4));
+    const sessionKey = Number(session?.session_key || event?.external_event_id);
+    if (!Number.isFinite(year) || !Number.isFinite(sessionKey)) {
+      return new Map();
+    }
+
+    try {
+      const sessionPath = await this.findLiveTimingSessionPath({ year, sessionKey });
+      if (!sessionPath) return new Map();
+
+      const normalizedPath = String(sessionPath).replace(/^\/+/, '').replace(/\/?$/, '/');
+      const url = `${this.liveTimingBaseUrl}/${normalizedPath}PitStopSeries.json`;
+      const payload = await this.requestJsonUrl(url);
+      return parseLiveTimingPitStopSeries(payload);
+    } catch {
+      return new Map();
+    }
+  }
+
   async fetchSessionMetadata(sessionKey) {
     const sessions = await this.request('/sessions', { session_key: sessionKey });
     const session = Array.isArray(sessions) ? sessions[0] : null;
@@ -557,11 +675,12 @@ class OpenF1ResultsProvider {
       const positionRows = await this.request('/position', { session_key: sessionKey });
       return deriveStartingGridFromPositions(positionRows);
     });
-    const [sessionResults, startingGrid, pitStops, roster] = await Promise.all([
+    const [sessionResults, startingGrid, pitStops, roster, liveTimingPitStops] = await Promise.all([
       this.request('/session_result', { session_key: sessionKey }),
       startingGridPromise,
       this.request('/pit', { session_key: sessionKey }),
       this.fetchNormalizedDriverRoster(session || { session_key: sessionKey }),
+      this.fetchLiveTimingPitStopDurations({ event, session }),
     ]);
 
     const gridByDriver = new Map(
@@ -581,6 +700,11 @@ class OpenF1ResultsProvider {
       if (current == null || stopDuration > current) {
         slowestPitByDriver.set(driverNumber, stopDuration);
       }
+    });
+
+    liveTimingPitStops.forEach((pitStopTime, driverNumber) => {
+      if (!Number.isFinite(Number(driverNumber)) || !Number.isFinite(Number(pitStopTime)) || Number(pitStopTime) <= 0) return;
+      slowestPitByDriver.set(Number(driverNumber), Number(pitStopTime));
     });
 
     const rows = sessionResults
@@ -756,6 +880,7 @@ class OpenF1ResultsProvider {
       return {
         provider: this.name,
         baseUrl: this.baseUrl,
+        liveTimingBaseUrl: this.liveTimingBaseUrl,
         authConfigured: this.authConfigured,
         tokenCached: Boolean(this.accessToken),
         tokenExpiresAt: this.accessTokenExpiresAt || null,

--- a/apps/f1/server/services/payoutRuleResolvers.js
+++ b/apps/f1/server/services/payoutRuleResolvers.js
@@ -133,7 +133,7 @@ function evaluateCategoryRule({ category, rows, event, rankOrder = 1 }) {
         resolution: {
           metric: 'slowest_pit_stop_seconds',
           target_value: slowestPit.targetDuration,
-          note: 'Highest OpenF1 stop_duration recorded for a driver in this event',
+          note: 'Highest stopped pit duration recorded for a driver in this event',
         },
       };
     }

--- a/apps/f1/server/tests/openF1ResultsProvider.test.js
+++ b/apps/f1/server/tests/openF1ResultsProvider.test.js
@@ -238,6 +238,108 @@ test('OpenF1ResultsProvider fetchEventResults falls back to earliest position sn
   ]);
 });
 
+test('OpenF1ResultsProvider fetchEventResults enriches stopped pit duration from Formula 1 LiveTiming', async () => {
+  const responses = {
+    '/v1/sessions?session_key=11234': [{
+      session_key: 11234,
+      meeting_key: 1254,
+      meeting_name: 'Australian Grand Prix',
+      session_name: 'Race',
+      date_start: '2026-03-08T04:00:00Z',
+      date_end: '2026-03-08T06:00:00Z',
+    }],
+    '/v1/session_result?session_key=11234': [
+      { driver_number: 55, position: 7 },
+      { driver_number: 18, position: 15 },
+    ],
+    '/v1/starting_grid?session_key=11234': [
+      { driver_number: 55, position: 11 },
+      { driver_number: 18, position: 14 },
+    ],
+    '/v1/pit?session_key=11234': [
+      { driver_number: 55, stop_duration: null },
+      { driver_number: 18, stop_duration: null },
+    ],
+    '/v1/drivers?session_key=11234': [
+      {
+        driver_number: 55,
+        name_acronym: 'SAI',
+        full_name: 'Carlos Sainz',
+        team_name: 'Williams',
+      },
+      {
+        driver_number: 18,
+        name_acronym: 'STR',
+        full_name: 'Lance Stroll',
+        team_name: 'Aston Martin',
+      },
+    ],
+    'https://livetiming.formula1.com/static/2026/Index.json': {
+      Meetings: [
+        {
+          Sessions: [
+            {
+              Key: 11234,
+              Path: '2026/2026-03-08_Australian_Grand_Prix/2026-03-08_Race/',
+            },
+          ],
+        },
+      ],
+    },
+    'https://livetiming.formula1.com/static/2026/2026-03-08_Australian_Grand_Prix/2026-03-08_Race/PitStopSeries.json': {
+      PitTimes: {
+        '55': [
+          { PitStop: { RacingNumber: '55', PitStopTime: '19.8', PitLaneTime: '34.615', Lap: '11' } },
+          { PitStop: { RacingNumber: '55', PitStopTime: '8.2', PitLaneTime: '25.900', Lap: '33' } },
+        ],
+        '18': [
+          { PitStop: { RacingNumber: '18', PitStopTime: '16.9', PitLaneTime: '36.686', Lap: '13' } },
+        ],
+      },
+    },
+  };
+
+  const provider = createNoAuthProvider({
+    fetchImpl: async (url) => {
+      const key = typeof url === 'string' ? url : url.toString();
+      const openF1Key = typeof url === 'string' ? url : `${url.pathname}${url.search}`;
+      const payload = responses[key] ?? responses[openF1Key] ?? [];
+      return {
+        ok: true,
+        async json() {
+          return payload;
+        },
+        headers: { get() { return 'application/json'; } },
+      };
+    },
+  });
+
+  const results = await provider.fetchEventResults({
+    event: { id: 1, external_event_id: '11234', starts_at: '2026-03-08T04:00:00Z' },
+  });
+
+  assert.deepEqual(results, [
+    {
+      external_driver_id: 55,
+      driver_code: 'SAI',
+      driver_name: 'Carlos Sainz',
+      team_name: 'Williams',
+      finish_position: 7,
+      start_position: 11,
+      slowest_pit_stop_seconds: 19.8,
+    },
+    {
+      external_driver_id: 18,
+      driver_code: 'STR',
+      driver_name: 'Lance Stroll',
+      team_name: 'Aston Martin',
+      finish_position: 15,
+      start_position: 14,
+      slowest_pit_stop_seconds: 16.9,
+    },
+  ]);
+});
+
 test('OpenF1ResultsProvider fetchDrivers uses the latest started non-testing session, including practice', async () => {
   const responses = {
     '/v1/sessions?year=2026': [

--- a/docs/adr/0014-f1-pit-stop-livetiming-fallback.md
+++ b/docs/adr/0014-f1-pit-stop-livetiming-fallback.md
@@ -1,0 +1,52 @@
+# ADR 0014: F1 Pit Stop Scoring Uses Formula 1 LiveTiming Static Feed
+
+Date: 2026-03-08
+
+## Status
+
+Accepted
+
+## Context
+
+The F1 app introduced a `slowest_pit_stop` novelty payout rule based on stopped pit duration.
+
+The original implementation sourced this value from OpenF1 `pit.stop_duration`. During the
+2026 Australian Grand Prix, OpenF1 returned pit rows but `stop_duration` was null for the full
+session, which made the rule unscorable even though other public data sources showed stopped pit
+times for the race.
+
+Formula 1 LiveTiming exposes a static season `Index.json` and per-session `PitStopSeries.json`
+payloads that include `PitStopTime` values per driver stop event.
+
+## Decision
+
+For F1 event sync:
+
+1. OpenF1 remains the primary source for:
+   - schedule
+   - driver roster
+   - classified results
+2. Formula 1 LiveTiming becomes the preferred source for stopped pit duration:
+   - resolve session path from season `Index.json`
+   - read `PitStopSeries.json`
+   - compute the maximum `PitStopTime` per driver for the synced session
+3. If the LiveTiming static feed is unavailable for a session, fall back to OpenF1
+   `pit.stop_duration`.
+4. If neither source produces a stopped pit duration, the rule remains unresolved and admin
+   manual override remains the operational fallback.
+
+## Consequences
+
+Positive:
+
+- The `slowest_pit_stop` rule now has a reliable stopped-duration source even when OpenF1
+  omits `stop_duration` for a race.
+- Event sync no longer fails or produces empty pit-stop scoring for races like 2026 Australia.
+
+Tradeoffs:
+
+- The app now depends on an additional undocumented public data surface from Formula 1
+  LiveTiming.
+- The session path must be resolved dynamically from the season index rather than guessed from
+  event names.
+- Manual override remains necessary if both external data surfaces are incomplete.


### PR DESCRIPTION
Summary
- document the operational state and runbook updates for the F1 calendar
- refresh the F1 app UI and backend services to use the livetiming.formula1.com data feeds, including standings, dashboard briefing, and admin flows
- add ADR for dashboard briefing history plus tests covering auth, services, and the openF1 provider

Testing
- Not run (not requested)