### PR TITLE
Allow Force Sync on scored events in admin UI

### DIFF
--- a/apps/f1/client/src/pages/admin/ResultsPage.jsx
+++ b/apps/f1/client/src/pages/admin/ResultsPage.jsx
@@ -331,7 +331,7 @@ export default function ResultsPage() {
                           <button
                             className="btn btn-outline"
                             onClick={() => runAndReload(() => syncEvent(event.id, { force: true }))}
-                            disabled={event.status === 'scored'}
+                            disabled={event.status === 'cancelled'}
                           >
                             Force Sync
                           </button>

--- a/apps/f1/server/tests/adminServices.test.js
+++ b/apps/f1/server/tests/adminServices.test.js
@@ -130,6 +130,12 @@ test('results admin syncNext skips cancelled events', async () => {
 
   db.prepare(`
     UPDATE events
+    SET starts_at = '2999-01-01T00:00:00Z',
+        lock_at = '2999-01-01T00:00:00Z'
+    WHERE season_id = ? AND id NOT IN (?, ?)
+  `).run(seasonId, events[0].id, events[1].id);
+  db.prepare(`
+    UPDATE events
     SET status = 'cancelled',
         cancelled_at = 1234567890,
         starts_at = '2000-01-01T00:00:00Z',


### PR DESCRIPTION
## Summary

- The **Force Sync** button in the admin Results page was disabled for `scored` events, preventing re-sync when the data feed was incomplete at initial sync time
- Root cause: all three action buttons (Sync, Force Sync, Mark Cancelled) shared the same `disabled={event.status === 'scored'}` guard — but Force Sync should be the escape hatch for exactly this scenario
- Fixed by changing Force Sync's guard to `disabled={event.status === 'cancelled'}`, matching what the backend already enforces

**Context:** This was discovered after the Canadian GP sync where the P18 finisher (a DNF) was missing from the OpenF1 results feed at sync time, leaving the random bonus payout unawarded. Force Sync is needed to re-pull the now-complete results and re-score the event.

## Test plan

- [ ] Verify Force Sync button is clickable on a scored event
- [ ] Verify Force Sync button remains disabled on a cancelled event
- [ ] Verify Sync and Mark Cancelled remain disabled on scored events (unchanged behavior)
- [ ] Force sync the Canadian GP and confirm the P18 random bonus payout is awarded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)