### PR TITLE
Refine F1 dashboard AI briefing summaries

### DIFF
--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -15,7 +15,7 @@ A dedicated Formula 1 Calcutta app for a full season pool.
 - Season bonus payouts from remaining pool
 - Season bonus payouts are withheld until all scoring events in the season are complete, then calculated from full-season data
 - Participant dashboard at `/dashboard` with personal KPIs, full standings ranked by net return, current-or-next race focus, and a live payout-category board driven by OpenF1 timing
-- On-demand Anthropic briefing on the dashboard with saved per-event history, contextual pre-race/live/post-race labels, and compact structured sections for faster reading
+- On-demand Anthropic briefing on the dashboard with a compact return-on-investment summary, saved history navigated by paired header arrows, and expanded weekend timing labels from pre-practice through post-race
 - Participant mobile UX now uses a compact nav shell, join-first login layout, card-based dashboard/portfolio views, and a list-to-detail event flow instead of relying on wide desktop tables
 - Results sync via provider adapter (`openf1` for real data, `mock` for local/dev/test)
 - Admin controls for auction, sync, payout rules, and settings
@@ -34,6 +34,29 @@ npm run dev
 
 Client: `http://localhost:5174`
 Server: `http://localhost:3002`
+
+## Shared Local Dev State
+
+New worktrees default to a fresh SQLite file unless `DB_PATH` is overridden. To keep one local F1 database and one env source across worktrees:
+
+```bash
+npm run bootstrap:local --prefix apps/f1
+```
+
+By default, F1 local dev will look for shared files here:
+
+- shared env: `~/Code/Calcutta-App-local/f1/f1.local.env`
+- shared DB: `~/Code/Calcutta-App-local/f1/f1-calcutta-local-dev.db`
+
+The bootstrap script sanitizes the shared env so runtime-specific overrides like `F1_PORT`, `PORT`, and `DB_PATH` do not leak across worktrees.
+
+Load order for local env files is:
+
+1. shared F1 env file above
+2. repo-root `.env`
+3. `apps/f1/.env`
+
+`DB_PATH` still wins if you set it explicitly in the shell.
 
 ## Core endpoints
 

--- a/apps/f1/client/src/index.css
+++ b/apps/f1/client/src/index.css
@@ -2595,39 +2595,32 @@ tbody tr:hover {
   background: rgba(11, 15, 21, 0.6);
 }
 
-.dashboard-briefing-history {
+.dashboard-briefing-card-full {
+  gap: var(--space-3);
+}
+
+.dashboard-briefing-header-actions {
   display: flex;
+  align-items: center;
+  justify-content: flex-end;
   gap: var(--space-2);
-  overflow-x: auto;
-  padding-bottom: 0.15rem;
+  flex-wrap: wrap;
 }
 
-.dashboard-briefing-nav-btn {
-  min-width: 190px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: var(--radius-sm);
-  background: rgba(10, 14, 20, 0.72);
-  color: var(--text);
-  padding: 0.55rem 0.65rem;
-  text-align: left;
-  display: grid;
-  gap: 0.18rem;
-  cursor: pointer;
+.dashboard-briefing-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
 }
 
-.dashboard-briefing-nav-btn span {
-  font-size: var(--text-xs);
-  color: var(--muted);
-}
-
-.dashboard-briefing-nav-btn.active {
-  border-color: rgba(159, 63, 67, 0.48);
-  background: rgba(159, 63, 67, 0.14);
+.dashboard-briefing-arrow {
+  min-width: 2.5rem;
+  padding-inline: 0.7rem;
 }
 
 .dashboard-briefing-body {
   display: grid;
-  gap: var(--space-3);
+  gap: var(--space-2);
 }
 
 .dashboard-briefing-meta {
@@ -2638,7 +2631,7 @@ tbody tr:hover {
 }
 
 .dashboard-briefing-meta h3,
-.dashboard-briefing-section h4 {
+.dashboard-briefing-rail p {
   margin: 0;
 }
 
@@ -2648,23 +2641,22 @@ tbody tr:hover {
   border: 1px solid rgba(159, 63, 67, 0.22);
   border-radius: var(--radius-md);
   background: rgba(11, 15, 21, 0.52);
+  font-size: 1.05rem;
 }
 
-.dashboard-briefing-sections {
+.dashboard-briefing-rails {
   display: grid;
-  gap: var(--space-3);
+  gap: var(--space-2);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.dashboard-briefing-section {
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  padding-top: var(--space-2);
-}
-
-.dashboard-briefing-section ul {
-  margin: 0.45rem 0 0;
-  padding-left: 1rem;
+.dashboard-briefing-rail {
   display: grid;
-  gap: 0.45rem;
+  gap: 0.28rem;
+  padding: 0.72rem 0.8rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(11, 15, 21, 0.48);
 }
 
 .dashboard-ranking-list {
@@ -3247,8 +3239,8 @@ tbody tr:hover {
     margin-bottom: var(--space-2);
   }
 
-  .dashboard-briefing-nav-btn {
-    min-width: 160px;
+  .dashboard-briefing-rails {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -3265,6 +3257,11 @@ tbody tr:hover {
   .dashboard-briefing-meta {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .dashboard-briefing-header-actions {
+    width: 100%;
+    justify-content: space-between;
   }
 }
 

--- a/apps/f1/client/src/pages/Dashboard.jsx
+++ b/apps/f1/client/src/pages/Dashboard.jsx
@@ -28,6 +28,19 @@ function formatCountdown(iso) {
   return `${minutes}m`;
 }
 
+function stripBriefingLead(text, leads = []) {
+  let value = String(text || '').trim();
+  if (!value) return '';
+
+  leads.forEach((lead) => {
+    const escaped = String(lead || '').trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    if (!escaped) return;
+    value = value.replace(new RegExp(`^${escaped}\\s*[:\\-]\\s*`, 'i'), '').trim();
+  });
+
+  return value;
+}
+
 function rowNet(row) {
   return Number(row?.total_earned_cents || 0) - Number(row?.total_spent_cents || 0);
 }
@@ -299,32 +312,43 @@ function formatBriefingHistoryLabel(briefing) {
   return `${eventName} • ${phase}`;
 }
 
-function BriefingHistoryNav({ history, selectedId, onSelect }) {
-  if (!history?.length) return null;
-
+function BriefingHistoryControls({
+  canGoPrevious,
+  canGoNext,
+  onPrevious,
+  onNext,
+}) {
   return (
-    <div className="dashboard-briefing-history" role="tablist" aria-label="Briefing history">
-      {history.map((entry) => (
-        <button
-          key={entry.id || `${entry.generatedAt || 'briefing'}-${entry.snapshotHash || ''}`}
-          type="button"
-          role="tab"
-          aria-selected={selectedId === entry.id}
-          className={`dashboard-briefing-nav-btn ${selectedId === entry.id ? 'active' : ''}`}
-          onClick={() => onSelect(entry.id)}
-        >
-          <strong>{entry.eventName || 'Saved Briefing'}</strong>
-          <span>{entry.phaseLabel || 'Saved'}{entry.generatedAt ? ` • ${fmtWhen(entry.generatedAt)}` : ''}</span>
-        </button>
-      ))}
+    <div className="dashboard-briefing-controls" aria-label="Briefing history navigation">
+      <button
+        type="button"
+        className="btn btn-outline dashboard-briefing-arrow"
+        onClick={onPrevious}
+        disabled={!canGoPrevious}
+        aria-label="View older briefing"
+      >
+        {'<'}
+      </button>
+      <button
+        type="button"
+        className="btn btn-outline dashboard-briefing-arrow"
+        onClick={onNext}
+        disabled={!canGoNext}
+        aria-label="View newer briefing"
+      >
+        {'>'}
+      </button>
     </div>
   );
 }
 
 function BriefingContent({ briefing }) {
   if (!briefing) {
-    return <p className="muted">Generate a briefing when you want a concise race-and-standings summary.</p>;
+    return <p className="muted">Generate a briefing when you want a concise portfolio return summary.</p>;
   }
+
+  const bestReturnPath = stripBriefingLead(briefing.bestReturnPath || briefing.financialSnapshot, ['best return path', 'best swing', 'financial snapshot']);
+  const capitalAtRisk = stripBriefingLead(briefing.capitalAtRisk || briefing.whatMattersNow, ['capital at risk', 'main risk', 'what matters now']);
 
   return (
     <div className="dashboard-briefing-body">
@@ -332,8 +356,7 @@ function BriefingContent({ briefing }) {
         <div>
           <h3>{briefing.title || formatBriefingHistoryLabel(briefing)}</h3>
           <p className="muted small">
-            {formatBriefingHistoryLabel(briefing)}
-            {briefing.generatedAt ? ` • ${fmtWhen(briefing.generatedAt)}` : ''}
+            {briefing.generatedAt ? fmtWhen(briefing.generatedAt) : formatBriefingHistoryLabel(briefing)}
           </p>
         </div>
         <span className={`dashboard-payout-status ${briefing.phase || 'pending'}`}>{briefing.phaseLabel || 'Saved'}</span>
@@ -341,18 +364,20 @@ function BriefingContent({ briefing }) {
 
       {briefing.summary ? <p className="dashboard-briefing-summary">{briefing.summary}</p> : null}
 
-      {Array.isArray(briefing.sections) && briefing.sections.length ? (
-        <div className="dashboard-briefing-sections">
-          {briefing.sections.map((section) => (
-            <section key={`${briefing.id || briefing.generatedAt}-${section.heading}`} className="dashboard-briefing-section">
-              <h4>{section.heading}</h4>
-              <ul>
-                {(section.bullets || []).map((bullet) => (
-                  <li key={`${section.heading}-${bullet}`}>{bullet}</li>
-                ))}
-              </ul>
-            </section>
-          ))}
+      {bestReturnPath || capitalAtRisk ? (
+        <div className="dashboard-briefing-rails">
+          {bestReturnPath ? (
+            <div className="dashboard-briefing-rail">
+              <span className="label">Best Return Path</span>
+              <p>{bestReturnPath}</p>
+            </div>
+          ) : null}
+          {capitalAtRisk ? (
+            <div className="dashboard-briefing-rail">
+              <span className="label">Capital At Risk</span>
+              <p>{capitalAtRisk}</p>
+            </div>
+          ) : null}
         </div>
       ) : briefing.text ? (
         <p className="dashboard-briefing-text">{briefing.text}</p>
@@ -459,6 +484,12 @@ export default function Dashboard() {
     [briefingHistory, selectedBriefingId],
   );
   const latestBriefing = briefingHistory[0] || null;
+  const selectedBriefingIndex = useMemo(
+    () => briefingHistory.findIndex((entry) => entry.id === selectedBriefing?.id),
+    [briefingHistory, selectedBriefing?.id],
+  );
+  const canGoToOlderBriefing = selectedBriefingIndex >= 0 && selectedBriefingIndex < (briefingHistory.length - 1);
+  const canGoToNewerBriefing = selectedBriefingIndex > 0;
 
   const highlightedStandings = useMemo(() => standings.map((row, index) => ({
     ...row,
@@ -582,6 +613,53 @@ export default function Dashboard() {
         )}
       </section>
 
+      <section className="panel stack dashboard-briefing-card dashboard-briefing-card-full">
+        <div className="dashboard-card-head">
+          <div>
+            <div className="live-header">
+              <span className="status-led" />
+              <span>AI Briefing</span>
+            </div>
+            <h2>AI Briefing</h2>
+          </div>
+          <div className="dashboard-briefing-header-actions">
+            <button
+              className="btn btn-outline"
+              disabled={briefingLoading || !data?.briefingMeta?.available}
+              onClick={() => requestBriefing({ force: !!latestBriefing?.generatedAt })}
+            >
+              {briefingLoading ? 'Loading...' : (latestBriefing?.generatedAt ? 'Refresh Briefing' : 'Generate Briefing')}
+            </button>
+            <BriefingHistoryControls
+              canGoPrevious={canGoToOlderBriefing}
+              canGoNext={canGoToNewerBriefing}
+              onPrevious={() => {
+                if (!canGoToOlderBriefing) return;
+                setSelectedBriefingId(briefingHistory[selectedBriefingIndex + 1]?.id || selectedBriefingId);
+              }}
+              onNext={() => {
+                if (!canGoToNewerBriefing) return;
+                setSelectedBriefingId(briefingHistory[selectedBriefingIndex - 1]?.id || selectedBriefingId);
+              }}
+            />
+          </div>
+        </div>
+
+        {!data?.briefingMeta?.available ? (
+          <p className="muted">Anthropic is not configured for the F1 service yet.</p>
+        ) : null}
+
+        <BriefingContent briefing={selectedBriefing} />
+
+        {selectedBriefing?.generatedAt ? (
+          <p className="muted small">
+            {selectedBriefing.cached ? 'Cached' : 'Saved'} briefing.
+          </p>
+        ) : null}
+
+        {briefingError ? <p className="error-text">{briefingError}</p> : null}
+      </section>
+
       <div className="dashboard-hero-grid">
         <section className="panel live-panel stack dashboard-event-card">
           <div className="dashboard-card-head">
@@ -620,49 +698,6 @@ export default function Dashboard() {
           {liveSession?.degradedReason ? (
             <p className="muted small">{liveSession.degradedReason}</p>
           ) : null}
-        </section>
-
-        <section className="panel stack dashboard-briefing-card">
-          <div className="dashboard-card-head">
-            <div>
-              <div className="live-header">
-                <span className="status-led" />
-                <span>AI Briefing</span>
-              </div>
-              <h2>Personal Readout</h2>
-              <p className="muted">
-                Anthropic-powered summary of your position, live race context, and likely impact.
-              </p>
-            </div>
-            <button
-              className="btn btn-outline"
-              disabled={briefingLoading || !data?.briefingMeta?.available}
-              onClick={() => requestBriefing({ force: !!latestBriefing?.generatedAt })}
-            >
-              {briefingLoading ? 'Loading...' : (latestBriefing?.generatedAt ? 'Refresh Briefing' : 'Generate Briefing')}
-            </button>
-          </div>
-
-          {!data?.briefingMeta?.available ? (
-            <p className="muted">Anthropic is not configured for the F1 service yet.</p>
-          ) : null}
-
-          <BriefingHistoryNav
-            history={briefingHistory}
-            selectedId={selectedBriefing?.id || null}
-            onSelect={setSelectedBriefingId}
-          />
-
-          <BriefingContent briefing={selectedBriefing} />
-
-          {selectedBriefing?.generatedAt ? (
-            <p className="muted small">
-              {selectedBriefing.cached ? 'Cached' : 'Saved'} briefing
-              {selectedBriefing.generatedAt ? ` • ${fmtWhen(selectedBriefing.generatedAt)}` : ''}.
-            </p>
-          ) : null}
-
-          {briefingError ? <p className="error-text">{briefingError}</p> : null}
         </section>
       </div>
 

--- a/apps/f1/package.json
+++ b/apps/f1/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "bootstrap:local": "bash ./scripts/bootstrap-local-dev.sh",
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
     "dev:server": "cd server && npm run dev",
     "dev:client": "cd client && npm run dev",

--- a/apps/f1/scripts/bootstrap-local-dev.sh
+++ b/apps/f1/scripts/bootstrap-local-dev.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TARGET_DIR="${F1_LOCAL_SHARED_DIR:-$HOME/Code/Calcutta-App-local/f1}"
+TARGET_ENV="${F1_SHARED_ENV_PATH:-$TARGET_DIR/f1.local.env}"
+TARGET_DB="${F1_SHARED_DB_PATH:-$TARGET_DIR/f1-calcutta-local-dev.db}"
+
+SOURCE_ENV="${SOURCE_ENV:-$HOME/Code/Calcutta-App/.env}"
+SOURCE_DB="${SOURCE_DB:-$HOME/Code/Calcutta-App/apps/f1/server/f1-calcutta-local-dev.db}"
+
+mkdir -p "$TARGET_DIR"
+
+sanitize_env_file() {
+  local input_path="$1"
+  local output_path="$2"
+
+  awk '
+    /^[[:space:]]*(F1_PORT|PORT|DB_PATH|F1_SHARED_ENV_PATH|F1_SHARED_DB_PATH|F1_LOCAL_SHARED_DIR)=/ { next }
+    { print }
+  ' "$input_path" > "$output_path"
+}
+
+if [[ -f "$SOURCE_ENV" && ! -f "$TARGET_ENV" ]]; then
+  cp "$SOURCE_ENV" "$TARGET_ENV"
+  echo "Seeded shared env: $TARGET_ENV"
+fi
+
+if [[ -f "$TARGET_ENV" ]]; then
+  tmp_env="$(mktemp)"
+  sanitize_env_file "$TARGET_ENV" "$tmp_env"
+  mv "$tmp_env" "$TARGET_ENV"
+elif [[ -f "$SOURCE_ENV" ]]; then
+  tmp_env="$(mktemp)"
+  sanitize_env_file "$SOURCE_ENV" "$tmp_env"
+  mv "$tmp_env" "$TARGET_ENV"
+  echo "Seeded shared env: $TARGET_ENV"
+fi
+
+if [[ -f "$SOURCE_DB" && ! -f "$TARGET_DB" ]]; then
+  cp "$SOURCE_DB" "$TARGET_DB"
+  [[ -f "${SOURCE_DB}-shm" ]] && cp "${SOURCE_DB}-shm" "${TARGET_DB}-shm"
+  [[ -f "${SOURCE_DB}-wal" ]] && cp "${SOURCE_DB}-wal" "${TARGET_DB}-wal"
+  echo "Seeded shared DB: $TARGET_DB"
+fi
+
+echo "Shared local F1 dir: $TARGET_DIR"
+echo "Shared env path: $TARGET_ENV"
+echo "Shared DB path: $TARGET_DB"

--- a/apps/f1/server/ai.js
+++ b/apps/f1/server/ai.js
@@ -1,5 +1,40 @@
 const Anthropic = require('@anthropic-ai/sdk');
 
+const IMMEDIATE_POST_RACE_WINDOW_MS = 48 * 60 * 60 * 1000;
+const MAX_EXECUTIVE_LINE_WORDS = 26;
+const GENERIC_BRIEFING_PATTERNS = [
+  /\bmonitor closely\b/i,
+  /\bsecondary payouts?\b/i,
+  /\bvalue picks?\b/i,
+  /\bkeep an eye on\b/i,
+  /\bopportunities\b/i,
+  /\blive swings?\b/i,
+];
+const STANDINGS_HEAVY_PATTERNS = [
+  /\bchase\b/i,
+  /\bmove up\b/i,
+  /\bclose the gap\b/i,
+  /\bbehind [a-z]/i,
+  /\bfor p\d+\b/i,
+  /\bgap widens?\b/i,
+];
+const SUMMARY_METRIC_PATTERNS = [
+  /\bearned\b/i,
+  /\bspent\b/i,
+  /\bnet\b/i,
+];
+const ROI_LANGUAGE_PATTERNS = [
+  /\bjustify\b/i,
+  /\boutperform\b/i,
+  /\bbuy price\b/i,
+  /\bcost basis\b/i,
+  /\bpay back\b/i,
+  /\blagging\b/i,
+  /\breturn\b/i,
+  /\bvalue\b/i,
+  /\bcost\b/i,
+];
+
 let client = null;
 
 function getClient() {
@@ -20,10 +55,58 @@ function formatSigned(value) {
   return `${num > 0 ? '+' : ''}${num}`;
 }
 
-function determineBriefingPhase({ primaryEvent, liveSession }) {
-  if (liveSession?.isLive || primaryEvent?.isLive) return 'live';
-  if (primaryEvent?.dashboardStatus === 'Next up') return 'pre_race';
-  return 'post_race';
+function normalizePhaseKey(phase) {
+  return String(phase || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_');
+}
+
+function phaseLabel(phase) {
+  switch (normalizePhaseKey(phase)) {
+    case 'before_practice':
+      return 'Before Practice';
+    case 'during_practice':
+      return 'During Practice';
+    case 'before_qualifying':
+      return 'Before Qualifying';
+    case 'during_qualifying':
+      return 'During Qualifying';
+    case 'during_sprint_qualifying':
+      return 'During Sprint Qualifying';
+    case 'after_qualifying_before_race':
+      return 'After Qualifying / Before Race';
+    case 'during_race':
+      return 'During Race';
+    case 'during_sprint':
+      return 'During Sprint';
+    case 'immediate_post_race':
+      return 'Immediate Post-Race';
+    case 'between_races':
+      return 'Between Races';
+    case 'pre_race':
+      return 'Pre-race';
+    case 'live':
+      return 'Live';
+    case 'post_race':
+      return 'Post-race';
+    default:
+      return 'Saved';
+  }
+}
+
+function determineBriefingPhase({ primaryEvent, liveSession, weekendContext, now = Date.now() }) {
+  if (weekendContext?.phase) return normalizePhaseKey(weekendContext.phase);
+
+  if (liveSession?.isLive || primaryEvent?.isLive) {
+    return primaryEvent?.type === 'sprint' ? 'during_sprint' : 'during_race';
+  }
+
+  const eventStartsAtMs = Date.parse(primaryEvent?.starts_at || '');
+  if (Number.isFinite(eventStartsAtMs)) {
+    if (eventStartsAtMs > now + IMMEDIATE_POST_RACE_WINDOW_MS) return 'before_practice';
+    if (eventStartsAtMs > now) return 'before_qualifying';
+    if (now - eventStartsAtMs <= IMMEDIATE_POST_RACE_WINDOW_MS) return 'immediate_post_race';
+  }
+
+  return 'between_races';
 }
 
 function describeStandingsWindow({ standings, viewerId }) {
@@ -53,7 +136,9 @@ function describeOwnedDrivers(portfolio) {
       if (live.position != null) liveParts.push(`P${live.position}`);
       if (live.positionsGained != null) liveParts.push(`${formatSigned(live.positionsGained)} from grid`);
       if (live.maxPitStopSeconds != null) liveParts.push(`slowest pit ${Number(live.maxPitStopSeconds).toFixed(2)}s`);
-      return `${driver.driver_name} (${driver.driver_code}) - purchase ${dollars(driver.purchase_price_cents)} dollars, earned ${dollars(driver.total_earnings_cents)} dollars${liveParts.length ? `, live ${liveParts.join(', ')}` : ''}`;
+      const profit = dollars(driverProfitCents(driver));
+      const roiMultiple = formatMultiple(driverRoiMultiple(driver));
+      return `${driver.driver_name} (${driver.driver_code}) - purchase ${dollars(driver.purchase_price_cents)} dollars, earned ${dollars(driver.total_earnings_cents)} dollars, ${profit >= 0 ? 'profit' : 'loss'} ${Math.abs(profit)} dollars${roiMultiple ? `, return ${roiMultiple}` : ''}${liveParts.length ? `, live ${liveParts.join(', ')}` : ''}`;
     })
     .join('\n');
 }
@@ -76,6 +161,19 @@ function describePayoutBoard(payoutBoard) {
     .join('\n');
 }
 
+function describeWeekendContext(weekendContext) {
+  if (!weekendContext) return 'Weekend context unavailable.';
+
+  return [
+    `Visible phase label: ${phaseLabel(weekendContext.phase)}`,
+    `Weekend title: ${weekendContext.title || weekendContext.meetingName || 'Unknown weekend'}`,
+    `Current session: ${weekendContext.currentSessionName || 'None'}`,
+    `Next session: ${weekendContext.nextSessionName || 'None'}`,
+    `Last completed session: ${weekendContext.lastCompletedSessionName || 'None'}`,
+    `Data source: ${weekendContext.source || 'unknown'}`,
+  ].join('\n');
+}
+
 function extractJsonBlock(text) {
   const raw = String(text || '').trim();
   if (!raw) return null;
@@ -95,52 +193,435 @@ function normalizeSections(sections) {
     .filter((section) => section.heading || section.bullets.length);
 }
 
-function composeText(summary, sections) {
-  const lines = [String(summary || '').trim()];
-  normalizeSections(sections).forEach((section) => {
-    if (section.heading) lines.push(`${section.heading}:`);
-    section.bullets.forEach((bullet) => lines.push(`- ${bullet}`));
-  });
-  return lines.filter(Boolean).join('\n');
+function firstBulletForHeading(sections, heading) {
+  const match = normalizeSections(sections).find((section) => String(section.heading || '').trim().toLowerCase() === heading);
+  return String(match?.bullets?.[0] || '').trim();
 }
 
-function normalizeBriefingPayload(payload, phase) {
-  const normalizedPhase = String(payload?.phase || phase || 'unknown').trim() || 'unknown';
-  const title = String(payload?.title || '').trim()
-    || (normalizedPhase === 'pre_race' ? 'Pre-race Outlook' : normalizedPhase === 'live' ? 'Live Race Readout' : 'Post-race Recap');
-  const summary = String(payload?.summary || '').trim();
-  const sections = normalizeSections(payload?.sections);
-
+function deriveLegacyExecutiveFields(sections) {
+  const normalizedSections = normalizeSections(sections);
   return {
-    phase: normalizedPhase,
-    title,
-    summary,
-    sections,
-    text: composeText(summary, sections),
+    bestReturnPath: firstBulletForHeading(normalizedSections, 'your position')
+      || firstBulletForHeading(normalizedSections, 'best swing')
+      || firstBulletForHeading(normalizedSections, 'financial snapshot'),
+    capitalAtRisk: firstBulletForHeading(normalizedSections, 'what to watch')
+      || firstBulletForHeading(normalizedSections, 'main risk')
+      || firstBulletForHeading(normalizedSections, 'what matters now')
+      || firstBulletForHeading(normalizedSections, 'scenarios'),
   };
 }
 
-function fallbackBriefingFromText(rawText, phase) {
-  const cleaned = String(rawText || '').trim();
+function computeNetCents(row) {
+  return Number(row?.total_earned_cents || 0) - Number(row?.total_spent_cents || 0);
+}
+
+function buildPositionContext({ standings, viewerId }) {
+  const rows = Array.isArray(standings) ? standings : [];
+  const viewerIndex = rows.findIndex((row) => Number(row.id) === Number(viewerId));
+  const viewerRow = viewerIndex >= 0 ? rows[viewerIndex] : null;
+  const aboveRow = viewerIndex > 0 ? rows[viewerIndex - 1] : null;
+  const belowRow = viewerIndex >= 0 && viewerIndex < (rows.length - 1) ? rows[viewerIndex + 1] : null;
+  const viewerRank = viewerIndex >= 0 ? viewerIndex + 1 : null;
+  const gapToAbove = aboveRow && viewerRow ? Math.abs(dollars(computeNetCents(viewerRow) - computeNetCents(aboveRow))) : null;
+  const leadToBelow = belowRow && viewerRow ? Math.abs(dollars(computeNetCents(viewerRow) - computeNetCents(belowRow))) : null;
+
+  return {
+    viewerRank,
+    aboveRow,
+    belowRow,
+    gapToAbove,
+    leadToBelow,
+  };
+}
+
+function topOwnedDrivers(portfolio, limit = 3) {
+  return (Array.isArray(portfolio?.drivers) ? portfolio.drivers : [])
+    .slice()
+    .sort((a, b) => (
+      Number(b.total_earnings_cents || 0) - Number(a.total_earnings_cents || 0)
+    ) || (
+      Number(b.purchase_price_cents || 0) - Number(a.purchase_price_cents || 0)
+    ))
+    .slice(0, limit)
+    .map((driver) => driver.driver_name || driver.driver_code)
+    .filter(Boolean);
+}
+
+function driverProfitCents(driver) {
+  return Number(driver?.total_earnings_cents || 0) - Number(driver?.purchase_price_cents || 0);
+}
+
+function driverRoiMultiple(driver) {
+  const spend = Number(driver?.purchase_price_cents || 0);
+  if (spend <= 0) return null;
+  return Number(driver?.total_earnings_cents || 0) / spend;
+}
+
+function returnCandidateDrivers(portfolio, limit = 2) {
+  return (Array.isArray(portfolio?.drivers) ? portfolio.drivers : [])
+    .slice()
+    .sort((a, b) => {
+      const roiDiff = (driverRoiMultiple(b) ?? -Infinity) - (driverRoiMultiple(a) ?? -Infinity);
+      if (roiDiff !== 0) return roiDiff;
+      const profitDiff = driverProfitCents(b) - driverProfitCents(a);
+      if (profitDiff !== 0) return profitDiff;
+      return Number(a.purchase_price_cents || 0) - Number(b.purchase_price_cents || 0);
+    })
+    .slice(0, limit);
+}
+
+function riskDrivers(portfolio, limit = 2) {
+  return (Array.isArray(portfolio?.drivers) ? portfolio.drivers : [])
+    .slice()
+    .sort((a, b) => {
+      const underperformanceA = Number(a.purchase_price_cents || 0) - Number(a.total_earnings_cents || 0);
+      const underperformanceB = Number(b.purchase_price_cents || 0) - Number(b.total_earnings_cents || 0);
+      if (underperformanceB !== underperformanceA) return underperformanceB - underperformanceA;
+      return Number(b.purchase_price_cents || 0) - Number(a.purchase_price_cents || 0);
+    })
+    .slice(0, limit);
+}
+
+function formatMultiple(value) {
+  if (!Number.isFinite(value)) return null;
+  return `${value.toFixed(value >= 2 ? 1 : 2)}x`;
+}
+
+function payoutSignals({ payoutBoard, rivalNames }) {
+  const rules = Array.isArray(payoutBoard?.rules) ? payoutBoard.rules : [];
+  const viewerRules = [];
+  const rivalRules = [];
+  const activeRules = [];
+
+  rules.forEach((rule) => {
+    const label = String(rule?.label || '').trim();
+    if (!label) return;
+    activeRules.push(label);
+    if ((rule.holders || []).some((holder) => holder.isViewerOwner)) viewerRules.push(label);
+    if ((rule.holders || []).some((holder) => rivalNames.includes(holder.participantName))) rivalRules.push(label);
+  });
+
+  return {
+    viewerRules: [...new Set(viewerRules)],
+    rivalRules: [...new Set(rivalRules)],
+    activeRules: [...new Set(activeRules)],
+  };
+}
+
+function buildDeterministicTitle({ primaryEvent, weekendContext }) {
+  const base = String(
+    weekendContext?.title
+    || weekendContext?.meetingName
+    || primaryEvent?.name
+    || 'Dashboard Briefing',
+  ).trim() || 'Dashboard Briefing';
+
+  return `${base} - Return Outlook`;
+}
+
+function defaultHeadlineForPhase(phase) {
+  switch (normalizePhaseKey(phase)) {
+    case 'before_practice':
+      return 'Your return outlook is waiting on the first real pace signal of the weekend.';
+    case 'during_practice':
+      return 'Practice is starting to show which parts of your portfolio can justify their buy prices.';
+    case 'before_qualifying':
+      return 'Qualifying is the next inflection point for which drivers can outperform their cost this weekend.';
+    case 'during_qualifying':
+    case 'during_sprint_qualifying':
+      return 'Qualifying is actively deciding whose weekend value can beat the purchase price.';
+    case 'after_qualifying_before_race':
+      return 'The grid is set, so race execution now decides which buys can pay back.';
+    case 'during_race':
+    case 'during_sprint':
+      return 'Live running is actively changing which drivers are paying back their cost.';
+    case 'immediate_post_race':
+      return 'The race has just finished, so the focus is which buys paid back and which did not.';
+    case 'between_races':
+      return 'Between races, the focus shifts to which drivers are most likely to deliver the next surplus return.';
+    default:
+      return 'Executive summary unavailable.';
+  }
+}
+
+function defaultBestReturnPath(phase) {
+  switch (normalizePhaseKey(phase)) {
+    case 'during_practice':
+      return 'The best return path will come from the owned driver showing live pace without needing a premium finish to justify the spend.';
+    case 'during_qualifying':
+    case 'during_sprint_qualifying':
+      return 'The cleanest return path is the owned driver who can turn grid position into a payout that beats the buy price.';
+    case 'during_race':
+    case 'during_sprint':
+      return 'The clearest return path is the owned driver still live for a payout category that can pay back the ticket price.';
+    default:
+      return 'The best return path will come from the owned driver with the clearest route to outperform the buy price this weekend.';
+  }
+}
+
+function defaultCapitalAtRisk(phase) {
+  switch (normalizePhaseKey(phase)) {
+    case 'before_practice':
+      return 'The main capital risk is any premium spend that arrives at the weekend without a clear path to paying back.';
+    case 'during_practice':
+      return 'The main capital risk is any expensive driver whose pace still looks too thin to justify the buy price.';
+    case 'before_qualifying':
+      return 'The main capital risk is any premium buy that needs a strong grid slot and does not get one.';
+    case 'during_qualifying':
+    case 'during_sprint_qualifying':
+      return 'The main capital risk is any expensive driver losing grid position and with it the clearest payout routes.';
+    case 'after_qualifying_before_race':
+      return 'The main capital risk is any premium buy starting too far back to pay back without race chaos or attrition.';
+    case 'during_race':
+    case 'during_sprint':
+      return 'The main capital risk is any expensive ticket falling out of the payout windows while the laps run down.';
+    case 'immediate_post_race':
+      return 'The main capital risk now is carrying premium buys that still have not justified what you paid.';
+    case 'between_races':
+      return 'The main capital risk between races is concentrated spend that still needs a clean weekend to pay back.';
+    default:
+      return 'Refresh after the next material session change for a clearer read.';
+  }
+}
+
+function normalizeCompareText(text) {
+  return String(text || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function containsOneOf(text, values) {
+  const haystack = normalizeCompareText(text);
+  return values.some((value) => {
+    const needle = normalizeCompareText(value);
+    return needle && haystack.includes(needle);
+  });
+}
+
+function countWords(text) {
+  return String(text || '').trim().split(/\s+/).filter(Boolean).length;
+}
+
+function stripExecutiveLead(text, leads = []) {
+  let value = String(text || '').trim();
+  if (!value) return '';
+
+  leads.forEach((lead) => {
+    const escaped = String(lead || '').trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    if (!escaped) return;
+    value = value.replace(new RegExp(`^${escaped}\\s*[:\\-]\\s*`, 'i'), '').trim();
+  });
+
+  return value;
+}
+
+function buildDeterministicExecutiveBriefing({
+  viewer,
+  summary,
+  standings,
+  portfolio,
+  payoutBoard,
+  primaryEvent,
+  weekendContext,
+  phase,
+}) {
+  const { viewerRank, aboveRow, belowRow, gapToAbove, leadToBelow } = buildPositionContext({
+    standings,
+    viewerId: viewer?.id,
+  });
+  const returnDrivers = returnCandidateDrivers(portfolio, 2);
+  const riskPool = riskDrivers(portfolio, 2);
+  const driverNames = topOwnedDrivers(portfolio, 3);
+  const rivalNames = [aboveRow?.name, belowRow?.name].filter(Boolean);
+  const { viewerRules, rivalRules, activeRules } = payoutSignals({ payoutBoard, rivalNames });
+  const leadDriver = returnDrivers[0]?.driver_name || returnDrivers[0]?.driver_code || driverNames[0] || 'your top driver';
+  const supportDriver = returnDrivers[1]?.driver_name || returnDrivers[1]?.driver_code || null;
+  const riskDriver = riskPool[0]?.driver_name || riskPool[0]?.driver_code || driverNames[0] || 'your priciest driver';
+  const targetName = aboveRow?.name || null;
+  const leadRoi = formatMultiple(driverRoiMultiple(returnDrivers[0]));
+  const riskProfit = dollars(driverProfitCents(riskPool[0]));
+
+  let headline = defaultHeadlineForPhase(phase);
+  if (leadDriver && supportDriver) {
+    headline = `Your return outlook for ${weekendContext?.title || primaryEvent?.name || 'this session'} hinges on ${leadDriver} validating the premium spend and ${supportDriver} delivering surplus value.`;
+  } else if (leadDriver && leadRoi) {
+    headline = `${leadDriver} is carrying the strongest ${leadRoi} return signal in your portfolio heading into ${weekendContext?.title || primaryEvent?.name || 'this session'}.`;
+  } else if (leadDriver) {
+    headline = `${leadDriver} is your clearest route to portfolio value in ${weekendContext?.title || primaryEvent?.name || 'this session'}.`;
+  }
+
+  let bestReturnPath = defaultBestReturnPath(phase);
+  if (viewerRules.length) {
+    bestReturnPath = `${leadDriver}${supportDriver ? ` plus ${supportDriver}` : ''} is your best value path if ${viewerRules[0]}${viewerRules[1] ? ` or ${viewerRules[1]}` : ''} pays back the buy price.`;
+  } else if (activeRules.length) {
+    bestReturnPath = `${leadDriver}${supportDriver ? ` plus ${supportDriver}` : ''} is your cleanest over-performance path if ${activeRules[0]}${activeRules[1] ? ` or ${activeRules[1]}` : ''} lands.`;
+  }
+
+  let capitalAtRisk = defaultCapitalAtRisk(phase);
+  if (targetName && rivalRules.length) {
+    capitalAtRisk = `${riskDriver} is your most exposed spend if ${targetName} locks down ${rivalRules[0]} and squeezes the payout path you need.`;
+  } else if (riskDriver && Number.isFinite(riskProfit) && riskProfit < 0) {
+    capitalAtRisk = `${riskDriver} is still ${Math.abs(riskProfit)} dollars short of paying back the ticket, so another quiet session leaves that spend lagging its cost.`;
+  } else if (riskDriver) {
+    capitalAtRisk = `${riskDriver} is your most exposed spend because it still needs a clean payout hit to justify the buy price.`;
+  }
+
   return normalizeBriefingPayload({
+    headline,
+    bestReturnPath,
+    capitalAtRisk,
+  }, {
     phase,
-    title: phase === 'pre_race' ? 'Pre-race Outlook' : phase === 'live' ? 'Live Race Readout' : 'Post-race Recap',
-    summary: cleaned.split('\n').find(Boolean) || 'Structured briefing unavailable.',
-    sections: [
-      {
-        heading: 'Your Position',
-        bullets: cleaned ? [cleaned] : ['Structured briefing unavailable.'],
-      },
-      {
-        heading: 'Scenarios',
-        bullets: ['If the briefing format is incomplete, use the live payout board and standings to confirm the current swing points.'],
-      },
-      {
-        heading: 'What To Watch',
-        bullets: ['Refresh the briefing again after a meaningful race-state change if you need a cleaner structured readout.'],
-      },
-    ],
-  }, phase);
+    title: buildDeterministicTitle({
+      primaryEvent,
+      weekendContext,
+    }),
+    summaryData: summary,
+    primaryEvent,
+    weekendContext,
+  });
+}
+
+function scoreExecutiveBriefing(briefing, {
+  viewer,
+  standings,
+  portfolio,
+  payoutBoard,
+} = {}) {
+  const lines = [briefing?.headline, briefing?.bestReturnPath, briefing?.capitalAtRisk]
+    .map((value) => String(value || '').trim())
+    .filter(Boolean);
+  const normalizedLines = lines.map(normalizeCompareText).filter(Boolean);
+  const driverNames = topOwnedDrivers(portfolio, 4);
+  const { aboveRow, belowRow } = buildPositionContext({ standings, viewerId: viewer?.id });
+  const rivalNames = [aboveRow?.name, belowRow?.name].filter(Boolean);
+  const payoutLabels = payoutSignals({ payoutBoard, rivalNames }).activeRules;
+  const combined = lines.join(' ');
+  const competitorMentioned = containsOneOf(combined, rivalNames);
+  const payoutMentioned = containsOneOf(combined, payoutLabels);
+  const metricMentions = SUMMARY_METRIC_PATTERNS.filter((pattern) => pattern.test(combined)).length;
+  const standingsHeavy = STANDINGS_HEAVY_PATTERNS.some((pattern) => pattern.test(combined));
+  const hasRoiLanguage = ROI_LANGUAGE_PATTERNS.some((pattern) => pattern.test(combined));
+
+  let score = 0;
+  if (lines.length === 3) score += 1;
+  if (new Set(normalizedLines).size === normalizedLines.length) score += 1;
+  if (lines.every((line) => countWords(line) <= MAX_EXECUTIVE_LINE_WORDS)) score += 1;
+  if (hasRoiLanguage) score += 1;
+  if (!standingsHeavy || (competitorMentioned && payoutMentioned)) score += 1;
+  if (metricMentions <= 1) score += 1;
+  if (!driverNames.length || containsOneOf(combined, driverNames)) score += 1;
+  if (!payoutLabels.length || containsOneOf(combined, payoutLabels)) score += 1;
+  if (!GENERIC_BRIEFING_PATTERNS.some((pattern) => pattern.test(combined))) score += 1;
+
+  return {
+    score,
+    passed: score >= 6
+      && new Set(normalizedLines).size === normalizedLines.length
+      && hasRoiLanguage
+      && (!standingsHeavy || (competitorMentioned && payoutMentioned)),
+  };
+}
+
+function composeText({ headline, bestReturnPath, capitalAtRisk, sections }) {
+  const lines = [];
+
+  if (headline) lines.push(headline);
+  if (bestReturnPath) lines.push(`Best Return Path: ${bestReturnPath}`);
+  if (capitalAtRisk) lines.push(`Capital At Risk: ${capitalAtRisk}`);
+
+  if (!lines.length) {
+    normalizeSections(sections).forEach((section) => {
+      if (section.heading) lines.push(`${section.heading}:`);
+      section.bullets.forEach((bullet) => lines.push(`- ${bullet}`));
+    });
+  }
+
+  return lines.filter(Boolean).join('\n');
+}
+
+function normalizeBriefingPayload(payload, {
+  phase,
+  title,
+  summaryData,
+  primaryEvent,
+  weekendContext,
+} = {}) {
+  const normalizedPhase = normalizePhaseKey(payload?.phase || phase || 'between_races') || 'between_races';
+  const normalizedSections = normalizeSections(payload?.sections);
+  const legacyFields = deriveLegacyExecutiveFields(normalizedSections);
+  const headline = stripExecutiveLead(payload?.headline || payload?.summary, ['headline', 'summary'])
+    || defaultHeadlineForPhase(normalizedPhase);
+  const bestReturnPath = stripExecutiveLead(
+    payload?.bestReturnPath || payload?.best_return_path || payload?.bestSwing || payload?.best_swing || payload?.financialSnapshot || payload?.financial_snapshot,
+    ['best return path', 'best swing', 'financial snapshot'],
+  )
+    || legacyFields.bestReturnPath
+    || defaultBestReturnPath(normalizedPhase);
+  const capitalAtRisk = stripExecutiveLead(
+    payload?.capitalAtRisk || payload?.capital_at_risk || payload?.mainRisk || payload?.main_risk || payload?.whatMattersNow || payload?.what_matters_now,
+    ['capital at risk', 'main risk', 'what matters now'],
+  )
+    || legacyFields.capitalAtRisk
+    || defaultCapitalAtRisk(normalizedPhase);
+  const deterministicTitle = String(title || buildDeterministicTitle({ primaryEvent, weekendContext })).trim()
+    || 'Dashboard Briefing';
+
+  return {
+    phase: normalizedPhase,
+    title: deterministicTitle,
+    headline,
+    summary: headline,
+    bestReturnPath,
+    capitalAtRisk,
+    financialSnapshot: bestReturnPath,
+    whatMattersNow: capitalAtRisk,
+    sections: normalizedSections,
+    text: composeText({
+      headline,
+      bestReturnPath,
+      capitalAtRisk,
+      sections: normalizedSections,
+    }),
+  };
+}
+
+function fallbackBriefingFromText(rawText, options) {
+  const cleaned = String(rawText || '').trim();
+  const lines = cleaned.split('\n').map((line) => line.trim()).filter(Boolean);
+
+  return normalizeBriefingPayload({
+    headline: lines[0] || 'Executive summary unavailable.',
+    bestReturnPath: lines[1] || '',
+    capitalAtRisk: lines[2] || '',
+  }, options);
+}
+
+function phaseTone(phase) {
+  switch (normalizePhaseKey(phase)) {
+    case 'before_practice':
+      return 'Sound executive and anticipatory. Focus on which owned drivers can justify their purchase prices once the weekend starts.';
+    case 'during_practice':
+      return 'Sound concise and evaluative. Focus on early pace signals, owned-driver value, and whether the spend looks justified.';
+    case 'before_qualifying':
+      return 'Sound tactical. Focus on what qualifying will lock in for return upside and cost-basis risk.';
+    case 'during_qualifying':
+    case 'during_sprint_qualifying':
+      return 'Sound urgent and compact. Focus on immediate grid swings and how they affect portfolio value.';
+    case 'after_qualifying_before_race':
+      return 'Sound pointed and tactical. Focus on confirmed grid position, return upside, and downside against the purchase price.';
+    case 'during_race':
+    case 'during_sprint':
+      return 'Sound urgent and tactical. Focus on live payout windows, owned-driver return upside, and the spend most at risk.';
+    case 'immediate_post_race':
+      return 'Sound reflective and outcome-focused. Explain which buys paid back, which missed, and what that means for future return.';
+    case 'between_races':
+      return 'Sound strategic and compact. Focus on portfolio efficiency, concentrated spend, and what matters before the next weekend.';
+    default:
+      return 'Sound concise, businesslike, and personalized to the participant.';
+  }
 }
 
 async function generateDashboardBriefing({
@@ -151,6 +632,7 @@ async function generateDashboardBriefing({
   standings,
   portfolio,
   payoutBoard,
+  weekendContext,
 }) {
   const anthropic = getClient();
   if (!anthropic) {
@@ -163,57 +645,62 @@ async function generateDashboardBriefing({
     };
   }
 
-  const phase = determineBriefingPhase({ primaryEvent, liveSession });
-  const phaseTone = phase === 'pre_race'
-    ? 'Sound anticipatory and tactical. Focus on setup, exposure, and what could move during the upcoming race.'
-    : phase === 'live'
-      ? 'Sound urgent and tactical. Focus on live swings, immediate threats, and current leverage.'
-      : 'Sound reflective and outcome-focused. Explain what happened and how it affected the participant.';
-
-  const prompt = `You are writing a structured F1 Calcutta dashboard briefing for one participant in a private pool.
+  const phase = determineBriefingPhase({ primaryEvent, liveSession, weekendContext });
+  const title = buildDeterministicTitle({
+    primaryEvent,
+    weekendContext,
+  });
+  const prompt = `You are writing a compact executive summary for one participant in a private F1 Calcutta pool.
 Return JSON only. No markdown fences.
 
 The JSON schema:
 {
-  "phase": "pre_race" | "live" | "post_race",
-  "title": "short heading",
-  "summary": "one short sentence",
-  "sections": [
-    { "heading": "Your Position", "bullets": ["...", "..."] },
-    { "heading": "Scenarios", "bullets": ["If ...", "If ..."] },
-    { "heading": "What To Watch", "bullets": ["...", "..."] }
-  ]
+  "headline": "one short sentence",
+  "bestReturnPath": "one short sentence",
+  "capitalAtRisk": "one short sentence"
 }
 
 Requirements:
-- Keep it readable and compact.
-- Use exactly 3 sections in this order: Your Position, Scenarios, What To Watch.
-- Each section must have 2 bullets maximum.
-- Every bullet must be one sentence.
-- The Scenarios section must use explicit scenario language starting with "If".
-- Personalize it to the viewer and connect live/payout context to standings impact.
-- ${phaseTone}
+- Keep the output tight and businesslike.
+- Write exactly one sentence for each field.
+- Personalize it to the viewer.
+- headline must summarize the participant's return posture for this session or weekend without restating dashboard totals like earned, spent, or net.
+- bestReturnPath must name at least one owned driver, optionally a second owned driver, and at least one payout category or live signal explaining how the buy can outperform its price.
+- capitalAtRisk must name the owned driver or spend cluster most at risk of underperforming its cost basis and explain the failure mode.
+- Do not reference standings or other participants unless another participant directly blocks a payout category this portfolio needs.
+- Prefer cost-basis language such as "justify the spend", "outperform the buy price", "pay back", "lagging its cost", and "value path".
+- Do not start any field with its own label. Never write "Best return path:", "Capital at risk:", or similar prefixes.
+- The three lines must not repeat the same opening clause or restate the same point.
+- Prefer exact names, exact payout labels, exact value language, and direct cause-effect phrasing.
+- Do not use generic phrases like "monitor closely", "secondary payouts", "value picks", or "opportunities".
+- Do not use section headings, bullet lists, or markdown.
+- ${phaseTone(phase)}
+
+Run context:
+- Generated at: ${new Date().toISOString()}
+- Derived phase key: ${phase}
+- Visible phase label: ${phaseLabel(phase)}
+- Deterministic title: ${title}
 
 Viewer:
 - Name: ${viewer?.name || 'Participant'}
-- Rank: ${summary?.rank ?? 'N/A'}
-- Earned: ${dollars(summary?.totalEarnedCents)} dollars
-- Spent: ${dollars(summary?.totalSpentCents)} dollars
-- Net: ${dollars(summary?.netCents)} dollars
+- Drivers owned: ${summary?.driversOwned ?? 0}
+
+Weekend context:
+${describeWeekendContext(weekendContext)}
 
 Primary event:
 - Name: ${primaryEvent?.name || 'No event selected'}
 - Type: ${primaryEvent?.type || 'unknown'}
 - Dashboard status: ${primaryEvent?.dashboardStatus || 'unknown'}
 - Event start: ${primaryEvent?.starts_at || 'TBD'}
-- Briefing phase to use: ${phase}
 
 Live session:
 - Is live: ${liveSession?.isLive ? 'yes' : 'no'}
 - Track status: ${liveSession?.trackStatus?.label || liveSession?.statusText || 'N/A'}
 - Headline: ${liveSession?.headline || 'N/A'}
 
-Standings around viewer:
+Competitive context (use only if it directly blocks a payout path):
 ${describeStandingsWindow({ standings, viewerId: viewer?.id })}
 
 Owned drivers:
@@ -226,7 +713,7 @@ ${describePayoutBoard(payoutBoard)}
   try {
     const message = await anthropic.messages.create({
       model: 'claude-sonnet-4-5-20250929',
-      max_tokens: 500,
+      max_tokens: 280,
       messages: [{ role: 'user', content: prompt }],
     });
 
@@ -236,9 +723,40 @@ ${describePayoutBoard(payoutBoard)}
     try {
       const jsonText = extractJsonBlock(rawText);
       const parsed = jsonText ? JSON.parse(jsonText) : null;
-      normalized = normalizeBriefingPayload(parsed, phase);
+      normalized = normalizeBriefingPayload(parsed, {
+        phase,
+        title,
+        summaryData: summary,
+        primaryEvent,
+        weekendContext,
+      });
     } catch {
-      normalized = fallbackBriefingFromText(rawText, phase);
+      normalized = fallbackBriefingFromText(rawText, {
+        phase,
+        title,
+        summaryData: summary,
+        primaryEvent,
+        weekendContext,
+      });
+    }
+
+    const quality = scoreExecutiveBriefing(normalized, {
+      viewer,
+      standings,
+      portfolio,
+      payoutBoard,
+    });
+    if (!quality.passed) {
+      normalized = buildDeterministicExecutiveBriefing({
+        viewer,
+        summary,
+        standings,
+        portfolio,
+        payoutBoard,
+        primaryEvent,
+        weekendContext,
+        phase,
+      });
     }
 
     return {
@@ -264,4 +782,7 @@ module.exports = {
   generateDashboardBriefing,
   determineBriefingPhase,
   normalizeBriefingPayload,
+  phaseLabel,
+  scoreExecutiveBriefing,
+  buildDeterministicExecutiveBriefing,
 };

--- a/apps/f1/server/index.js
+++ b/apps/f1/server/index.js
@@ -1,7 +1,11 @@
 const path = require('path');
+const dotenv = require('dotenv');
 
-require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
-require('dotenv').config({ path: path.join(__dirname, '..', '..', '..', '.env') });
+const { envSearchPaths } = require('./lib/localDevPaths');
+
+envSearchPaths().forEach((envPath) => {
+  dotenv.config({ path: envPath });
+});
 
 process.on('uncaughtException', (err) => console.error('[uncaughtException]', err));
 process.on('unhandledRejection', (reason) => console.error('[unhandledRejection]', reason));

--- a/apps/f1/server/lib/localDevPaths.js
+++ b/apps/f1/server/lib/localDevPaths.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SHARED_LOCAL_DIR = process.env.F1_LOCAL_SHARED_DIR
+  || path.join(os.homedir(), 'Code', 'Calcutta-App-local', 'f1');
+const SHARED_ENV_PATH = process.env.F1_SHARED_ENV_PATH
+  || path.join(SHARED_LOCAL_DIR, 'f1.local.env');
+const SHARED_DB_PATH = process.env.F1_SHARED_DB_PATH
+  || path.join(SHARED_LOCAL_DIR, 'f1-calcutta-local-dev.db');
+const APP_ENV_PATH = path.join(__dirname, '..', '..', '.env');
+const ROOT_ENV_PATH = path.join(__dirname, '..', '..', '..', '.env');
+const WORKTREE_DB_PATH = path.join(__dirname, '..', 'f1-calcutta.db');
+
+function envSearchPaths() {
+  return [SHARED_ENV_PATH, ROOT_ENV_PATH, APP_ENV_PATH];
+}
+
+function resolveDbPath() {
+  if (process.env.DB_PATH) return process.env.DB_PATH;
+  if (fs.existsSync(SHARED_DB_PATH)) return SHARED_DB_PATH;
+  return WORKTREE_DB_PATH;
+}
+
+module.exports = {
+  APP_ENV_PATH,
+  ROOT_ENV_PATH,
+  SHARED_DB_PATH,
+  SHARED_ENV_PATH,
+  SHARED_LOCAL_DIR,
+  WORKTREE_DB_PATH,
+  envSearchPaths,
+  resolveDbPath,
+};

--- a/apps/f1/server/persistence/connection.js
+++ b/apps/f1/server/persistence/connection.js
@@ -1,7 +1,7 @@
 const Database = require('better-sqlite3');
-const path = require('path');
+const { resolveDbPath } = require('../lib/localDevPaths');
 
-const DB_PATH = process.env.DB_PATH || path.join(__dirname, '..', 'f1-calcutta.db');
+const DB_PATH = resolveDbPath();
 const db = new Database(DB_PATH);
 
 db.pragma('journal_mode = WAL');

--- a/apps/f1/server/providers/openF1ResultsProvider.js
+++ b/apps/f1/server/providers/openF1ResultsProvider.js
@@ -85,8 +85,12 @@ function subtractMinutes(iso, minutes) {
 }
 
 function normalizeSessionType(sessionName) {
-  if (sessionName === 'Race') return 'grand_prix';
-  if (sessionName === 'Sprint') return 'sprint';
+  const normalized = String(sessionName || '').trim().toLowerCase();
+  if (/practice/.test(normalized)) return 'practice';
+  if (/sprint/.test(normalized) && /(qualifying|shootout)/.test(normalized)) return 'sprint_qualifying';
+  if (normalized === 'qualifying') return 'qualifying';
+  if (normalized === 'race') return 'grand_prix';
+  if (normalized === 'sprint') return 'sprint';
   return null;
 }
 
@@ -637,7 +641,8 @@ class OpenF1ResultsProvider {
   }
 
   async fetchSeasonSchedule({ year }) {
-    const sessions = await this.fetchSeasonSessions({ year });
+    const sessions = (await this.fetchSeasonSessions({ year }))
+      .filter((session) => session.event_type === 'grand_prix' || session.event_type === 'sprint');
     const meetingRoundMap = new Map();
     let nextRound = 1;
 

--- a/apps/f1/server/services/dashboardBriefingService.js
+++ b/apps/f1/server/services/dashboardBriefingService.js
@@ -1,5 +1,5 @@
 const crypto = require('crypto');
-const { generateDashboardBriefing } = require('../ai');
+const { generateDashboardBriefing, phaseLabel } = require('../ai');
 const {
   getDashboardBriefingHistory,
   getLatestDashboardBriefing,
@@ -10,13 +10,6 @@ const DEFAULT_TTL_MS = 30 * 60 * 1000;
 
 function hashPayload(payload) {
   return crypto.createHash('sha256').update(JSON.stringify(payload || {})).digest('hex');
-}
-
-function phaseLabel(phase) {
-  if (phase === 'pre_race') return 'Pre-race';
-  if (phase === 'live') return 'Live';
-  if (phase === 'post_race') return 'Post-race';
-  return 'Saved';
 }
 
 function normalizeSections(sections) {
@@ -31,16 +24,113 @@ function normalizeSections(sections) {
     .filter((section) => section.heading || section.bullets.length);
 }
 
-function composeBriefingText(content) {
-  const summary = String(content?.summary || '').trim();
-  const sectionLines = normalizeSections(content?.sections)
-    .flatMap((section) => [
-      section.heading ? `${section.heading}:` : null,
-      ...section.bullets.map((bullet) => `- ${bullet}`),
-    ])
-    .filter(Boolean);
+function firstSectionBullet(sections, heading) {
+  const match = normalizeSections(sections)
+    .find((section) => String(section.heading || '').trim().toLowerCase() === heading);
+  return String(match?.bullets?.[0] || '').trim();
+}
 
-  return [summary, ...sectionLines].filter(Boolean).join('\n').trim();
+function stripExecutiveLead(text, leads = []) {
+  let value = String(text || '').trim();
+  if (!value) return '';
+
+  leads.forEach((lead) => {
+    const escaped = String(lead || '').trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    if (!escaped) return;
+    value = value.replace(new RegExp(`^${escaped}\\s*[:\\-]\\s*`, 'i'), '').trim();
+  });
+
+  return value;
+}
+
+function normalizeExecutiveContent(content, row = null) {
+  const summary = String(content?.summary || row?.briefing_summary || '').trim();
+  const sections = normalizeSections(content?.sections);
+  const bestReturnPath = stripExecutiveLead(
+    content?.bestReturnPath || content?.best_return_path || content?.financialSnapshot || content?.financial_snapshot,
+    ['best return path', 'best swing', 'financial snapshot'],
+  )
+    || firstSectionBullet(sections, 'your position');
+  const capitalAtRisk = stripExecutiveLead(
+    content?.capitalAtRisk || content?.capital_at_risk || content?.whatMattersNow || content?.what_matters_now,
+    ['capital at risk', 'main risk', 'what matters now'],
+  )
+    || firstSectionBullet(sections, 'what to watch')
+    || firstSectionBullet(sections, 'scenarios');
+
+  return {
+    summary,
+    headline: stripExecutiveLead(content?.headline || summary, ['headline', 'summary']) || summary,
+    bestReturnPath,
+    capitalAtRisk,
+    sections,
+  };
+}
+
+function composeBriefingText(content) {
+  const executive = normalizeExecutiveContent(content);
+  const lines = [];
+
+  if (executive.headline) lines.push(executive.headline);
+  if (executive.bestReturnPath) lines.push(`Best Return Path: ${executive.bestReturnPath}`);
+  if (executive.capitalAtRisk) lines.push(`Capital At Risk: ${executive.capitalAtRisk}`);
+
+  if (!lines.length) {
+    executive.sections.forEach((section) => {
+      if (section.heading) lines.push(`${section.heading}:`);
+      section.bullets.forEach((bullet) => lines.push(`- ${bullet}`));
+    });
+  }
+
+  return lines.filter(Boolean).join('\n').trim();
+}
+
+function normalizeSavedBriefing(row) {
+  if (!row?.briefing_json && !row?.briefing_text) return null;
+
+  let content = null;
+  try {
+    content = row?.briefing_json ? JSON.parse(row.briefing_json) : null;
+  } catch {
+    content = null;
+  }
+
+  if (!content) {
+    const legacyText = String(row?.briefing_text || '').trim();
+    content = {
+      summary: legacyText,
+      sections: legacyText ? [{ heading: 'Saved Briefing', bullets: [legacyText] }] : [],
+    };
+  }
+
+  const executive = normalizeExecutiveContent(content, row);
+  const title = String(row?.briefing_title || '').trim() || (row?.event_name ? row.event_name : 'Dashboard Briefing');
+
+  return {
+    id: row.id || null,
+    available: true,
+    title,
+    headline: executive.headline,
+    summary: executive.headline || executive.summary,
+    bestReturnPath: executive.bestReturnPath,
+    capitalAtRisk: executive.capitalAtRisk,
+    financialSnapshot: executive.bestReturnPath,
+    whatMattersNow: executive.capitalAtRisk,
+    sections: executive.sections,
+    phase: row.briefing_phase || 'unknown',
+    phaseLabel: phaseLabel(row.briefing_phase),
+    text: composeBriefingText(executive),
+    generatedAt: row.generated_at || null,
+    source: row.source || 'persisted',
+    error: null,
+    cached: true,
+    snapshotHash: row.snapshot_hash || '',
+    persisted: true,
+    eventId: row.event_id || null,
+    eventName: row.event_name || null,
+    eventType: row.event_type || null,
+    eventStartsAt: row.event_starts_at || null,
+  };
 }
 
 function createDashboardBriefingService({
@@ -73,6 +163,16 @@ function createDashboardBriefingService({
             type: dashboardPayload.primaryEvent.type ?? null,
             dashboardStatus: dashboardPayload.primaryEvent.dashboardStatus ?? null,
             isLive: !!dashboardPayload.primaryEvent.isLive,
+          }
+        : null,
+      weekendContext: dashboardPayload?.weekendContext
+        ? {
+            phase: dashboardPayload.weekendContext.phase || null,
+            title: dashboardPayload.weekendContext.title || null,
+            meetingName: dashboardPayload.weekendContext.meetingName || null,
+            currentSessionName: dashboardPayload.weekendContext.currentSessionName || null,
+            nextSessionName: dashboardPayload.weekendContext.nextSessionName || null,
+            lastCompletedSessionName: dashboardPayload.weekendContext.lastCompletedSessionName || null,
           }
         : null,
       liveSession: dashboardPayload?.liveSession
@@ -121,6 +221,7 @@ function createDashboardBriefingService({
             netCents: dashboardPayload.portfolio.netCents ?? null,
             drivers: (dashboardPayload.portfolio.drivers || []).slice(0, 8).map((driver) => ({
               driver_id: driver.driver_id,
+              purchase_price_cents: driver.purchase_price_cents,
               total_earnings_cents: driver.total_earnings_cents,
               live: driver.live
                 ? {
@@ -133,49 +234,6 @@ function createDashboardBriefingService({
             })),
           }
         : null,
-    };
-  }
-
-  function normalizeSavedBriefing(row) {
-    if (!row?.briefing_json && !row?.briefing_text) return null;
-    let content = null;
-    try {
-      content = row?.briefing_json ? JSON.parse(row.briefing_json) : null;
-    } catch {
-      content = null;
-    }
-
-    if (!content) {
-      const legacyText = String(row?.briefing_text || '').trim();
-      content = {
-        summary: legacyText,
-        sections: legacyText ? [{ heading: 'Saved Briefing', bullets: [legacyText] }] : [],
-      };
-    }
-
-    const sections = normalizeSections(content.sections);
-    const summary = String(content.summary || row?.briefing_summary || '').trim();
-    const title = String(row?.briefing_title || '').trim() || (row?.event_name ? `${row.event_name} Briefing` : 'Dashboard Briefing');
-
-    return {
-      id: row.id || null,
-      available: true,
-      text: composeBriefingText({ summary, sections }),
-      title,
-      summary,
-      sections,
-      phase: row.briefing_phase || 'unknown',
-      phaseLabel: phaseLabel(row.briefing_phase),
-      generatedAt: row.generated_at || null,
-      source: row.source || 'persisted',
-      error: null,
-      cached: true,
-      snapshotHash: row.snapshot_hash || '',
-      persisted: true,
-      eventId: row.event_id || null,
-      eventName: row.event_name || null,
-      eventType: row.event_type || null,
-      eventStartsAt: row.event_starts_at || null,
     };
   }
 
@@ -220,13 +278,7 @@ function createDashboardBriefingService({
       if (saved && saved.snapshotHash === snapshotHash) {
         cache.set(cacheKey, {
           expiresAt: now + ttlMs,
-          value: {
-            available: saved.available,
-            text: saved.text,
-            generatedAt: saved.generatedAt,
-            source: saved.source,
-            error: saved.error,
-          },
+          value: { ...saved },
         });
         return saved;
       }
@@ -236,6 +288,7 @@ function createDashboardBriefingService({
       viewer: dashboardPayload?.viewer || null,
       summary: dashboardPayload?.summary || null,
       primaryEvent: dashboardPayload?.primaryEvent || null,
+      weekendContext: dashboardPayload?.weekendContext || null,
       liveSession: dashboardPayload?.liveSession || null,
       standings: dashboardPayload?.standings || [],
       portfolio: dashboardPayload?.portfolio || null,
@@ -246,12 +299,22 @@ function createDashboardBriefingService({
       available: !!briefing?.available,
       id: briefing?.id || null,
       title: briefing?.title || '',
-      summary: briefing?.summary || '',
+      headline: briefing?.headline || briefing?.summary || '',
+      summary: briefing?.summary || briefing?.headline || '',
+      bestReturnPath: briefing?.bestReturnPath || briefing?.financialSnapshot || '',
+      capitalAtRisk: briefing?.capitalAtRisk || briefing?.whatMattersNow || '',
+      financialSnapshot: briefing?.bestReturnPath || briefing?.financialSnapshot || '',
+      whatMattersNow: briefing?.capitalAtRisk || briefing?.whatMattersNow || '',
       sections: normalizeSections(briefing?.sections),
       phase: briefing?.phase || 'unknown',
       phaseLabel: phaseLabel(briefing?.phase),
       text: briefing?.text || composeBriefingText({
-        summary: briefing?.summary || '',
+        headline: briefing?.headline || briefing?.summary || '',
+        summary: briefing?.summary || briefing?.headline || '',
+        bestReturnPath: briefing?.bestReturnPath || briefing?.financialSnapshot || '',
+        capitalAtRisk: briefing?.capitalAtRisk || briefing?.whatMattersNow || '',
+        financialSnapshot: briefing?.bestReturnPath || briefing?.financialSnapshot || '',
+        whatMattersNow: briefing?.capitalAtRisk || briefing?.whatMattersNow || '',
         sections: briefing?.sections || [],
       }),
       generatedAt: briefing?.generatedAt || null,
@@ -276,7 +339,12 @@ function createDashboardBriefingService({
         title: value.title,
         summary: value.summary,
         content: {
+          headline: value.headline,
           summary: value.summary,
+          bestReturnPath: value.bestReturnPath,
+          capitalAtRisk: value.capitalAtRisk,
+          financialSnapshot: value.bestReturnPath,
+          whatMattersNow: value.capitalAtRisk,
           sections: value.sections,
         },
         source: value.source,

--- a/apps/f1/server/services/dashboardService.js
+++ b/apps/f1/server/services/dashboardService.js
@@ -14,8 +14,11 @@ const { evaluateCategoryRule } = require('./payoutRuleResolvers');
 const LIVE_CACHE_TTL_MS = 15_000;
 const ACTIVE_SESSION_GRACE_MS = 20 * 60 * 1000;
 const FALLBACK_SESSION_WINDOW_MS = 4 * 60 * 60 * 1000;
+const WEEKEND_SESSION_CACHE_TTL_MS = 5 * 60 * 1000;
+const BETWEEN_RACES_WINDOW_MS = 48 * 60 * 60 * 1000;
 
 const liveSnapshotCache = new Map();
+const weekendSessionCache = new Map();
 
 function toTimestampMs(value) {
   if (!value) return null;
@@ -57,6 +60,264 @@ function isSessionLive(session, now) {
   }
 
   return false;
+}
+
+function normalizeWeekendName(value) {
+  return String(value || '')
+    .replace(/\s*\(sprint\)\s*/gi, '')
+    .replace(/[^a-z0-9]+/gi, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function classifyWeekendSession(session) {
+  const sessionName = String(session?.session_name || '').trim().toLowerCase();
+  const eventType = String(session?.event_type || '').trim().toLowerCase();
+
+  if (/practice/.test(sessionName)) return 'practice';
+  if (/sprint/.test(sessionName) && /(qualifying|shootout)/.test(sessionName)) return 'sprint_qualifying';
+  if (sessionName === 'qualifying') return 'qualifying';
+  if (sessionName === 'sprint' || eventType === 'sprint') return 'sprint';
+  if (sessionName === 'race' || eventType === 'grand_prix') return 'race';
+  return 'other';
+}
+
+function isPracticeSession(session) {
+  return classifyWeekendSession(session) === 'practice';
+}
+
+function isQualifyingSession(session) {
+  const type = classifyWeekendSession(session);
+  return type === 'qualifying' || type === 'sprint_qualifying';
+}
+
+function isRaceSession(session) {
+  const type = classifyWeekendSession(session);
+  return type === 'race' || type === 'sprint';
+}
+
+function weekendSessionStartMs(session) {
+  return toTimestampMs(session?.starts_at || session?.date_start);
+}
+
+function weekendSessionEndMs(session) {
+  return toTimestampMs(session?.ends_at || session?.date_end);
+}
+
+function compareSessionStarts(a, b) {
+  return (weekendSessionStartMs(a) || 0) - (weekendSessionStartMs(b) || 0);
+}
+
+function baseWeekendTitle(event) {
+  return String(event?.name || '')
+    .replace(/\s*\(Sprint\)\s*/gi, '')
+    .trim();
+}
+
+async function getCachedWeekendSessions({ provider, year, now }) {
+  if (!provider?.fetchSeasonSessions || !Number.isFinite(year)) return [];
+
+  const cacheKey = `${provider.name || 'provider'}:${year}`;
+  const existing = weekendSessionCache.get(cacheKey);
+  if (existing?.value && existing.expiresAt > now) {
+    return existing.value;
+  }
+  if (existing?.promise) {
+    return existing.promise;
+  }
+
+  const promise = Promise.resolve()
+    .then(() => provider.fetchSeasonSessions({ year }))
+    .then((sessions) => {
+      const value = Array.isArray(sessions) ? sessions : [];
+      weekendSessionCache.set(cacheKey, {
+        value,
+        expiresAt: now + WEEKEND_SESSION_CACHE_TTL_MS,
+      });
+      return value;
+    })
+    .catch((error) => {
+      weekendSessionCache.delete(cacheKey);
+      throw error;
+    });
+
+  weekendSessionCache.set(cacheKey, {
+    promise,
+    expiresAt: now + WEEKEND_SESSION_CACHE_TTL_MS,
+  });
+  return promise;
+}
+
+function findWeekendSessionsForEvent({ sessions, event }) {
+  if (!event) return [];
+
+  const eventKey = normalizeWeekendName(event.name);
+  const eventStartsAtMs = toTimestampMs(event.starts_at);
+  const grouped = new Map();
+
+  (Array.isArray(sessions) ? sessions : []).forEach((session) => {
+    const groupKey = String(session?.meeting_key || normalizeWeekendName(session?.meeting_name || session?.location || session?.circuit_short_name || ''));
+    if (!grouped.has(groupKey)) grouped.set(groupKey, []);
+    grouped.get(groupKey).push(session);
+  });
+
+  const groups = [...grouped.values()].filter((group) => group.length);
+  if (!groups.length) return [];
+
+  const directMatch = groups.find((group) => normalizeWeekendName(group[0]?.meeting_name) === eventKey);
+  if (directMatch) {
+    return directMatch.slice().sort(compareSessionStarts);
+  }
+
+  if (!Number.isFinite(eventStartsAtMs)) return [];
+
+  return groups
+    .slice()
+    .sort((a, b) => {
+      const aDiff = Math.min(...a.map((session) => Math.abs((weekendSessionStartMs(session) || eventStartsAtMs) - eventStartsAtMs)));
+      const bDiff = Math.min(...b.map((session) => Math.abs((weekendSessionStartMs(session) || eventStartsAtMs) - eventStartsAtMs)));
+      return aDiff - bDiff;
+    })[0]
+    ?.slice()
+    .sort(compareSessionStarts) || [];
+}
+
+function phaseFromActiveSession(session, primaryEvent) {
+  switch (classifyWeekendSession(session)) {
+    case 'practice':
+      return 'during_practice';
+    case 'sprint_qualifying':
+      return 'during_sprint_qualifying';
+    case 'qualifying':
+      return 'during_qualifying';
+    case 'sprint':
+      return 'during_sprint';
+    case 'race':
+      return 'during_race';
+    default:
+      return primaryEvent?.type === 'sprint' ? 'during_sprint' : 'during_race';
+  }
+}
+
+function buildFallbackWeekendContext({ primaryEvent, liveSession, now }) {
+  const startsAtMs = toTimestampMs(primaryEvent?.starts_at);
+  let phase = 'between_races';
+
+  if (liveSession?.isLive || primaryEvent?.isLive) {
+    phase = primaryEvent?.type === 'sprint' ? 'during_sprint' : 'during_race';
+  } else if (Number.isFinite(startsAtMs)) {
+    if (startsAtMs > now + BETWEEN_RACES_WINDOW_MS) phase = 'between_races';
+    else if (startsAtMs > now) phase = 'before_practice';
+    else if ((now - startsAtMs) <= BETWEEN_RACES_WINDOW_MS) phase = 'immediate_post_race';
+  }
+
+  return {
+    phase,
+    title: baseWeekendTitle(primaryEvent) || primaryEvent?.name || 'Dashboard Briefing',
+    meetingName: baseWeekendTitle(primaryEvent) || primaryEvent?.name || null,
+    currentSessionName: liveSession?.statusText || null,
+    nextSessionName: null,
+    lastCompletedSessionName: null,
+    source: 'fallback',
+  };
+}
+
+function buildWeekendContextFromSessions({ primaryEvent, weekendSessions, now, liveSession }) {
+  const sessions = (weekendSessions || []).slice().sort(compareSessionStarts);
+  if (!sessions.length) {
+    return buildFallbackWeekendContext({ primaryEvent, liveSession, now });
+  }
+
+  const activeSession = sessions.find((session) => isSessionLive(session, now)) || null;
+  const nextSession = sessions.find((session) => {
+    const startMs = weekendSessionStartMs(session);
+    return Number.isFinite(startMs) && startMs > now;
+  }) || null;
+  const completedSessions = sessions.filter((session) => {
+    const endMs = weekendSessionEndMs(session);
+    return Number.isFinite(endMs) && endMs <= now;
+  });
+  const lastCompletedSession = completedSessions[completedSessions.length - 1] || null;
+  const mainRaceSession = sessions.find((session) => classifyWeekendSession(session) === 'race') || null;
+  const firstSession = sessions[0] || null;
+
+  let phase = 'between_races';
+  if (activeSession) {
+    phase = phaseFromActiveSession(activeSession, primaryEvent);
+  } else {
+    const firstStartMs = weekendSessionStartMs(firstSession);
+    const raceEndMs = weekendSessionEndMs(mainRaceSession);
+    const hasCompletedQualifying = completedSessions.some(isQualifyingSession);
+    const hasCompletedPractice = completedSessions.some(isPracticeSession);
+
+    if (Number.isFinite(raceEndMs) && now > raceEndMs) {
+      phase = (now - raceEndMs) <= BETWEEN_RACES_WINDOW_MS ? 'immediate_post_race' : 'between_races';
+    } else if (Number.isFinite(firstStartMs) && now < firstStartMs) {
+      phase = (firstStartMs - now) > BETWEEN_RACES_WINDOW_MS ? 'between_races' : 'before_practice';
+    } else if (hasCompletedQualifying) {
+      phase = 'after_qualifying_before_race';
+    } else if (hasCompletedPractice || isQualifyingSession(nextSession)) {
+      phase = 'before_qualifying';
+    } else if (nextSession && isPracticeSession(nextSession)) {
+      phase = 'before_practice';
+    } else {
+      phase = 'before_qualifying';
+    }
+  }
+
+  return {
+    phase,
+    title: String(firstSession?.meeting_name || baseWeekendTitle(primaryEvent) || primaryEvent?.name || 'Dashboard Briefing').trim(),
+    meetingName: String(firstSession?.meeting_name || baseWeekendTitle(primaryEvent) || primaryEvent?.name || '').trim() || null,
+    currentSessionName: activeSession?.session_name || null,
+    nextSessionName: nextSession?.session_name || null,
+    lastCompletedSessionName: lastCompletedSession?.session_name || null,
+    source: 'provider',
+  };
+}
+
+async function buildWeekendContext({ events, primaryEvent, provider, now, liveSession }) {
+  if (!primaryEvent) return null;
+
+  const fallback = buildFallbackWeekendContext({ primaryEvent, liveSession, now });
+  const year = Number(String(primaryEvent?.starts_at || '').slice(0, 4));
+  if (!provider?.fetchSeasonSessions || !Number.isFinite(year)) {
+    return fallback;
+  }
+
+  try {
+    const seasonSessions = await getCachedWeekendSessions({ provider, year, now });
+    const latestCompletedRace = seasonSessions
+      .filter((session) => classifyWeekendSession(session) === 'race')
+      .filter((session) => {
+        const endMs = weekendSessionEndMs(session);
+        return Number.isFinite(endMs) && endMs <= now;
+      })
+      .sort((a, b) => (weekendSessionEndMs(b) || 0) - (weekendSessionEndMs(a) || 0))[0] || null;
+
+    const recentRaceStillRelevant = latestCompletedRace
+      && Number.isFinite(weekendSessionEndMs(latestCompletedRace))
+      && (now - weekendSessionEndMs(latestCompletedRace)) <= BETWEEN_RACES_WINDOW_MS;
+
+    const focusEvent = recentRaceStillRelevant
+      ? { ...primaryEvent, name: latestCompletedRace.meeting_name || primaryEvent.name }
+      : primaryEvent;
+    const weekendSessions = recentRaceStillRelevant
+      ? findWeekendSessionsForEvent({
+          sessions: seasonSessions,
+          event: { ...focusEvent, starts_at: latestCompletedRace.starts_at || focusEvent.starts_at },
+        })
+      : findWeekendSessionsForEvent({ sessions: seasonSessions, event: focusEvent });
+
+    return buildWeekendContextFromSessions({
+      primaryEvent: focusEvent,
+      weekendSessions,
+      now,
+      liveSession,
+    });
+  } catch {
+    return fallback;
+  }
 }
 
 async function getCachedLiveSnapshot({ cacheKey, loader, now }) {
@@ -580,6 +841,15 @@ async function buildDashboardPayload({
     };
   }
 
+  const primaryEvent = buildPrimaryEvent(selection.event, selection.state, liveSession);
+  const weekendContext = await buildWeekendContext({
+    events,
+    primaryEvent,
+    provider,
+    now,
+    liveSession,
+  });
+
   const payoutBoard = buildPayoutBoard({
     event: selection.event,
     selectionState: selection.state,
@@ -609,7 +879,8 @@ async function buildDashboardPayload({
     viewer: viewerShape,
     summary,
     standings,
-    primaryEvent: buildPrimaryEvent(selection.event, selection.state, liveSession),
+    primaryEvent,
+    weekendContext,
     liveSession,
     portfolio,
     payoutBoard,

--- a/apps/f1/server/tests/ai.test.js
+++ b/apps/f1/server/tests/ai.test.js
@@ -1,0 +1,75 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  normalizeBriefingPayload,
+  scoreExecutiveBriefing,
+  buildDeterministicExecutiveBriefing,
+} = require('../ai');
+
+test('normalizeBriefingPayload accepts return-path aliases and strips old labels', () => {
+  const briefing = normalizeBriefingPayload({
+    headline: 'Your return this weekend hinges on Verstappen justifying the premium spend.',
+    bestReturnPath: 'Best return path: Verstappen landing Sprint Winner plus Best Finisher P6 or Lower is your best value route.',
+    capitalAtRisk: 'Capital at risk: Perez is still lagging his cost if he misses the payout windows again.',
+  }, {
+    phase: 'during_sprint',
+    title: 'Chinese GP Sprint - Return Outlook',
+    summaryData: { rank: 3, netCents: -1200, driversOwned: 4 },
+  });
+
+  assert.equal(briefing.summary, 'Your return this weekend hinges on Verstappen justifying the premium spend.');
+  assert.equal(briefing.bestReturnPath, 'Verstappen landing Sprint Winner plus Best Finisher P6 or Lower is your best value route.');
+  assert.equal(briefing.capitalAtRisk, 'Perez is still lagging his cost if he misses the payout windows again.');
+});
+
+test('scoreExecutiveBriefing rejects repetitive generic summaries and deterministic fallback is richer', () => {
+  const weakBriefing = normalizeBriefingPayload({
+    headline: 'You are $33 behind P3 with five drivers in play.',
+    bestReturnPath: 'You are $33 behind P3 with five drivers in play.',
+    capitalAtRisk: 'Monitor closely for opportunities.',
+  }, {
+    phase: 'before_practice',
+    title: 'Chinese GP Sprint',
+    summaryData: { rank: 4, netCents: -3300, driversOwned: 5 },
+  });
+
+  const context = {
+    viewer: { id: 4, name: 'Sam' },
+    summary: { rank: 4, netCents: -3300, driversOwned: 5 },
+    standings: [
+      { id: 1, name: 'Alex', total_earned_cents: 15000, total_spent_cents: 5000, drivers_owned: 5 },
+      { id: 2, name: 'Paul', total_earned_cents: 14000, total_spent_cents: 5000, drivers_owned: 4 },
+      { id: 4, name: 'Sam', total_earned_cents: 12600, total_spent_cents: 5000, drivers_owned: 5 },
+      { id: 5, name: 'Joe', total_earned_cents: 12000, total_spent_cents: 5000, drivers_owned: 4 },
+    ],
+    portfolio: {
+      drivers: [
+        { driver_name: 'Max Verstappen', total_earnings_cents: 4000, purchase_price_cents: 3000 },
+        { driver_name: 'Pierre Gasly', total_earnings_cents: 2000, purchase_price_cents: 1500 },
+        { driver_name: 'Sergio Perez', total_earnings_cents: 1500, purchase_price_cents: 1200 },
+      ],
+    },
+    payoutBoard: {
+      rules: [
+        { label: 'Sprint Winner', holders: [{ isViewerOwner: true, participantName: 'Sam' }] },
+        { label: 'Best Finisher P6 or Lower', holders: [] },
+        { label: 'Most Positions Gained', holders: [{ isViewerOwner: false, participantName: 'Paul' }] },
+      ],
+    },
+    primaryEvent: { name: 'Chinese GP Sprint' },
+    weekendContext: { title: 'Chinese GP Sprint' },
+    phase: 'during_sprint',
+  };
+
+  const quality = scoreExecutiveBriefing(weakBriefing, context);
+  assert.equal(quality.passed, false);
+
+  const fallback = buildDeterministicExecutiveBriefing(context);
+  assert.match(fallback.summary, /return|value|spend/i);
+  assert.match(fallback.summary, /Max Verstappen|Pierre Gasly|Sergio Perez/);
+  assert.match(fallback.bestReturnPath, /Sprint Winner|Best Finisher P6 or Lower|Most Positions Gained/);
+  assert.match(fallback.capitalAtRisk, /spend|cost|ticket|price|lagging/i);
+  assert.doesNotMatch(fallback.bestReturnPath, /^Best return path[:\-]/i);
+  assert.doesNotMatch(fallback.capitalAtRisk, /^Capital at risk[:\-]/i);
+});

--- a/apps/f1/server/tests/dashboardService.test.js
+++ b/apps/f1/server/tests/dashboardService.test.js
@@ -189,6 +189,7 @@ test('GET /api/standings/dashboard returns participant summary, portfolio, and f
   assert.equal(payload.briefingMeta.mode, 'on_demand');
   assert.equal(payload.briefing.summary, 'Persistent participant briefing.');
   assert.equal(payload.briefing.phase, 'pre_race');
+  assert.equal(payload.briefing.bestReturnPath, 'You enter the weekend with the strongest net in the pool.');
   assert.equal(payload.briefingHistory.length, 1);
   assert.ok(payload.primaryEvent);
   assert.ok(Array.isArray(payload.payoutBoard.rules));
@@ -247,6 +248,7 @@ test('GET /api/standings/dashboard returns briefing history most recent first', 
   assert.equal(response.statusCode, 200);
   assert.equal(response.body.briefingHistory.length, 2);
   assert.equal(response.body.briefingHistory[0].summary, 'Newer saved briefing.');
+  assert.equal(response.body.briefingHistory[0].bestReturnPath, 'Newer item.');
   assert.equal(response.body.briefingHistory[0].phase, 'live');
   assert.equal(response.body.briefingHistory[1].summary, 'Older saved briefing.');
 });
@@ -477,6 +479,177 @@ test('selectPrimaryEvent ignores cancelled scoring events', async () => {
 
   assert.equal(selection.event.id, 2);
   assert.equal(selection.state, 'upcoming');
+});
+
+test('buildDashboardPayload derives executive briefing weekend phases across weekend states', async () => {
+  const { db, getActiveSeasonId, dashboardService } = setupDb();
+  const seasonId = getActiveSeasonId();
+  const viewerId = createParticipant(db, seasonId, {
+    name: 'Phase Viewer',
+    token: 'phase-viewer',
+    color: '#445566',
+  });
+
+  db.prepare(`
+    UPDATE events
+    SET external_event_id = CASE
+      WHEN round_number = 1 AND type = 'grand_prix' THEN '9001'
+      WHEN round_number = 2 AND type = 'sprint' THEN '9002'
+      WHEN round_number = 2 AND type = 'grand_prix' THEN '9003'
+      ELSE external_event_id
+    END
+    WHERE season_id = ?
+  `).run(seasonId);
+
+  const seasonSessions = [
+    {
+      meeting_key: 100,
+      meeting_name: 'Australian Grand Prix',
+      session_name: 'Practice 1',
+      starts_at: '2026-03-06T02:30:00Z',
+      ends_at: '2026-03-06T03:30:00Z',
+      date_start: '2026-03-06T02:30:00Z',
+      date_end: '2026-03-06T03:30:00Z',
+      event_type: 'practice',
+    },
+    {
+      meeting_key: 100,
+      meeting_name: 'Australian Grand Prix',
+      session_name: 'Practice 2',
+      starts_at: '2026-03-06T06:00:00Z',
+      ends_at: '2026-03-06T07:00:00Z',
+      date_start: '2026-03-06T06:00:00Z',
+      date_end: '2026-03-06T07:00:00Z',
+      event_type: 'practice',
+    },
+    {
+      meeting_key: 100,
+      meeting_name: 'Australian Grand Prix',
+      session_name: 'Qualifying',
+      starts_at: '2026-03-07T06:00:00Z',
+      ends_at: '2026-03-07T07:00:00Z',
+      date_start: '2026-03-07T06:00:00Z',
+      date_end: '2026-03-07T07:00:00Z',
+      event_type: 'qualifying',
+    },
+    {
+      meeting_key: 100,
+      meeting_name: 'Australian Grand Prix',
+      session_name: 'Race',
+      session_key: 9001,
+      starts_at: '2026-03-08T04:00:00Z',
+      ends_at: '2026-03-08T06:00:00Z',
+      date_start: '2026-03-08T04:00:00Z',
+      date_end: '2026-03-08T06:00:00Z',
+      event_type: 'grand_prix',
+    },
+    {
+      meeting_key: 200,
+      meeting_name: 'Chinese Grand Prix',
+      session_name: 'Practice 1',
+      starts_at: '2026-03-13T03:00:00Z',
+      ends_at: '2026-03-13T04:00:00Z',
+      date_start: '2026-03-13T03:00:00Z',
+      date_end: '2026-03-13T04:00:00Z',
+      event_type: 'practice',
+    },
+    {
+      meeting_key: 200,
+      meeting_name: 'Chinese Grand Prix',
+      session_name: 'Sprint Shootout',
+      starts_at: '2026-03-13T07:00:00Z',
+      ends_at: '2026-03-13T08:00:00Z',
+      date_start: '2026-03-13T07:00:00Z',
+      date_end: '2026-03-13T08:00:00Z',
+      event_type: 'sprint_qualifying',
+    },
+    {
+      meeting_key: 200,
+      meeting_name: 'Chinese Grand Prix',
+      session_name: 'Sprint',
+      session_key: 9002,
+      starts_at: '2026-03-14T03:00:00Z',
+      ends_at: '2026-03-14T04:00:00Z',
+      date_start: '2026-03-14T03:00:00Z',
+      date_end: '2026-03-14T04:00:00Z',
+      event_type: 'sprint',
+    },
+    {
+      meeting_key: 200,
+      meeting_name: 'Chinese Grand Prix',
+      session_name: 'Qualifying',
+      starts_at: '2026-03-14T07:00:00Z',
+      ends_at: '2026-03-14T08:00:00Z',
+      date_start: '2026-03-14T07:00:00Z',
+      date_end: '2026-03-14T08:00:00Z',
+      event_type: 'qualifying',
+    },
+    {
+      meeting_key: 200,
+      meeting_name: 'Chinese Grand Prix',
+      session_name: 'Race',
+      session_key: 9003,
+      starts_at: '2026-03-15T07:00:00Z',
+      ends_at: '2026-03-15T09:00:00Z',
+      date_start: '2026-03-15T07:00:00Z',
+      date_end: '2026-03-15T09:00:00Z',
+      event_type: 'grand_prix',
+    },
+  ];
+
+  const cases = [
+    ['before practice', '2026-03-05T12:00:00Z', 'before_practice'],
+    ['during practice', '2026-03-06T02:45:00Z', 'during_practice'],
+    ['before qualifying', '2026-03-07T04:00:00Z', 'before_qualifying'],
+    ['during qualifying', '2026-03-07T06:15:00Z', 'during_qualifying'],
+    ['after qualifying before race', '2026-03-07T08:30:00Z', 'after_qualifying_before_race'],
+    ['during race', '2026-03-08T04:30:00Z', 'during_race'],
+    ['immediate post race', '2026-03-09T00:00:00Z', 'immediate_post_race'],
+    ['between races', '2026-03-10T12:30:00Z', 'between_races'],
+    ['during sprint qualifying', '2026-03-13T07:15:00Z', 'during_sprint_qualifying'],
+    ['during sprint', '2026-03-14T03:15:00Z', 'during_sprint'],
+  ];
+
+  for (const [label, nowIso, expectedPhase] of cases) {
+    const currentMs = Date.parse(nowIso);
+    const provider = {
+      name: 'openf1',
+      async fetchSeasonSessions() {
+        return seasonSessions;
+      },
+      async fetchSessionMetadata(sessionKey) {
+        return seasonSessions.find((session) => Number(session.session_key) === Number(sessionKey)) || null;
+      },
+      async fetchLiveSessionSnapshot({ event }) {
+        return {
+          available: true,
+          isLive: true,
+          fetchedAt: new Date(currentMs).toISOString(),
+          headline: `${event?.name || 'Session'} live`,
+          statusText: 'Live session',
+          trackStatus: null,
+          driverStates: [],
+          leaders: [],
+          championshipDrivers: [],
+          ownedDrivers: [],
+        };
+      },
+    };
+
+    const payload = await dashboardService.buildDashboardPayload({
+      seasonId,
+      viewer: {
+        id: viewerId,
+        name: 'Phase Viewer',
+        color: '#445566',
+        is_admin: 0,
+      },
+      nowImpl: () => currentMs,
+      provider,
+    });
+
+    assert.equal(payload.weekendContext.phase, expectedPhase, label);
+  }
 });
 
 test('buildDashboardPayload resolves live grand prix payout board with ownership and draw pending state', async () => {
@@ -783,14 +956,12 @@ test('dashboard briefing service caches and refreshes on force', async () => {
       callCount += 1;
       return {
         available: true,
-        phase: 'live',
+        phase: 'during_race',
         title: `Briefing ${callCount}`,
+        headline: `briefing-${callCount}`,
         summary: `briefing-${callCount}`,
-        sections: [
-          { heading: 'Your Position', bullets: [`Bullet ${callCount}`] },
-          { heading: 'Scenarios', bullets: [`If item ${callCount}`] },
-          { heading: 'What To Watch', bullets: [`Watch ${callCount}`] },
-        ],
+        bestReturnPath: `return-${callCount}`,
+        capitalAtRisk: `risk-${callCount}`,
         generatedAt: '2026-03-07T00:00:00Z',
         source: 'test',
       };
@@ -812,9 +983,10 @@ test('dashboard briefing service caches and refreshes on force', async () => {
   const third = await service.getBriefing({ dashboardPayload, force: true });
 
   assert.match(first.text, /briefing-1/);
+  assert.match(first.text, /return-1/);
   assert.match(second.text, /briefing-1/);
   assert.equal(second.cached, true);
   assert.match(third.text, /briefing-2/);
-  assert.equal(third.phase, 'live');
+  assert.equal(third.phase, 'during_race');
   assert.equal(callCount, 2);
 });


### PR DESCRIPTION
## Summary
- redesign the F1 dashboard AI Briefing into a full-width executive summary above Race Center
- replace standings-first copy with ROI-first briefing output built around best return path and capital at risk
- add shared local F1 env/DB bootstrapping so new worktrees reuse the same local state

## Testing
- npm run test:f1
- npm run build:f1