### PR TITLE
Tighten F1 mobile dashboard and driver cards

### DIFF
--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -2691,7 +2691,7 @@ tbody tr:hover {
 
 .mobile-card-list {
   display: grid;
-  gap: var(--space-3);
+  gap: 0.7rem;
 }
 
 .mobile-info-card {
@@ -2701,6 +2701,11 @@ tbody tr:hover {
   padding: 0.8rem;
   display: grid;
   gap: var(--space-3);
+}
+
+.mobile-info-card-compact {
+  padding: 0.58rem 0.66rem;
+  gap: 0.45rem;
 }
 
 .mobile-info-card-active {
@@ -2713,6 +2718,17 @@ tbody tr:hover {
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-3);
+}
+
+.mobile-compact-heading {
+  min-width: 0;
+}
+
+.mobile-compact-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  flex-wrap: wrap;
 }
 
 .mobile-card-note {
@@ -2744,9 +2760,47 @@ tbody tr:hover {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.mobile-stat-grid-compact {
+  gap: 0.35rem 0.55rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
 .mobile-stat-grid > div {
   display: grid;
   gap: 0.16rem;
+  align-content: start;
+}
+
+.mobile-stat-grid-compact .label {
+  font-size: 0.58rem;
+  letter-spacing: 0.06em;
+}
+
+.mobile-stat-grid-compact strong {
+  font-size: 0.96rem;
+  line-height: 1.05;
+}
+
+.mobile-driver-card .mobile-info-card-head {
+  align-items: center;
+}
+
+.mobile-driver-subhead {
+  margin: -0.18rem 0 0;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.mobile-driver-subhead-label {
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.56rem;
+}
+
+.mobile-driver-card .driver-identity {
+  min-width: 0;
 }
 
 .fade-in {
@@ -3105,6 +3159,10 @@ tbody tr:hover {
 
   .mobile-stat-grid {
     grid-template-columns: 1fr;
+  }
+
+  .mobile-stat-grid.mobile-stat-grid-compact {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .events-back-btn {

--- a/apps/f1/client/src/pages/Dashboard.jsx
+++ b/apps/f1/client/src/pages/Dashboard.jsx
@@ -246,7 +246,7 @@ function StandingsCards({ rows }) {
   return (
     <div className="mobile-card-list">
       {rows.map((row) => (
-        <article key={row.id} className={`mobile-info-card ${row.isViewer ? 'mobile-info-card-active' : ''}`}>
+        <article key={row.id} className={`mobile-info-card mobile-info-card-compact ${row.isViewer ? 'mobile-info-card-active' : ''}`}>
           <div className="mobile-info-card-head">
             <div className="dashboard-participant-cell">
               <span
@@ -259,15 +259,17 @@ function StandingsCards({ rows }) {
               >
                 {(row.name || '?').trim().charAt(0).toUpperCase() || '?'}
               </span>
-              <div>
-                <strong>{row.name}</strong>
-                <div className="muted small">Rank #{row.rank}</div>
+              <div className="mobile-compact-heading">
+                <div className="mobile-compact-title-row">
+                  <strong>{row.name}</strong>
+                  <span className="muted small">#{row.rank}</span>
+                </div>
               </div>
             </div>
             {row.isViewer ? <span className="dashboard-owner-badge">You</span> : null}
           </div>
 
-          <div className="mobile-stat-grid">
+          <div className="mobile-stat-grid mobile-stat-grid-compact">
             <div>
               <span className="label">Drivers</span>
               <strong>{row.drivers_owned}</strong>

--- a/apps/f1/client/src/pages/MyDrivers.jsx
+++ b/apps/f1/client/src/pages/MyDrivers.jsx
@@ -52,7 +52,7 @@ export default function MyDrivers() {
               {drivers.map((driver) => {
                 const total = driver.event_earnings_cents + driver.bonus_earnings_cents;
                 return (
-                  <article key={driver.driver_id} className="mobile-info-card">
+                  <article key={driver.driver_id} className="mobile-info-card mobile-info-card-compact mobile-driver-card">
                     <div className="mobile-info-card-head">
                       <DriverIdentity
                         driverName={driver.driver_name}
@@ -70,7 +70,8 @@ export default function MyDrivers() {
                       </span>
                     </div>
 
-                    <p className="muted small">
+                    <p className="muted small mobile-driver-subhead">
+                      <span className="mobile-driver-subhead-label">Team</span>
                       <span
                         className="team-accent-text"
                         style={getTeamColorStyle({ teamName: driver.team_name, driverCode: driver.driver_code })}
@@ -79,7 +80,7 @@ export default function MyDrivers() {
                       </span>
                     </p>
 
-                    <div className="mobile-stat-grid">
+                    <div className="mobile-stat-grid mobile-stat-grid-compact">
                       <div>
                         <span className="label">Purchase</span>
                         <strong>{fmtCents(driver.purchase_price_cents)}</strong>


### PR DESCRIPTION
## Summary
- reduce vertical space used by mobile dashboard standings cards
- condense mobile My Drivers cards into denser summary cards
- keep compact metric rails at small screen widths instead of collapsing into tall one-column stacks

## Verification
- npm run build:f1
